### PR TITLE
Growth wave 3: security badge, CI cost gates, blog posts, discussions, cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Set a dollar budget. Get warnings at 80%. Kill the agent when it exceeds the lim
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bmdhodl/agent47/badge)](https://scorecard.dev/viewer/?uri=github.com/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
 ```bash
@@ -223,6 +224,32 @@ result = (
 agentguard eval traces.jsonl --ci   # exits non-zero on failure
 ```
 
+## CI Cost Gates
+
+Fail your CI pipeline if an agent run exceeds a cost budget. No competitor offers this.
+
+```yaml
+# .github/workflows/cost-gate.yml (simplified)
+- name: Run agent with budget guard
+  run: |
+    python3 -c "
+    from agentguard import Tracer, BudgetGuard, JsonlFileSink
+    tracer = Tracer(
+        sink=JsonlFileSink('ci_traces.jsonl'),
+        guards=[BudgetGuard(max_cost_usd=5.00)],
+    )
+    # ... your agent run here ...
+    "
+
+- name: Evaluate traces
+  uses: bmdhodl/agent47/.github/actions/agentguard-eval@main
+  with:
+    trace-file: ci_traces.jsonl
+    assertions: "no_errors,max_cost:5.00"
+```
+
+Full workflow: [`docs/ci/cost-gate-workflow.yml`](docs/ci/cost-gate-workflow.yml)
+
 ## Async Support
 
 Full async API mirrors the sync API.
@@ -296,6 +323,13 @@ Your Agent Code
 | `site/` | Landing page | MIT |
 
 > Dashboard is in a separate private repo ([agent47-dashboard](https://github.com/bmdhodl/agent47-dashboard)).
+
+## Security
+
+- **Zero runtime dependencies** — one package, nothing to audit, no supply chain risk
+- **[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/bmdhodl/agent47)** — automated security analysis on every push
+- **CodeQL scanning** — GitHub's semantic code analysis on every PR
+- **Bandit security linting** — Python-specific security checks in CI
 
 ## Contributing
 

--- a/docs/blog/002-budget-enforcement-patterns-devto.md
+++ b/docs/blog/002-budget-enforcement-patterns-devto.md
@@ -1,0 +1,129 @@
+---
+title: "3 Patterns for Enforcing AI Agent Budgets in Python"
+published: true
+tags: [ai, python, openai, budgets]
+description: "Hard dollar caps, warning callbacks, and auto-tracking — three patterns to stop runaway agent costs."
+canonical_url: https://github.com/bmdhodl/agent47/blob/main/docs/blog/002-budget-enforcement-patterns-devto.md
+---
+
+"How do I stop my agent from spending more than $X?"
+
+OpenAI's API doesn't have per-request budget caps. Account-level spend limits are a blunt instrument — they kill everything, not just the runaway agent. And by the time the limit kicks in, you've already spent the money.
+
+Here are three patterns for enforcing budgets at the agent level, from simplest to most automated.
+
+## Pattern 1: Hard Dollar Cap
+
+Stop execution the moment cost exceeds a threshold:
+
+```python
+from agentguard import BudgetGuard, BudgetExceeded
+
+guard = BudgetGuard(max_cost_usd=2.00)
+
+# After each LLM call, feed in the cost:
+guard.consume(tokens=1500, cost_usd=0.045)
+
+# When cumulative cost exceeds $2.00 → BudgetExceeded raised
+```
+
+Set a dollar amount. Call `consume()` after each API call. Catch the exception. Done.
+
+## Pattern 2: Warning Before the Limit
+
+Get a heads-up at 80% so you can gracefully wrap up:
+
+```python
+from agentguard import BudgetGuard, BudgetExceeded
+
+wrapping_up = False
+
+def on_budget_warning(msg):
+    global wrapping_up
+    wrapping_up = True
+    print(f"Budget warning: {msg}")
+
+guard = BudgetGuard(
+    max_cost_usd=5.00,
+    warn_at_pct=0.8,
+    on_warning=on_budget_warning,
+)
+
+for step in range(100):
+    try:
+        guard.consume(cost_usd=0.12)
+    except BudgetExceeded:
+        print("Hard stop — budget exceeded")
+        break
+
+    if wrapping_up:
+        break  # Finish current task, skip new tool calls
+```
+
+Two-phase shutdown: `on_warning` fires at 80%, `BudgetExceeded` is the hard stop.
+
+## Pattern 3: Auto-Tracking with OpenAI Patching
+
+Skip manual `consume()` calls entirely — let AgentGuard estimate cost automatically:
+
+```python
+from agentguard import Tracer, BudgetGuard, JsonlFileSink, patch_openai
+
+tracer = Tracer(
+    sink=JsonlFileSink("traces.jsonl"),
+    service="my-agent",
+    guards=[BudgetGuard(max_cost_usd=5.00)],
+)
+patch_openai(tracer)
+
+# Every OpenAI call is now auto-traced with cost estimates.
+# BudgetGuard checks after each call.
+# Supports GPT-4o, GPT-4, GPT-3.5, and embedding models.
+```
+
+`patch_openai` intercepts `ChatCompletion` responses, extracts token counts from the response, and feeds them into BudgetGuard. No manual tracking.
+
+Works with Anthropic too:
+
+```python
+from agentguard import patch_anthropic
+patch_anthropic(tracer)
+```
+
+## Combining with Loop Detection
+
+Budget overruns and loops often go together. A stuck agent burns through your budget fast. Layer both guards:
+
+```python
+from agentguard import Tracer, LoopGuard, BudgetGuard, JsonlFileSink
+
+tracer = Tracer(
+    sink=JsonlFileSink("traces.jsonl"),
+    service="my-agent",
+    guards=[
+        LoopGuard(max_repeats=3),
+        BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8),
+    ],
+)
+```
+
+Whichever guard triggers first stops the agent.
+
+## Which Pattern to Use
+
+- **Pattern 1** — quick scripts, one-off runs, prototypes
+- **Pattern 2** — production agents that need graceful shutdown
+- **Pattern 3** — any project using OpenAI/Anthropic SDKs directly
+
+All three work with zero dependencies. Pattern 3 adds auto-instrumentation, so you never forget to track a call.
+
+## Try It
+
+```bash
+pip install agentguard47
+python examples/try_it_now.py
+```
+
+Zero config, no API keys needed to see BudgetGuard in action.
+
+Repo: [github.com/bmdhodl/agent47](https://github.com/bmdhodl/agent47)

--- a/docs/blog/003-ci-cost-gates-devto.md
+++ b/docs/blog/003-ci-cost-gates-devto.md
@@ -1,0 +1,129 @@
+---
+title: "How to Add Cost Gates to Your AI Agent CI Pipeline"
+published: true
+tags: [ai, python, cicd, devops]
+description: "Fail CI if your AI agent exceeds a dollar budget. A GitHub Actions workflow for cost-controlled agent testing."
+canonical_url: https://github.com/bmdhodl/agent47/blob/main/docs/blog/003-ci-cost-gates-devto.md
+---
+
+Your AI agent passes all your tests. Great. But did you check how much it *cost*?
+
+Most CI pipelines test for correctness — they don't test for cost. A single agent run can burn $5, $50, or $500 depending on model choice, tool loops, and context window size. In CI, this adds up fast: 10 PRs × 3 test runs × $5/run = $150/day in API costs.
+
+**AgentGuard adds cost gates to your CI pipeline.** If an agent run exceeds a dollar threshold, CI fails. No surprises on your OpenAI invoice.
+
+## The Problem
+
+AI agent tests are fundamentally different from unit tests:
+
+1. **Non-deterministic** — the same input can produce different (and differently priced) outputs
+2. **Expensive** — each run costs real money in API calls
+3. **Unbounded** — an agent can make 3 tool calls or 300, and you won't know until the bill arrives
+
+Traditional test assertions don't catch these issues. `assert result == expected` doesn't tell you the test cost $12.
+
+## The Solution: Cost Gates in CI
+
+Here's a GitHub Actions workflow that runs your agent with a budget guard and fails if costs exceed a threshold:
+
+```yaml
+name: Cost Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  cost-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install agentguard47
+
+      - name: Run agent with budget guard
+        run: |
+          python3 -c "
+          from agentguard import Tracer, BudgetGuard, JsonlFileSink
+
+          tracer = Tracer(
+              sink=JsonlFileSink('ci_traces.jsonl'),
+              service='ci-agent-test',
+              guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)],
+          )
+
+          with tracer.trace('ci.agent_run') as span:
+              # Your agent code here
+              pass
+          "
+
+      - name: Evaluate traces
+        if: always()
+        uses: bmdhodl/agent47/.github/actions/agentguard-eval@main
+        with:
+          trace-file: ci_traces.jsonl
+          assertions: "no_errors,max_cost:5.00"
+```
+
+## What This Does
+
+1. **BudgetGuard** tracks cost during the agent run. If the agent exceeds $5, it raises `BudgetExceeded` and the run stops immediately.
+2. **JsonlFileSink** writes structured traces to a file for post-run analysis.
+3. **agentguard-eval** action reads the trace file and asserts:
+   - No errors occurred
+   - Total cost stayed under $5.00
+4. If any assertion fails, **CI fails**. The eval action posts results as a PR comment.
+
+## Auto-Tracking Cost with OpenAI
+
+If your agent uses OpenAI, AgentGuard can auto-track cost per API call:
+
+```python
+from agentguard import Tracer, BudgetGuard, JsonlFileSink, patch_openai
+
+tracer = Tracer(
+    sink=JsonlFileSink("ci_traces.jsonl"),
+    service="ci-agent-test",
+    guards=[BudgetGuard(max_cost_usd=5.00)],
+)
+patch_openai(tracer)  # auto-tracks cost for every ChatCompletion call
+
+# Now run your agent normally — costs are tracked automatically
+```
+
+No manual `consume()` calls needed. AgentGuard intercepts OpenAI responses, extracts token counts, and estimates cost using published pricing.
+
+## Multiple Assertions
+
+The eval action supports several assertion types:
+
+```yaml
+assertions: "no_errors,max_cost:5.00,max_duration:30,max_events:100"
+```
+
+- `no_errors` — no error events in the trace
+- `max_cost:X` — total cost under $X
+- `max_duration:X` — no span longer than X seconds
+- `max_events:X` — total event count under X (catches runaway loops)
+
+## Why This Matters
+
+Every other agent observability tool (LangSmith, Langfuse, Portkey) shows you cost *after* the run. AgentGuard is the only tool that:
+
+1. **Kills the agent mid-run** when the budget is exceeded
+2. **Fails CI** if cost thresholds are breached
+3. **Does it with zero dependencies** — stdlib Python only
+
+## Try It
+
+```bash
+pip install agentguard47
+```
+
+Full workflow file: [docs/ci/cost-gate-workflow.yml](https://github.com/bmdhodl/agent47/blob/main/docs/ci/cost-gate-workflow.yml)
+
+Repo: [github.com/bmdhodl/agent47](https://github.com/bmdhodl/agent47)

--- a/docs/blog/PUBLISHING.md
+++ b/docs/blog/PUBLISHING.md
@@ -1,0 +1,57 @@
+# Publishing Blog Posts
+
+Step-by-step instructions for cross-posting AgentGuard blog posts to Dev.to, Hashnode, and Medium.
+
+## Dev.to
+
+1. Go to [dev.to/enter](https://dev.to/enter) and sign in
+2. Click **Write a Post**
+3. Copy the entire markdown file content (including the frontmatter `---` block)
+4. Paste into the editor — Dev.to reads the frontmatter automatically:
+   - `title` → post title
+   - `tags` → post tags (max 4)
+   - `description` → meta description
+   - `canonical_url` → prevents SEO duplicate penalty
+   - `published: true` → publishes immediately (set to `false` for draft)
+5. Preview, then publish
+
+**Tags to use:** `ai`, `python`, `opensource`, `devops`, `agents`, `openai`, `cicd`
+(Dev.to allows max 4 tags per post — pick the most relevant)
+
+## Hashnode
+
+1. Go to [hashnode.com](https://hashnode.com) and sign in
+2. Click **Write an article**
+3. Paste markdown content (without frontmatter)
+4. Set manually:
+   - **Title** — from the `title` field in frontmatter
+   - **Tags** — from the `tags` field
+   - **Canonical URL** — from the `canonical_url` field (under SEO settings)
+5. Publish
+
+## Medium
+
+1. Go to [medium.com/new-story](https://medium.com/new-story)
+2. Paste markdown — Medium will auto-format (code blocks may need manual cleanup)
+3. Add tags (Medium allows up to 5): `AI`, `Python`, `DevOps`, `Open Source`, `Machine Learning`
+4. Set canonical URL: Settings → This story was originally published on → paste the `canonical_url`
+5. Publish
+
+## Post Checklist
+
+Before publishing each post:
+
+- [ ] All code examples run against `agentguard47==1.2.1`
+- [ ] `canonical_url` points to the GitHub source file
+- [ ] Links to repo (`github.com/bmdhodl/agent47`) are correct
+- [ ] `pip install agentguard47` command is correct
+- [ ] No broken images or links
+- [ ] Preview looks clean on the target platform
+
+## Posts Ready to Publish
+
+| File | Title | Platforms |
+|------|-------|-----------|
+| `001-why-agents-loop-devto.md` | Why Your AI Agent Loops (And How to See It) | Dev.to, Hashnode |
+| `002-budget-enforcement-patterns-devto.md` | 3 Patterns for Enforcing AI Agent Budgets in Python | Dev.to, Hashnode |
+| `003-ci-cost-gates-devto.md` | How to Add Cost Gates to Your AI Agent CI Pipeline | Dev.to, Hashnode |

--- a/docs/ci/cost-gate-workflow.yml
+++ b/docs/ci/cost-gate-workflow.yml
@@ -1,0 +1,57 @@
+# AgentGuard CI Cost Gate
+# Fail CI if your AI agent exceeds a cost budget during tests.
+#
+# Usage: Copy this file to .github/workflows/cost-gate.yml
+# Customize BUDGET_LIMIT and your agent run command.
+
+name: Cost Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  cost-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install agentguard47
+
+      - name: Run agent with budget guard
+        env:
+          BUDGET_LIMIT: "5.00"  # Max dollars per CI run
+        run: |
+          python3 - <<'EOF'
+          import os, sys
+          from agentguard import Tracer, BudgetGuard, JsonlFileSink, BudgetExceeded
+
+          budget = float(os.environ["BUDGET_LIMIT"])
+          tracer = Tracer(
+              sink=JsonlFileSink("ci_traces.jsonl"),
+              service="ci-agent-test",
+              guards=[BudgetGuard(max_cost_usd=budget, warn_at_pct=0.8)],
+          )
+
+          # --- Replace this section with your actual agent run ---
+          with tracer.trace("ci.agent_run") as span:
+              # Your agent code here. Example:
+              # from my_agent import run_agent
+              # run_agent(tracer=tracer)
+              span.event("placeholder", data={"note": "Replace with your agent run"})
+          # --- End of agent run ---
+
+          print(f"Agent completed within ${budget:.2f} budget")
+          EOF
+
+      - name: Evaluate traces
+        if: always()
+        uses: ./.github/actions/agentguard-eval
+        with:
+          trace-file: ci_traces.jsonl
+          assertions: "no_errors,max_cost:5.00"

--- a/docs/cookbooks/langchain-budget-rag.ipynb
+++ b/docs/cookbooks/langchain-budget-rag.ipynb
@@ -1,0 +1,190 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "name": "Budget-Guarded RAG Agent with AgentGuard"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Budget-Guarded RAG Agent with AgentGuard + LangChain\n",
+    "\n",
+    "RAG agents are expensive. A retrieval-augmented generation pipeline that searches, retrieves, and synthesizes can easily make 10-50 LLM calls per query. Without budget controls, a single stuck query can burn through your API budget.\n",
+    "\n",
+    "This notebook shows how to add a hard dollar cap to a LangChain RAG agent using [AgentGuard](https://github.com/bmdhodl/agent47). When the budget is exceeded, the agent stops immediately.\n",
+    "\n",
+    "**No API keys required** — this notebook uses a mocked LLM to demonstrate the pattern."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q agentguard47"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Set up the budget guard\n",
+    "\n",
+    "BudgetGuard enforces a hard dollar limit. When cumulative cost exceeds the limit, it raises `BudgetExceeded` and the agent stops."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agentguard import BudgetGuard, BudgetExceeded, LoopGuard\n",
+    "\n",
+    "budget_guard = BudgetGuard(\n",
+    "    max_cost_usd=1.00,\n",
+    "    warn_at_pct=0.8,\n",
+    "    on_warning=lambda msg: print(f\"WARNING: {msg}\"),\n",
+    ")\n",
+    "\n",
+    "loop_guard = LoopGuard(max_repeats=3, window=6)\n",
+    "\n",
+    "print(f\"Budget: ${budget_guard._max_cost_usd:.2f}\")\n",
+    "print(f\"Warning at: 80%\")\n",
+    "print(f\"Loop detection: max 3 repeats in 6-call window\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Simulate a RAG agent\n",
+    "\n",
+    "This simulates a RAG pipeline making multiple retrieval + synthesis calls. Each step has a realistic cost estimate based on GPT-4o pricing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulated RAG pipeline steps with realistic costs\n",
+    "rag_steps = [\n",
+    "    {\"step\": \"embed_query\", \"description\": \"Embed user query\", \"cost\": 0.001},\n",
+    "    {\"step\": \"retrieve_docs\", \"description\": \"Retrieve top-k documents\", \"cost\": 0.002},\n",
+    "    {\"step\": \"rerank\", \"description\": \"Rerank retrieved docs\", \"cost\": 0.05},\n",
+    "    {\"step\": \"synthesize_1\", \"description\": \"Synthesize chunk 1\", \"cost\": 0.08},\n",
+    "    {\"step\": \"synthesize_2\", \"description\": \"Synthesize chunk 2\", \"cost\": 0.08},\n",
+    "    {\"step\": \"synthesize_3\", \"description\": \"Synthesize chunk 3\", \"cost\": 0.08},\n",
+    "    {\"step\": \"merge_results\", \"description\": \"Merge synthesis results\", \"cost\": 0.12},\n",
+    "    {\"step\": \"fact_check\", \"description\": \"Fact-check against sources\", \"cost\": 0.15},\n",
+    "    {\"step\": \"refine\", \"description\": \"Refine final answer\", \"cost\": 0.12},\n",
+    "    {\"step\": \"format_output\", \"description\": \"Format and cite sources\", \"cost\": 0.09},\n",
+    "    {\"step\": \"follow_up_1\", \"description\": \"Generate follow-up query 1\", \"cost\": 0.06},\n",
+    "    {\"step\": \"follow_up_2\", \"description\": \"Generate follow-up query 2\", \"cost\": 0.06},\n",
+    "    {\"step\": \"deep_dive\", \"description\": \"Deep dive on subtopic\", \"cost\": 0.15},\n",
+    "]\n",
+    "\n",
+    "print(f\"RAG pipeline: {len(rag_steps)} steps\")\n",
+    "print(f\"Estimated total cost: ${sum(s['cost'] for s in rag_steps):.2f}\")\n",
+    "print(f\"Budget: $1.00 — agent will be stopped before completing all steps\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Running RAG pipeline with budget guard...\\n\")\n",
+    "\n",
+    "for i, step in enumerate(rag_steps, 1):\n",
+    "    try:\n",
+    "        # Check for loops\n",
+    "        loop_guard.check(step[\"step\"])\n",
+    "        \n",
+    "        # Consume budget\n",
+    "        budget_guard.consume(calls=1, cost_usd=step[\"cost\"])\n",
+    "        \n",
+    "        cost_so_far = budget_guard.state.cost_used\n",
+    "        pct = (cost_so_far / 1.00) * 100\n",
+    "        print(f\"  [{i:2d}] {step['description']:<35s} +${step['cost']:.3f}  (total: ${cost_so_far:.3f}, {pct:.0f}%)\")\n",
+    "        \n",
+    "    except BudgetExceeded as e:\n",
+    "        print(f\"\\n  BUDGET EXCEEDED at step {i}: {step['description']}\")\n",
+    "        print(f\"  {e}\")\n",
+    "        print(f\"\\n  Final stats:\")\n",
+    "        print(f\"    Total cost:  ${budget_guard.state.cost_used:.3f}\")\n",
+    "        print(f\"    API calls:   {budget_guard.state.calls_used}\")\n",
+    "        print(f\"    Steps completed: {i-1} of {len(rag_steps)}\")\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Using with a real LangChain agent\n",
+    "\n",
+    "In production, replace the simulation with AgentGuard's LangChain callback handler:\n",
+    "\n",
+    "```python\n",
+    "from agentguard import Tracer, BudgetGuard, LoopGuard\n",
+    "from agentguard.integrations.langchain import AgentGuardCallbackHandler\n",
+    "\n",
+    "tracer = Tracer(service=\"rag-agent\")\n",
+    "handler = AgentGuardCallbackHandler(\n",
+    "    tracer=tracer,\n",
+    "    budget_guard=BudgetGuard(max_cost_usd=5.00),\n",
+    "    loop_guard=LoopGuard(max_repeats=3),\n",
+    ")\n",
+    "\n",
+    "# Pass to any LangChain component\n",
+    "llm = ChatOpenAI(model=\"gpt-4o\", callbacks=[handler])\n",
+    "retriever = vectorstore.as_retriever(callbacks=[handler])\n",
+    "\n",
+    "# The handler auto-tracks cost and detects loops\n",
+    "chain = RetrievalQA.from_chain_type(llm=llm, retriever=retriever)\n",
+    "result = chain.invoke({\"query\": \"What is quantum computing?\"})\n",
+    "```\n",
+    "\n",
+    "Install with LangChain extras:\n",
+    "```bash\n",
+    "pip install agentguard47[langchain]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key takeaways\n",
+    "\n",
+    "- **BudgetGuard** enforces hard dollar limits — the agent stops immediately when exceeded\n",
+    "- **LoopGuard** catches repeated tool calls before they compound costs\n",
+    "- **Warning callbacks** give you a chance to wrap up gracefully at 80%\n",
+    "- Works with any LangChain component via the callback handler\n",
+    "- Zero dependencies — pure Python stdlib\n",
+    "\n",
+    "**Links:**\n",
+    "- [AgentGuard repo](https://github.com/bmdhodl/agent47)\n",
+    "- [LangChain integration docs](https://github.com/bmdhodl/agent47#langchain)\n",
+    "- [Full guard reference](https://github.com/bmdhodl/agent47#guards)"
+   ]
+  }
+ ]
+}

--- a/docs/discussions/03_limit_openai_spend.md
+++ b/docs/discussions/03_limit_openai_spend.md
@@ -1,0 +1,70 @@
+# How to Limit OpenAI API Spend Per Agent Run
+
+**Category:** Show and tell
+**Labels:** openai, budget, cost-control
+
+---
+
+If you're running autonomous agents with OpenAI, you've probably wondered: how do I set a hard dollar limit per agent run?
+
+OpenAI has account-level spend limits, but those are a kill switch for your entire organization. They don't help when one agent run out of 50 goes haywire.
+
+Here's how to set a per-run budget that kills the agent the moment it exceeds your limit.
+
+## Setup
+
+```bash
+pip install agentguard47
+```
+
+```python
+from agentguard import Tracer, BudgetGuard, BudgetExceeded, patch_openai
+
+tracer = Tracer(
+    service="my-agent",
+    guards=[BudgetGuard(max_cost_usd=2.00, warn_at_pct=0.8)],
+)
+patch_openai(tracer)
+
+# Now use OpenAI normally:
+import openai
+client = openai.OpenAI()
+
+try:
+    for i in range(100):
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": f"Step {i}: analyze data"}],
+        )
+except BudgetExceeded as e:
+    print(f"Agent stopped: {e}")
+    # Agent killed at $2.00 — no more API calls
+```
+
+`patch_openai` intercepts every `ChatCompletion` response, extracts token counts, estimates cost using published pricing, and feeds it into BudgetGuard. When the cumulative cost exceeds your limit, `BudgetExceeded` is raised.
+
+## Warning before the hard stop
+
+The `warn_at_pct=0.8` parameter fires a callback at 80% of the budget. You can use this for graceful shutdown:
+
+```python
+guard = BudgetGuard(
+    max_cost_usd=5.00,
+    warn_at_pct=0.8,
+    on_warning=lambda msg: print(f"WARNING: {msg}"),
+)
+```
+
+## Zero dependencies
+
+AgentGuard is pure Python stdlib. No extra packages to audit.
+
+```bash
+pip install agentguard47
+```
+
+Repo: [github.com/bmdhodl/agent47](https://github.com/bmdhodl/agent47)
+
+---
+
+*What's your current approach to limiting per-agent spend? Curious if anyone has built custom solutions.*

--- a/docs/discussions/04_detect_tool_loops.md
+++ b/docs/discussions/04_detect_tool_loops.md
@@ -1,0 +1,83 @@
+# How to Detect Tool Call Loops in AI Agents
+
+**Category:** Show and tell
+**Labels:** loop-detection, agents, python
+
+---
+
+AI agents get stuck in loops more often than most people realize. The pattern: agent calls a tool, gets a result it doesn't understand, and calls the same tool again with the same arguments. Repeat 50 times. Your token budget is gone.
+
+This happens with every model — GPT-4, Claude, Gemini. It happens more often with complex tool schemas and ambiguous queries.
+
+## Exact loops
+
+Catch when the same `(tool_name, tool_args)` pair is called repeatedly:
+
+```python
+from agentguard import LoopGuard, LoopDetected
+
+guard = LoopGuard(max_repeats=3, window=6)
+
+# In your agent loop:
+for step in agent_steps:
+    try:
+        guard.check(tool_name=step["tool"], tool_args=step["args"])
+    except LoopDetected as e:
+        print(f"Loop detected: {e}")
+        break
+
+    # Execute the tool call...
+```
+
+`LoopGuard` keeps a sliding window of recent calls. If the same call appears 3 times in a 6-call window, it raises `LoopDetected`.
+
+## Fuzzy loops
+
+Sometimes agents loop with slightly different arguments — `search("weather NYC")` then `search("NYC weather")`. Basic loop detection misses this.
+
+`FuzzyLoopGuard` catches two additional patterns:
+
+1. **Same tool, different args** — tool called too many times regardless of arguments
+2. **A-B-A-B alternation** — two tools called in alternating pattern
+
+```python
+from agentguard import FuzzyLoopGuard
+
+guard = FuzzyLoopGuard(
+    max_tool_repeats=5,     # same tool called 5+ times
+    max_alternations=3,     # A-B-A-B pattern 3+ times
+    window=10,
+)
+```
+
+## With LangChain
+
+```python
+from agentguard import LoopGuard
+from agentguard.integrations.langchain import AgentGuardCallbackHandler
+
+handler = AgentGuardCallbackHandler(
+    loop_guard=LoopGuard(max_repeats=3),
+)
+
+agent_executor.invoke(
+    {"input": "Research quantum computing"},
+    config={"callbacks": [handler]},
+)
+```
+
+The callback handler automatically feeds tool calls into the guard.
+
+## Install
+
+```bash
+pip install agentguard47
+```
+
+Zero dependencies, MIT licensed, Python 3.9+.
+
+Repo: [github.com/bmdhodl/agent47](https://github.com/bmdhodl/agent47)
+
+---
+
+*What loop patterns have you seen in your agents? I'm collecting failure modes to improve detection — drop a comment with examples.*

--- a/docs/discussions/05_langgraph_cost_tracking.md
+++ b/docs/discussions/05_langgraph_cost_tracking.md
@@ -1,0 +1,90 @@
+# Cost Tracking for LangGraph Agents
+
+**Category:** Show and tell
+**Labels:** langgraph, cost-control, budget
+
+---
+
+LangGraph agents can run for a long time — branching, backtracking, calling tools across multiple nodes. Without cost tracking, you have no idea what a graph execution costs until the OpenAI invoice arrives.
+
+Here's how to add per-node budget enforcement to a LangGraph agent.
+
+## The `guarded_node` decorator
+
+AgentGuard provides a LangGraph-specific decorator that wraps any node with budget and loop guards:
+
+```bash
+pip install agentguard47[langgraph]
+```
+
+```python
+from agentguard import Tracer, BudgetGuard, LoopGuard
+from agentguard.integrations.langgraph import guarded_node
+
+tracer = Tracer(service="my-graph-agent")
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+
+@guarded_node(tracer=tracer, budget_guard=budget)
+def research_node(state):
+    # Your LLM calls here
+    return {"messages": state["messages"] + [result]}
+
+@guarded_node(tracer=tracer, budget_guard=budget)
+def synthesis_node(state):
+    # More LLM calls
+    return {"messages": state["messages"] + [summary]}
+```
+
+Every node execution is:
+1. **Traced** — start/end events with timing
+2. **Budget-checked** — if cumulative cost exceeds $5, `BudgetExceeded` is raised
+3. **Loop-guarded** (optional) — catches repeated tool calls within the node
+
+## What happens when the budget is exceeded
+
+`BudgetExceeded` propagates up through the graph execution. You can catch it at the top level:
+
+```python
+from agentguard import BudgetExceeded
+
+try:
+    result = graph.invoke({"messages": [initial_message]})
+except BudgetExceeded as e:
+    print(f"Graph stopped: {e}")
+    print(f"Total cost: ${budget.state.cost_used:.2f}")
+    print(f"API calls: {budget.state.calls_used}")
+```
+
+The budget is shared across all nodes — so a $5 limit applies to the entire graph execution, not per-node.
+
+## Adding the `guard_node` to your graph
+
+For more control, you can add a standalone guard node that checks the budget between steps:
+
+```python
+from agentguard.integrations.langgraph import guard_node
+
+# Create a guard node
+budget_check = guard_node(budget_guard=budget)
+
+# Add to your graph
+graph.add_node("budget_check", budget_check)
+graph.add_edge("research", "budget_check")
+graph.add_edge("budget_check", "synthesis")
+```
+
+This checks the budget explicitly between the research and synthesis steps.
+
+## Install
+
+```bash
+pip install agentguard47[langgraph]
+```
+
+Zero runtime dependencies in the core SDK. The LangGraph integration is an optional extra.
+
+Repo: [github.com/bmdhodl/agent47](https://github.com/bmdhodl/agent47)
+
+---
+
+*Anyone running LangGraph in production? Curious how you're handling cost tracking today.*


### PR DESCRIPTION
## Summary
- **#191** — OpenSSF Scorecard badge + Security section in README (4 lines, factual)
- **#189** — CI cost gates workflow (`docs/ci/cost-gate-workflow.yml`) + blog post 003 + README section
- **#186** — Blog post 002 (budget enforcement patterns) + `PUBLISHING.md` with Dev.to/Hashnode/Medium instructions
- **#187** — 3 new GitHub Discussions posted: [#203](https://github.com/bmdhodl/agent47/discussions/203), [#204](https://github.com/bmdhodl/agent47/discussions/204), [#205](https://github.com/bmdhodl/agent47/discussions/205)
- **#195** — LangChain cookbook notebook (`docs/cookbooks/langchain-budget-rag.ipynb`)

Closes #191, #189, #186, #187, #195

## New files
- `docs/ci/cost-gate-workflow.yml` — copy-paste-ready GitHub Actions workflow
- `docs/blog/002-budget-enforcement-patterns-devto.md` — 3 budget patterns blog
- `docs/blog/003-ci-cost-gates-devto.md` — CI cost gates blog
- `docs/blog/PUBLISHING.md` — publishing checklist for Dev.to/Hashnode/Medium
- `docs/cookbooks/langchain-budget-rag.ipynb` — Colab-ready budget-guarded RAG demo
- `docs/discussions/03-05` — discussion drafts (already posted live)

## Test plan
- [ ] OpenSSF badge renders in README
- [ ] Security section is ≤ 10 lines
- [ ] CI cost gate workflow YAML is valid
- [ ] Blog code examples match v1.2.1 API
- [ ] 6 total discussions live on the repo
- [ ] Cookbook notebook runs without API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)