### PR TITLE
Add PyPI download badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Runtime guardrails for AI agents.** Stop loops, enforce budgets, trace everything — zero dependencies.
 
 [![PyPI](https://img.shields.io/pypi/v/agentguard47)](https://pypi.org/project/agentguard47/)
+[![Downloads](https://img.shields.io/pypi/dm/agentguard47)](https://pypi.org/project/agentguard47/)
 [![Python](https://img.shields.io/pypi/pyversions/agentguard47)](https://pypi.org/project/agentguard47/)
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen)](https://github.com/bmdhodl/agent47)


### PR DESCRIPTION
## Summary
- Adds monthly download count badge from shields.io/pypi
- Social proof signal — visitors see the package is being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)