### PR TITLE
Release v1.0.0 GA

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentguard47"
-version = "0.8.0"
+version = "1.0.0"
 description = "Zero-dependency observability and runtime guards for AI agents — loop detection, budget enforcement, cost tracking, and structured tracing"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -29,7 +29,7 @@ keywords = [
   "replay",
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary
- Bump version from 0.8.0 to 1.0.0
- Update classifier from Beta to Production/Stable

## Pre-launch checklist
- [x] Repo is public
- [x] `pip install agentguard47` works (v0.8.0 currently, v1.0.0 after tag)
- [x] All README links verified (zero 404s)
- [x] All integration imports verified
- [x] PyPI metadata correct
- [x] LICENSE file correct (MIT for SDK)
- [x] Blog post draft exists (`docs/blog/001-why-agents-loop.md`)
- [x] 317 tests pass, 86% coverage, lint clean
- [ ] Tag v1.0.0 after merge → triggers PyPI publish

## Test plan
- [ ] CI passes on all Python versions (3.9-3.12)
- [ ] After merge, tag v1.0.0 and verify PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)