### PR TITLE
Add public property accessors to guards

### DIFF
--- a/sdk/agentguard/guards.py
+++ b/sdk/agentguard/guards.py
@@ -148,6 +148,16 @@ class LoopGuard(BaseGuard):
         """Auto-check: delegates to check(event_name, event_data)."""
         self.check(event_name, event_data)
 
+    @property
+    def max_repeats(self) -> int:
+        """Maximum identical calls before triggering detection."""
+        return self._max_repeats
+
+    @property
+    def window(self) -> int:
+        """Size of the sliding history window."""
+        return self._window
+
     def reset(self) -> None:
         """Clear the call history."""
         with self._lock:
@@ -210,6 +220,21 @@ class BudgetGuard(BaseGuard):
         self._warned = False
         self._lock = threading.Lock()
         self.state = BudgetState()
+
+    @property
+    def max_tokens(self) -> Optional[int]:
+        """Maximum total tokens allowed, or None if unlimited."""
+        return self._max_tokens
+
+    @property
+    def max_calls(self) -> Optional[int]:
+        """Maximum total calls allowed, or None if unlimited."""
+        return self._max_calls
+
+    @property
+    def max_cost_usd(self) -> Optional[float]:
+        """Maximum total cost in USD, or None if unlimited."""
+        return self._max_cost_usd
 
     def consume(self, tokens: int = 0, calls: int = 0, cost_usd: float = 0.0) -> None:
         """Record resource consumption and check limits.

--- a/sdk/agentguard/integrations/langchain.py
+++ b/sdk/agentguard/integrations/langchain.py
@@ -143,9 +143,9 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
                 except BudgetExceeded as e:
                     ctx.event("guard.budget_exceeded", data={
                         "tokens_used": self._budget_guard.state.tokens_used,
-                        "tokens_limit": self._budget_guard._max_tokens,
+                        "tokens_limit": self._budget_guard.max_tokens,
                         "calls_used": self._budget_guard.state.calls_used,
-                        "calls_limit": self._budget_guard._max_calls,
+                        "calls_limit": self._budget_guard.max_calls,
                         "error": str(e),
                     })
                     ctx.event("llm.end", data=payload)
@@ -187,7 +187,7 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
                 if ctx:
                     ctx.event("guard.loop_detected", data={
                         "tool_name": tool_name,
-                        "repeat_count": self._loop_guard._max_repeats,
+                        "repeat_count": self._loop_guard.max_repeats,
                         "error": str(e),
                     })
                 raise
@@ -199,9 +199,9 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
                 if ctx:
                     ctx.event("guard.budget_exceeded", data={
                         "tokens_used": self._budget_guard.state.tokens_used,
-                        "tokens_limit": self._budget_guard._max_tokens,
+                        "tokens_limit": self._budget_guard.max_tokens,
                         "calls_used": self._budget_guard.state.calls_used,
-                        "calls_limit": self._budget_guard._max_calls,
+                        "calls_limit": self._budget_guard.max_calls,
                         "error": str(e),
                     })
                 raise


### PR DESCRIPTION
## Summary

- Add read-only `@property` accessors to `BudgetGuard` (`max_tokens`, `max_calls`, `max_cost_usd`) and `LoopGuard` (`max_repeats`, `window`)
- Replace all private attribute access (`._max_tokens`, `._max_calls`, `._max_repeats`) in `langchain.py` with public properties

## Test plan

- [x] All 38 guard + langchain tests pass
- [x] Lint clean

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)