### PR TITLE
SDK hardening: security, thread safety, CI tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/sdk"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,6 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install
         run: |
           python -m pip install -e ./sdk
@@ -40,7 +44,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install ruff
-        run: pip install ruff
-      - name: Lint
+          cache: 'pip'
+      - name: Install tools
+        run: pip install ruff bandit
+      - name: Lint (ruff)
         run: ruff check sdk/agentguard/
+      - name: Security lint (bandit)
+        run: bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,23 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly Monday 8am UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,24 +5,42 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install build tools
         run: pip install build
 
       - name: Build package
         run: python -m build ./sdk
+        env:
+          SOURCE_DATE_EPOCH: "0"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: sdk/dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdk/dist/
           password: ${{ secrets.PYPI_TOKEN }}
+          # To enable PyPI attestations, switch to Trusted Publishing:
+          # 1. Configure at pypi.org -> agentguard47 -> Settings -> Publishing
+          # 2. Remove the 'password' line above
+          # 3. Add: attestations: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,28 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 1.0.x   | Yes       |
-| < 1.0   | No        |
+| Version | Supported          |
+|---------|--------------------|
+| 1.1.x   | Yes                |
+| 1.0.x   | Security fixes only |
+| < 1.0   | No                 |
 
 ## Reporting a Vulnerability
 
@@ -18,16 +19,36 @@ Include:
 - Steps to reproduce
 - Impact assessment (if known)
 
-We will acknowledge your report within 48 hours and provide a fix timeline within 7 days.
-
 **Do not** open a public GitHub issue for security vulnerabilities.
+
+## Disclosure Timeline
+
+- **Acknowledgment:** Within 48 hours of report
+- **Triage:** Within 7 days
+- **Fix:** Target 30 days for critical, 90 days for others
+- **Disclosure:** Coordinated with reporter, following 90-day standard
+
+## Scope
+
+This policy applies to:
+- The `agentguard47` PyPI package
+- The `bmdhodl/agent47` GitHub repository
+- The `sdk/agentguard/` source directory
+
+Out of scope:
+- Third-party integrations (LangChain, OpenAI, etc.)
+- The AgentGuard dashboard (separate security policy)
 
 ## Security Design
 
 The AgentGuard SDK is designed with security in mind:
 
 - **Zero dependencies** — no transitive supply chain risk
-- **SSRF protection** — HttpSink blocks requests to private/loopback IPs
+- **SSRF protection** — HttpSink blocks requests to private/loopback IPs, validates redirect targets
+- **HTTP header injection prevention** — API keys validated against CRLF injection
 - **Input validation** — all public constructors validate parameters
+- **Event data size limits** — 64 KB max per event to prevent OOM
+- **Thread safety** — all guards and sinks use locks for concurrent access
 - **No eval/exec** — no dynamic code execution
 - **XSS protection** — Gantt trace viewer escapes all user-supplied data
+- **IDN/Punycode normalization** — prevents Unicode SSRF bypasses

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -1,6 +1,10 @@
+import logging
+from importlib.metadata import version, PackageNotFoundError
+
 from .setup import init, shutdown, get_tracer, get_budget_guard
 from .tracing import Tracer, JsonlFileSink, StdoutSink, TraceSink
 from .guards import (
+    AgentGuardError,
     BaseGuard,
     LoopGuard,
     BudgetGuard,
@@ -32,7 +36,17 @@ from .instrument import (
     unpatch_anthropic_async,
 )
 
+try:
+    __version__ = version("agentguard47")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
+
+# Libraries should not configure logging — only add NullHandler
+# so consumers don't see "No handler found" warnings.
+logging.getLogger("agentguard").addHandler(logging.NullHandler())
+
 __all__ = [
+    "__version__",
     "init",
     "shutdown",
     "get_tracer",
@@ -41,6 +55,7 @@ __all__ = [
     "JsonlFileSink",
     "StdoutSink",
     "TraceSink",
+    "AgentGuardError",
     "LoopGuard",
     "BudgetGuard",
     "TimeoutGuard",

--- a/sdk/agentguard/setup.py
+++ b/sdk/agentguard/setup.py
@@ -79,6 +79,17 @@ def init(
             "to re-initialize, or use the returned tracer directly."
         )
 
+    # --- Validate inputs ---
+    if not (0.0 <= warn_pct <= 1.0):
+        raise ValueError(
+            f"warn_pct must be between 0.0 and 1.0, got {warn_pct}"
+        )
+    if api_key and ("\n" in api_key or "\r" in api_key):
+        raise ValueError(
+            "api_key must not contain newline or carriage return characters "
+            "(possible HTTP header injection)"
+        )
+
     # --- Resolve config: kwargs > env vars > defaults ---
     resolved_key = api_key or os.environ.get("AGENTGUARD_API_KEY")
     resolved_service = service or os.environ.get("AGENTGUARD_SERVICE", "default")

--- a/sdk/tests/test_exports.py
+++ b/sdk/tests/test_exports.py
@@ -70,8 +70,10 @@ class TestTopLevelExports(unittest.TestCase):
     def test_all_list_complete(self):
         import agentguard
         expected = {
+            "__version__",
             "init", "shutdown", "get_tracer", "get_budget_guard",
             "Tracer", "JsonlFileSink", "StdoutSink", "TraceSink",
+            "AgentGuardError",
             "BaseGuard", "LoopGuard", "BudgetGuard", "TimeoutGuard",
             "FuzzyLoopGuard", "RateLimitGuard",
             "LoopDetected", "BudgetExceeded", "BudgetWarning", "TimeoutExceeded",

--- a/sdk/tests/test_hardening.py
+++ b/sdk/tests/test_hardening.py
@@ -1,0 +1,252 @@
+"""Tests for SDK hardening: security, thread safety, and DX improvements."""
+from __future__ import annotations
+
+import json
+import threading
+import types
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+import agentguard
+from agentguard.guards import (
+    AgentGuardError,
+    BudgetExceeded,
+    FuzzyLoopGuard,
+    LoopDetected,
+    LoopGuard,
+    TimeoutExceeded,
+)
+from agentguard.sinks.http import _validate_api_key, _validate_url
+from agentguard.tracing import _sanitize_data
+
+
+# --- AgentGuardError base exception ---
+
+
+class TestAgentGuardError:
+    """Test the base exception hierarchy."""
+
+    def test_base_exception_exists(self):
+        assert issubclass(AgentGuardError, Exception)
+
+    def test_loop_detected_inherits(self):
+        assert issubclass(LoopDetected, AgentGuardError)
+        assert issubclass(LoopDetected, RuntimeError)
+
+    def test_budget_exceeded_inherits(self):
+        assert issubclass(BudgetExceeded, AgentGuardError)
+        assert issubclass(BudgetExceeded, RuntimeError)
+
+    def test_timeout_exceeded_inherits(self):
+        assert issubclass(TimeoutExceeded, AgentGuardError)
+        assert issubclass(TimeoutExceeded, RuntimeError)
+
+    def test_catch_all_agentguard_errors(self):
+        """Users can catch AgentGuardError to handle any SDK error."""
+        guard = LoopGuard(max_repeats=2)
+        with pytest.raises(AgentGuardError):
+            for _ in range(3):
+                guard.check("tool", {"arg": "same"})
+
+    def test_catch_specific_still_works(self):
+        """Catching RuntimeError still works (backward compat)."""
+        guard = LoopGuard(max_repeats=2)
+        with pytest.raises(RuntimeError):
+            for _ in range(3):
+                guard.check("tool", {"arg": "same"})
+
+    def test_agentguard_error_importable(self):
+        from agentguard import AgentGuardError as AGE
+        assert AGE is AgentGuardError
+
+
+# --- __version__ ---
+
+
+class TestVersion:
+    def test_version_attribute_exists(self):
+        assert hasattr(agentguard, "__version__")
+
+    def test_version_is_string(self):
+        assert isinstance(agentguard.__version__, str)
+
+    def test_version_in_all(self):
+        assert "__version__" in agentguard.__all__
+
+
+# --- Thread safety: LoopGuard ---
+
+
+class TestLoopGuardThreadSafety:
+    def test_concurrent_checks_no_crash(self):
+        guard = LoopGuard(max_repeats=100, window=200)
+        errors: List[Exception] = []
+        barrier = threading.Barrier(10)
+
+        def worker(tid: int):
+            barrier.wait()
+            try:
+                for i in range(50):
+                    guard.check(f"tool_{tid}_{i}", {"i": i})
+            except LoopDetected:
+                pass
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors, f"Unexpected errors: {errors}"
+
+    def test_concurrent_reset_no_crash(self):
+        guard = LoopGuard(max_repeats=3)
+        errors: List[Exception] = []
+
+        def worker():
+            try:
+                for _ in range(100):
+                    try:
+                        guard.check("tool", {"a": 1})
+                    except LoopDetected:
+                        guard.reset()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors, f"Unexpected errors: {errors}"
+
+
+# --- Thread safety: FuzzyLoopGuard ---
+
+
+class TestFuzzyLoopGuardThreadSafety:
+    def test_concurrent_checks_no_crash(self):
+        guard = FuzzyLoopGuard(max_tool_repeats=100, window=200)
+        errors: List[Exception] = []
+        barrier = threading.Barrier(10)
+
+        def worker(tid: int):
+            barrier.wait()
+            try:
+                for i in range(50):
+                    guard.check(f"tool_{tid}_{i}")
+            except LoopDetected:
+                pass
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors, f"Unexpected errors: {errors}"
+
+
+# --- HTTP header injection ---
+
+
+class TestHeaderInjection:
+    def test_newline_in_api_key_rejected(self):
+        with pytest.raises(ValueError, match="header injection"):
+            _validate_api_key("ag_key\nEvil-Header: injected")
+
+    def test_carriage_return_in_api_key_rejected(self):
+        with pytest.raises(ValueError, match="header injection"):
+            _validate_api_key("ag_key\r\nEvil-Header: injected")
+
+    def test_clean_api_key_accepted(self):
+        # Should not raise
+        _validate_api_key("ag_abc123def456")
+
+    def test_init_rejects_crlf_api_key(self):
+        from agentguard.setup import shutdown
+        shutdown()
+        with pytest.raises(ValueError, match="header injection"):
+            agentguard.init(api_key="ag_key\nEvil: header", auto_patch=False)
+        shutdown()
+
+
+# --- SSRF redirect protection ---
+
+
+class TestSsrfRedirectProtection:
+    def test_redirect_to_private_ip_blocked(self):
+        """_validate_url is called on redirect targets."""
+        with pytest.raises(ValueError, match="private"):
+            _validate_url("http://127.0.0.1/api")
+
+    def test_redirect_to_metadata_endpoint_blocked(self):
+        """Cloud metadata IP is blocked."""
+        with pytest.raises(ValueError, match="private"):
+            _validate_url("http://169.254.169.254/latest/meta-data/")
+
+
+# --- Event data size limit ---
+
+
+class TestEventDataSizeLimit:
+    def test_small_data_passes_through(self):
+        data = {"key": "value"}
+        assert _sanitize_data(data) == data
+
+    def test_none_passes_through(self):
+        assert _sanitize_data(None) is None
+
+    def test_oversized_data_truncated(self):
+        # Create data that exceeds 64KB
+        big_data = {"payload": "x" * 70_000}
+        result = _sanitize_data(big_data)
+        assert result is not None
+        assert result.get("_truncated") is True
+        assert "_original_size_bytes" in result
+
+    def test_non_serializable_data_replaced(self):
+        data = {"obj": object()}
+        result = _sanitize_data(data)
+        assert result == {"_error": "not_serializable"}
+
+    def test_exactly_at_limit_passes(self):
+        # Just under 64KB should pass
+        data = {"payload": "x" * 65_000}
+        result = _sanitize_data(data)
+        # This is right around the limit — check if it's truncated or not
+        serialized_size = len(json.dumps(data).encode("utf-8"))
+        if serialized_size <= 65_536:
+            assert result == data
+        else:
+            assert result.get("_truncated") is True
+
+
+# --- init() validation ---
+
+
+class TestInitValidation:
+    @pytest.fixture(autouse=True)
+    def clean_state(self):
+        agentguard.shutdown()
+        yield
+        agentguard.shutdown()
+
+    def test_warn_pct_too_low(self):
+        with pytest.raises(ValueError, match="warn_pct"):
+            agentguard.init(budget_usd=5.0, warn_pct=-0.1, auto_patch=False)
+
+    def test_warn_pct_too_high(self):
+        with pytest.raises(ValueError, match="warn_pct"):
+            agentguard.init(budget_usd=5.0, warn_pct=1.5, auto_patch=False)
+
+    def test_warn_pct_valid_boundaries(self):
+        tracer = agentguard.init(budget_usd=5.0, warn_pct=0.0, auto_patch=False)
+        assert tracer is not None
+        agentguard.shutdown()
+        tracer = agentguard.init(budget_usd=5.0, warn_pct=1.0, auto_patch=False)
+        assert tracer is not None


### PR DESCRIPTION
## Summary

Comprehensive hardening pass across code security, thread safety, DX, and CI tooling.

### Code Fixes
- **AgentGuardError base exception** — all SDK errors now inherit from it, users can `except AgentGuardError` to catch everything. Backward-compatible: `RuntimeError` still works.
- **`__version__`** — `agentguard.__version__` now works (via `importlib.metadata`)
- **NullHandler** — prevents "No handler found" warnings for library consumers
- **Thread-safe LoopGuard/FuzzyLoopGuard** — `threading.Lock` on all mutations, safe for free-threading (3.13+)
- **SSRF redirect protection** — custom redirect handler re-validates redirect targets against private IP blocklist
- **HTTP header injection** — API keys rejected if they contain `\r\n` (CRLF injection prevention)
- **Event data size limit** — 64 KB max per event data dict, oversized payloads replaced with truncation marker
- **`init()` validates `warn_pct`** — rejects values outside [0.0, 1.0]
- **SECURITY.md** — updated version table (1.1.x), added disclosure timeline, scope section

### CI/Security Tooling
- **CodeQL** — weekly + on PRs, SARIF results in GitHub Security tab
- **OpenSSF Scorecard** — automated 0-10 security score, badge-ready
- **Dependabot** — automated updates for GitHub Actions + pip dependencies
- **bandit** — Python-specific security linter in CI
- **pip cache** — faster CI builds
- **GitHub artifact attestations** — Sigstore-signed provenance on publish
- **Reproducible builds** — `SOURCE_DATE_EPOCH=0` for deterministic timestamps
- **Minimal permissions** — all workflows use least-privilege `permissions:`

## Test plan
- [x] 514 tests passing (30 new hardening tests)
- [x] 7/7 e2e smoke checks pass (version, exceptions, NullHandler, header injection, data limits, init validation, thread safety)
- [x] ruff lint clean
- [x] bandit clean (5 intentional low-severity skips documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)