### PR TITLE
Enforce ops/ alignment via PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -43,3 +43,27 @@ body:
       description: Who benefits and why?
     validations:
       required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? Be specific.
+      placeholder: |
+        - [ ] Guard raises exception when budget exceeds $5
+        - [ ] Works with LangChain AgentGuardCallbackHandler
+        - [ ] Test coverage for new code
+    validations:
+      required: true
+
+  - type: dropdown
+    id: roadmap
+    attributes:
+      label: Roadmap alignment
+      description: Does this relate to an existing ops/03-ROADMAP item?
+      options:
+        - "Yes — existing Now/Next item"
+        - "Yes — existing Later item"
+        - "No — new idea"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,23 @@
 ## Summary
 
-<!-- What does this PR do? Keep it to 1-3 bullet points. -->
+<!-- What does this PR do? 1-3 bullet points. -->
 
 ## Related Issues
 
 <!-- Link to GitHub issues: Closes #XX -->
 
+## Scope
+
+- **Related ops/ doc(s):** <!-- NORTHSTAR | SDK_SCOPE | ARCHITECTURE | ROADMAP | DEFINITION_OF_DONE | N/A -->
+- **Does this change the public API?** <!-- Yes / No — if Yes, update ops/02-ARCHITECTURE.md -->
+- **Does this shift roadmap priority?** <!-- Yes / No — if Yes, update ops/03-ROADMAP_NOW_NEXT_LATER.md -->
+
 ## Checklist
 
-- [ ] Tests pass locally (`python -m pytest sdk/tests/ -v --cov=agentguard --cov-fail-under=80`)
-- [ ] Lint passes (`ruff check sdk/agentguard/`)
-- [ ] New functionality includes tests
-- [ ] No new dependencies added to core SDK
+- [ ] `make check` passes (pytest + ruff, coverage >= 80%)
+- [ ] `make structural` passes (10 Golden Principles)
+- [ ] `make security` passes (bandit)
+- [ ] New functionality has tests
+- [ ] No new hard dependencies in core SDK
+- [ ] No hardcoded absolute paths
+- [ ] If `__init__.py` exports changed, `ops/02-ARCHITECTURE.md` updated


### PR DESCRIPTION
## Summary

- Upgraded PR template with Scope section linking to ops/ docs and expanded checklist matching Definition of Done
- Added required acceptance criteria and roadmap alignment fields to feature request template

## Scope

- **Related ops/ doc(s):** DEFINITION_OF_DONE
- **Does this change the public API?** No
- **Does this shift roadmap priority?** No

## Test plan

- [ ] Open a draft PR to verify rendered PR template shows Scope section and 7-item checklist
- [ ] Click "New Issue" → "Feature Request" to verify acceptance criteria and roadmap dropdown render
- [ ] Confirm checklist items match `ops/04-DEFINITION_OF_DONE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)