### PR TITLE
Fix inaccuracies before external promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,28 @@ Set a dollar budget. Get warnings at 80%. Kill the agent when it exceeds the lim
 pip install agentguard47
 ```
 
-<!-- Replace with recorded GIF: vhs examples/demo.tape -->
-![AgentGuard BudgetGuard Demo](examples/demo.gif)
-
 ## Try it in 60 seconds
 
 No API keys. No config. Just run it:
 
 ```bash
 pip install agentguard47 && python examples/try_it_now.py
+```
+
+```
+Simulating agent making LLM calls with a $1.00 budget...
+
+  Call 1: $0.12 spent
+  Call 2: $0.24 spent
+  ...
+  WARNING: Budget warning: cost 84% of limit reached (threshold: 80%)
+  Call 7: $0.84 spent
+  Call 8: $0.96 spent
+
+  STOPPED at call 9: Cost budget exceeded: $1.08 > $1.00
+  Total: $1.08 | 9 calls
+
+  Without AgentGuard, this agent would have kept spending.
 ```
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/main/examples/quickstart.ipynb)

--- a/docs/blog/001-why-agents-loop-devto.md
+++ b/docs/blog/001-why-agents-loop-devto.md
@@ -75,12 +75,6 @@ AgentGuard report
 
 The guard caught the loop on the third identical call. No tokens wasted. No silent failure.
 
-Open the trace viewer to see the full event timeline in your browser:
-
-```bash
-agentguard view traces.jsonl
-```
-
 ## Why this matters
 
 Without tracing, loop failures are invisible. Your agent returns after 30 seconds and you don't know if it did useful work or burned $2 in API calls repeating itself.
@@ -90,7 +84,7 @@ AgentGuard gives you:
 - **Loop detection** — automatically catch repeated tool calls before they burn your budget
 - **Budget guards** — set hard limits on tokens and API calls
 - **Timeout guards** — kill runs that exceed wall-clock limits
-- **Deterministic replay** — record runs and replay them for regression tests
+- **Trace evaluation** — assert properties of recorded runs for regression testing in CI
 
 ## Try it yourself
 

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -25,8 +25,8 @@ AgentGuard is different: it kills the agent mid-run.
 
 - BudgetGuard: set a dollar limit ($5, $50, whatever). Get a warning at 80%. Agent dies at 100%.
 - LoopGuard: detects repeated tool calls and A-B-A-B patterns. Raises an exception.
-- CostTracker: built-in pricing for GPT-4o, Claude, Gemini, Llama, etc. Updated monthly.
-- Full tracing: JSONL output, spans, events, cost data. CLI reports and Gantt viewer.
+- Cost tracking: built-in pricing for GPT-4o, Claude, Gemini, Llama, etc. Updated monthly.
+- Full tracing: JSONL output, spans, events, cost data. CLI reports and eval assertions.
 
 **4 lines to stop runaway costs:**
 
@@ -62,7 +62,7 @@ Docs: https://agentguard47.com
 
 - [ ] `pip install agentguard47==1.2.1` works
 - [ ] README hero is cost guardrail (done)
-- [ ] Demo GIF embedded in README (need to record with VHS)
+- [x] Try-it-now terminal output in README
 - [ ] All README links resolve (no 404s)
 - [ ] `examples/demo_budget_kill.py` runs without API keys
 - [ ] Repo description updated (done)


### PR DESCRIPTION
## Summary
- Replace broken `examples/demo.gif` image in README with actual `try_it_now.py` terminal output
- Fix blog 001: remove nonexistent `agentguard view` CLI command, replace false "deterministic replay" claim with accurate "trace evaluation" feature
- Fix Show HN draft: `CostTracker` → `cost tracking`, remove nonexistent Gantt viewer reference

## Context
Prepping for awesome-list submissions and Show HN. Every claim must be verifiable.

## Test plan
- [ ] README renders correctly on GitHub (no broken images)
- [ ] Blog 001 code examples all reference real SDK features
- [ ] Show HN text is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)