### PR TITLE
Fix lint errors and audit issues in v0.7.0/v0.8.0 integrations

### DIFF
--- a/sdk/agentguard/integrations/crewai.py
+++ b/sdk/agentguard/integrations/crewai.py
@@ -29,15 +29,10 @@ Requires ``crewai`` (optional dependency). Core SDK remains zero-dep.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-from agentguard.guards import (
-    BudgetGuard,
-    BudgetExceeded,
-    LoopGuard,
-    LoopDetected,
-)
-from agentguard.tracing import Tracer, TraceContext
+from agentguard.guards import BudgetGuard, LoopGuard
+from agentguard.tracing import Tracer
 
 
 class AgentGuardCrewHandler:
@@ -60,7 +55,6 @@ class AgentGuardCrewHandler:
         self._tracer = tracer or Tracer()
         self._loop_guard = loop_guard
         self._budget_guard = budget_guard
-        self._task_spans: Dict[str, Any] = {}  # task_id -> (ctx_mgr, ctx)
 
     def step_callback(self, step_output: Any) -> None:
         """CrewAI step callback — called after each agent step (tool use or thought).


### PR DESCRIPTION
## Summary
- **OTel parent-child span linking** — child spans now receive parent context via `set_span_in_context`, fixing broken trace trees where all spans appeared as roots
- **Thread safety** — added `threading.Lock` to protect `OtelTraceSink._spans` dict from concurrent access
- **Defensive error handling** — `_end_span` now handles string error values (not just dicts) without crashing
- **Lint fixes** — removed 7 unused imports flagged by ruff (F401) across crewai.py and otel.py
- **Dead code removal** — removed unused `_task_spans` dict from CrewAI handler, dead try/except from LangGraph wrapper
- **Guard visibility** — moved guard checks inside trace span in LangGraph integration so rejections appear in traces
- **JSON safety** — `_summarize_state` now always produces JSON-serializable values

## Files changed
- `sdk/agentguard/integrations/crewai.py` — clean up imports, remove dead state
- `sdk/agentguard/integrations/langgraph.py` — restructure guards, fix serialization
- `sdk/agentguard/sinks/otel.py` — parent linking, thread safety, error handling
- `sdk/tests/test_otel_sink.py` — 2 new tests (parent-child linking, string errors)

## Test plan
- [x] 317 tests passing locally
- [x] `ruff check sdk/agentguard/` clean
- [ ] CI passes on this PR (lint + tests on Python 3.9–3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)