### PR TITLE
Add agentguard.init() one-liner setup

### DIFF
--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -1,3 +1,4 @@
+from .setup import init, shutdown, get_tracer, get_budget_guard
 from .tracing import Tracer, JsonlFileSink, StdoutSink, TraceSink
 from .guards import (
     BaseGuard,
@@ -32,6 +33,10 @@ from .instrument import (
 )
 
 __all__ = [
+    "init",
+    "shutdown",
+    "get_tracer",
+    "get_budget_guard",
     "Tracer",
     "JsonlFileSink",
     "StdoutSink",

--- a/sdk/agentguard/setup.py
+++ b/sdk/agentguard/setup.py
@@ -1,0 +1,221 @@
+"""One-liner setup for AgentGuard.
+
+Usage::
+
+    import agentguard
+    agentguard.init()
+
+That's it. Reads config from environment variables, auto-patches LLM
+clients, and starts tracing with sane defaults.
+
+Environment variables:
+    AGENTGUARD_API_KEY    — API key for dashboard. If set, traces go to
+                            the hosted dashboard. If missing, traces go
+                            to a local JSONL file.
+    AGENTGUARD_BUDGET_USD — Dollar budget limit (e.g. "5.00"). Enables
+                            BudgetGuard with 80% warning threshold.
+    AGENTGUARD_SERVICE    — Service name for traces. Default: "default".
+    AGENTGUARD_TRACE_FILE — Local trace file path. Default: "traces.jsonl".
+                            Only used when AGENTGUARD_API_KEY is not set.
+
+Power-user override::
+
+    agentguard.init(
+        api_key="ag_...",
+        budget_usd=5.00,
+        service="my-agent",
+    )
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger("agentguard")
+
+# Global state — set by init(), cleared by shutdown()
+_tracer: Optional[Any] = None
+_budget_guard: Optional[Any] = None
+_initialized: bool = False
+
+
+def init(
+    *,
+    api_key: Optional[str] = None,
+    budget_usd: Optional[float] = None,
+    service: Optional[str] = None,
+    trace_file: Optional[str] = None,
+    warn_pct: float = 0.8,
+    loop_max: int = 5,
+    auto_patch: bool = True,
+) -> Any:
+    """Initialize AgentGuard with one call.
+
+    Reads configuration from environment variables, falling back to
+    keyword arguments, falling back to sane defaults.
+
+    Args:
+        api_key: Dashboard API key. Env: ``AGENTGUARD_API_KEY``.
+        budget_usd: Dollar budget limit. Env: ``AGENTGUARD_BUDGET_USD``.
+        service: Service name. Env: ``AGENTGUARD_SERVICE``. Default: "default".
+        trace_file: Local JSONL path (used when no api_key).
+            Env: ``AGENTGUARD_TRACE_FILE``. Default: "traces.jsonl".
+        warn_pct: Budget warning threshold (0.0-1.0). Default: 0.8.
+        loop_max: Max identical calls before LoopGuard fires. Default: 5.
+        auto_patch: Auto-patch OpenAI/Anthropic clients. Default: True.
+
+    Returns:
+        The configured Tracer instance.
+
+    Raises:
+        RuntimeError: If init() is called twice without shutdown() first.
+    """
+    global _tracer, _budget_guard, _initialized
+
+    if _initialized:
+        raise RuntimeError(
+            "agentguard.init() already called. Call agentguard.shutdown() first "
+            "to re-initialize, or use the returned tracer directly."
+        )
+
+    # --- Resolve config: kwargs > env vars > defaults ---
+    resolved_key = api_key or os.environ.get("AGENTGUARD_API_KEY")
+    resolved_service = service or os.environ.get("AGENTGUARD_SERVICE", "default")
+    resolved_file = trace_file or os.environ.get("AGENTGUARD_TRACE_FILE", "traces.jsonl")
+
+    resolved_budget: Optional[float] = budget_usd
+    if resolved_budget is None:
+        env_budget = os.environ.get("AGENTGUARD_BUDGET_USD")
+        if env_budget:
+            try:
+                resolved_budget = float(env_budget)
+            except ValueError:
+                logger.warning(
+                    "Invalid AGENTGUARD_BUDGET_USD=%r, ignoring", env_budget
+                )
+
+    # --- Build sink ---
+    if resolved_key:
+        from agentguard.sinks.http import HttpSink
+
+        sink = HttpSink(
+            url="https://app.agentguard47.com/api/ingest",
+            api_key=resolved_key,
+        )
+    else:
+        from agentguard.tracing import JsonlFileSink
+
+        sink = JsonlFileSink(resolved_file)
+
+    # --- Build guards ---
+    from agentguard.guards import BudgetGuard, LoopGuard
+
+    guards = [LoopGuard(max_repeats=loop_max, window=max(loop_max, 6))]
+
+    if resolved_budget is not None:
+        _budget_guard = BudgetGuard(
+            max_cost_usd=resolved_budget,
+            warn_at_pct=warn_pct,
+            on_warning=lambda msg: logger.warning(msg),
+        )
+        guards.append(_budget_guard)
+
+    # --- Build tracer ---
+    from agentguard.tracing import Tracer
+
+    _tracer = Tracer(sink=sink, service=resolved_service, guards=guards)
+
+    # --- Auto-patch LLM clients ---
+    if auto_patch:
+        _auto_patch(_tracer, _budget_guard)
+
+    _initialized = True
+
+    # Log what we did
+    sink_desc = f"dashboard ({resolved_key[:8]}...)" if resolved_key else resolved_file
+    budget_desc = f"${resolved_budget:.2f}" if resolved_budget else "unlimited"
+    logger.info(
+        "AgentGuard initialized: service=%s sink=%s budget=%s",
+        resolved_service, sink_desc, budget_desc,
+    )
+
+    return _tracer
+
+
+def _auto_patch(tracer: Any, budget_guard: Optional[Any]) -> None:
+    """Auto-patch OpenAI and Anthropic clients if importable."""
+    from agentguard.instrument import (
+        patch_anthropic,
+        patch_anthropic_async,
+        patch_openai,
+        patch_openai_async,
+    )
+
+    # OpenAI sync + async
+    try:
+        import openai  # noqa: F401
+
+        patch_openai(tracer, budget_guard=budget_guard)
+        patch_openai_async(tracer, budget_guard=budget_guard)
+        logger.debug("Auto-patched OpenAI (sync + async)")
+    except ImportError:
+        pass
+
+    # Anthropic sync + async
+    try:
+        import anthropic  # noqa: F401
+
+        patch_anthropic(tracer, budget_guard=budget_guard)
+        patch_anthropic_async(tracer, budget_guard=budget_guard)
+        logger.debug("Auto-patched Anthropic (sync + async)")
+    except ImportError:
+        pass
+
+
+def shutdown() -> None:
+    """Flush traces and tear down AgentGuard.
+
+    Safe to call even if init() was never called.
+    After shutdown(), init() can be called again.
+    """
+    global _tracer, _budget_guard, _initialized
+
+    if _tracer is not None:
+        sink = getattr(_tracer, "_sink", None)
+        if hasattr(sink, "shutdown"):
+            sink.shutdown()
+
+    from agentguard.instrument import (
+        unpatch_anthropic,
+        unpatch_anthropic_async,
+        unpatch_openai,
+        unpatch_openai_async,
+    )
+
+    unpatch_openai()
+    unpatch_openai_async()
+    unpatch_anthropic()
+    unpatch_anthropic_async()
+
+    _tracer = None
+    _budget_guard = None
+    _initialized = False
+
+
+def get_tracer() -> Any:
+    """Get the global tracer created by init().
+
+    Returns:
+        The Tracer instance, or None if init() hasn't been called.
+    """
+    return _tracer
+
+
+def get_budget_guard() -> Any:
+    """Get the global BudgetGuard created by init().
+
+    Returns:
+        The BudgetGuard instance, or None if no budget was configured.
+    """
+    return _budget_guard

--- a/sdk/tests/test_exports.py
+++ b/sdk/tests/test_exports.py
@@ -70,6 +70,7 @@ class TestTopLevelExports(unittest.TestCase):
     def test_all_list_complete(self):
         import agentguard
         expected = {
+            "init", "shutdown", "get_tracer", "get_budget_guard",
             "Tracer", "JsonlFileSink", "StdoutSink", "TraceSink",
             "BaseGuard", "LoopGuard", "BudgetGuard", "TimeoutGuard",
             "FuzzyLoopGuard", "RateLimitGuard",

--- a/sdk/tests/test_init.py
+++ b/sdk/tests/test_init.py
@@ -1,0 +1,273 @@
+"""Tests for agentguard.init() one-liner setup."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import types
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+import agentguard
+from agentguard.setup import (
+    _auto_patch,
+    _budget_guard,
+    _initialized,
+    _tracer,
+    get_budget_guard,
+    get_tracer,
+    init,
+    shutdown,
+)
+
+
+class CollectorSink:
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    def emit(self, event: Dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Ensure clean state before and after each test."""
+    shutdown()
+    yield
+    shutdown()
+
+
+class TestInit:
+    """Test agentguard.init() basic behavior."""
+
+    def test_init_returns_tracer(self):
+        tracer = agentguard.init(auto_patch=False)
+        assert tracer is not None
+        assert hasattr(tracer, "trace")
+
+    def test_init_default_local_sink(self):
+        tracer = agentguard.init(auto_patch=False)
+        assert "JsonlFileSink" in repr(tracer._sink)
+
+    def test_init_custom_trace_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            tracer = agentguard.init(trace_file=path, auto_patch=False)
+            assert path in repr(tracer._sink)
+        finally:
+            os.unlink(path)
+
+    def test_init_custom_service(self):
+        tracer = agentguard.init(service="test-svc", auto_patch=False)
+        assert tracer._service == "test-svc"
+
+    def test_init_default_service(self):
+        tracer = agentguard.init(auto_patch=False)
+        assert tracer._service == "default"
+
+    def test_init_idempotency_raises(self):
+        agentguard.init(auto_patch=False)
+        with pytest.raises(RuntimeError, match="already called"):
+            agentguard.init(auto_patch=False)
+
+    def test_init_after_shutdown_works(self):
+        agentguard.init(auto_patch=False)
+        agentguard.shutdown()
+        tracer = agentguard.init(auto_patch=False)
+        assert tracer is not None
+
+
+class TestInitEnvVars:
+    """Test env var configuration."""
+
+    def test_service_from_env(self):
+        with patch.dict(os.environ, {"AGENTGUARD_SERVICE": "env-svc"}):
+            tracer = agentguard.init(auto_patch=False)
+            assert tracer._service == "env-svc"
+
+    def test_trace_file_from_env(self):
+        with patch.dict(os.environ, {"AGENTGUARD_TRACE_FILE": "/tmp/test.jsonl"}):
+            tracer = agentguard.init(auto_patch=False)
+            assert "/tmp/test.jsonl" in repr(tracer._sink)
+
+    def test_budget_from_env(self):
+        with patch.dict(os.environ, {"AGENTGUARD_BUDGET_USD": "3.50"}):
+            agentguard.init(auto_patch=False)
+            guard = agentguard.get_budget_guard()
+            assert guard is not None
+            assert guard._max_cost_usd == 3.50
+
+    def test_invalid_budget_env_ignored(self):
+        with patch.dict(os.environ, {"AGENTGUARD_BUDGET_USD": "not-a-number"}):
+            agentguard.init(auto_patch=False)
+            guard = agentguard.get_budget_guard()
+            assert guard is None
+
+    def test_kwargs_override_env(self):
+        with patch.dict(os.environ, {"AGENTGUARD_SERVICE": "env-svc"}):
+            tracer = agentguard.init(service="kwarg-svc", auto_patch=False)
+            assert tracer._service == "kwarg-svc"
+
+
+class TestInitBudgetGuard:
+    """Test budget guard setup via init()."""
+
+    def test_no_budget_by_default(self):
+        agentguard.init(auto_patch=False)
+        assert agentguard.get_budget_guard() is None
+
+    def test_budget_creates_guard(self):
+        agentguard.init(budget_usd=5.00, auto_patch=False)
+        guard = agentguard.get_budget_guard()
+        assert guard is not None
+        assert guard._max_cost_usd == 5.00
+
+    def test_budget_warning_threshold(self):
+        agentguard.init(budget_usd=10.00, warn_pct=0.5, auto_patch=False)
+        guard = agentguard.get_budget_guard()
+        assert guard._warn_at_pct == 0.5
+
+    def test_budget_guard_in_tracer_guards(self):
+        agentguard.init(budget_usd=5.00, auto_patch=False)
+        tracer = agentguard.get_tracer()
+        guard = agentguard.get_budget_guard()
+        assert guard in tracer._guards
+
+
+class TestInitLoopGuard:
+    """Test loop guard is always enabled."""
+
+    def test_loop_guard_default(self):
+        tracer = agentguard.init(auto_patch=False)
+        from agentguard.guards import LoopGuard
+        loop_guards = [g for g in tracer._guards if isinstance(g, LoopGuard)]
+        assert len(loop_guards) == 1
+        assert loop_guards[0]._max_repeats == 5
+
+    def test_loop_guard_custom(self):
+        tracer = agentguard.init(loop_max=10, auto_patch=False)
+        from agentguard.guards import LoopGuard
+        loop_guards = [g for g in tracer._guards if isinstance(g, LoopGuard)]
+        assert loop_guards[0]._max_repeats == 10
+
+
+class TestInitAutoPatch:
+    """Test auto-patching of LLM clients."""
+
+    def test_auto_patch_openai(self):
+        """If openai is importable, it gets patched."""
+        # Create mock openai module
+        mock_usage = types.SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        mock_result = types.SimpleNamespace(usage=mock_usage)
+
+        class MockCompletions:
+            def create(self, *a, **kw):
+                return mock_result
+
+        class MockChat:
+            def __init__(self):
+                self.completions = MockCompletions()
+
+        class MockOpenAI:
+            def __init__(self, *a, **kw):
+                self.chat = MockChat()
+
+        mod = types.ModuleType("openai")
+        mod.OpenAI = MockOpenAI
+
+        sys.modules["openai"] = mod
+        try:
+            tracer = agentguard.init(budget_usd=10.0)
+            client = MockOpenAI()
+            client.chat.completions.create(model="gpt-4o-mini")
+
+            guard = agentguard.get_budget_guard()
+            assert guard.state.tokens_used == 15
+            assert guard.state.calls_used == 1
+        finally:
+            agentguard.shutdown()
+            del sys.modules["openai"]
+
+    def test_auto_patch_disabled(self):
+        """auto_patch=False skips patching."""
+        tracer = agentguard.init(auto_patch=False)
+        from agentguard.instrument import _originals
+        # No openai/anthropic entries in _originals
+        assert "openai_init" not in _originals
+        assert "anthropic_init" not in _originals
+
+
+class TestShutdown:
+    """Test shutdown behavior."""
+
+    def test_shutdown_clears_state(self):
+        agentguard.init(auto_patch=False)
+        assert agentguard.get_tracer() is not None
+        agentguard.shutdown()
+        assert agentguard.get_tracer() is None
+
+    def test_shutdown_safe_when_not_initialized(self):
+        # Should not raise
+        agentguard.shutdown()
+        agentguard.shutdown()
+
+    def test_shutdown_unpatches(self):
+        from agentguard.instrument import _originals
+
+        # Mock openai
+        mod = types.ModuleType("openai")
+        class MockOpenAI:
+            def __init__(self, *a, **kw):
+                pass
+        mod.OpenAI = MockOpenAI
+        sys.modules["openai"] = mod
+
+        try:
+            agentguard.init()
+            assert "openai_init" in _originals
+            agentguard.shutdown()
+            assert "openai_init" not in _originals
+        finally:
+            if "openai" in sys.modules:
+                del sys.modules["openai"]
+
+
+class TestGetters:
+    """Test get_tracer() and get_budget_guard()."""
+
+    def test_get_tracer_before_init(self):
+        assert agentguard.get_tracer() is None
+
+    def test_get_tracer_after_init(self):
+        agentguard.init(auto_patch=False)
+        assert agentguard.get_tracer() is not None
+
+    def test_get_budget_guard_no_budget(self):
+        agentguard.init(auto_patch=False)
+        assert agentguard.get_budget_guard() is None
+
+    def test_get_budget_guard_with_budget(self):
+        agentguard.init(budget_usd=1.00, auto_patch=False)
+        assert agentguard.get_budget_guard() is not None
+
+
+class TestModuleLevelAccess:
+    """Test that init/shutdown are accessible via agentguard module."""
+
+    def test_module_has_init(self):
+        assert hasattr(agentguard, "init")
+        assert callable(agentguard.init)
+
+    def test_module_has_shutdown(self):
+        assert hasattr(agentguard, "shutdown")
+        assert callable(agentguard.shutdown)
+
+    def test_two_line_quickstart(self):
+        """The actual two-liner works."""
+        import agentguard
+        tracer = agentguard.init(auto_patch=False)
+        assert tracer is not None
+        agentguard.shutdown()


### PR DESCRIPTION
## Summary
- Sentry-style `agentguard.init()` one-liner replaces 7-40 lines of boilerplate
- Reads config from env vars (`AGENTGUARD_API_KEY`, `AGENTGUARD_BUDGET_USD`, `AGENTGUARD_SERVICE`, `AGENTGUARD_TRACE_FILE`)
- Auto-patches OpenAI/Anthropic clients (sync + async), enables LoopGuard by default
- `shutdown()` flushes traces, unpatches clients, resets global state
- 30 new tests (452 total), lint clean

## Before vs After

**Before (7+ lines):**
```python
from agentguard import Tracer, JsonlFileSink, LoopGuard, BudgetGuard, patch_openai
sink = JsonlFileSink("traces.jsonl")
guards = [LoopGuard(), BudgetGuard(max_cost_usd=5.0)]
tracer = Tracer(sink=sink, guards=guards)
patch_openai(tracer, budget_guard=guards[1])
```

**After (2 lines):**
```python
import agentguard
agentguard.init(budget_usd=5.0)
```

## Test plan
- [x] 30 tests covering init, env vars, budget guard, loop guard, auto-patch, shutdown, getters
- [x] Export test updated for new public API names
- [x] Full suite: 452 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)