### PR TITLE
Pivot positioning: observability → cost control

### DIFF
--- a/ops/00-NORTHSTAR.md
+++ b/ops/00-NORTHSTAR.md
@@ -1,19 +1,23 @@
-# AgentGuard SDK — North Star
+# AgentGuard — North Star
 
 ## What it is
 
-A zero-dependency Python SDK that gives AI agent builders runtime guards — hard budget limits, loop detection, and timeout enforcement that kill agents mid-run before they cause damage.
+An open-source Python SDK + hosted dashboard that gives AI teams cost control over their agents — hard budget limits, loop detection, spend visibility, and policy management that stop runaway AI bills before they happen.
+
+**SDK:** Zero-dependency runtime guards that kill agents mid-run when they exceed spend limits.
+**Dashboard:** The hosted control surface — see spend, set limits, get alerts when things go wrong.
 
 ## Who it's for
 
-Python developers building autonomous agent systems with LangChain, LangGraph, CrewAI, or raw OpenAI/Anthropic APIs — especially those moving agents from prototype to production.
+Small AI teams (1-10 engineers) building autonomous agent systems with LangChain, LangGraph, CrewAI, or raw OpenAI/Anthropic APIs — especially those moving agents from prototype to production and needing predictable AI costs.
 
 ## What problem it solves
 
-Agents fail silently. They loop, overspend, and hang. AgentGuard intercepts these failures at runtime with structured tracing and guards that raise exceptions — not dashboards that show you the damage after it happened.
+Agents fail silently. They loop, overspend, and hang. AgentGuard intercepts these failures at runtime with hard budget caps, loop detection, and timeout enforcement. The hosted dashboard gives teams spend visibility and policy management without building infrastructure.
 
 ## Non-goals
 
 1. **Not a framework.** We don't orchestrate agents. We guard whatever framework you already use.
-2. **Not an observability platform.** We emit structured traces (JSONL) but don't store, query, or visualize them. Sinks push traces elsewhere (files, HTTP, OpenTelemetry).
+2. **Not a full observability platform.** We are not LangSmith, Langfuse, or Helicone. We don't do prompt management, eval suites, or deep trace exploration. We control costs and stop runaways.
 3. **Not a prompt engineering tool.** We don't evaluate prompt quality or optimize outputs. We stop agents from burning money and looping.
+4. **Not enterprise governance.** No RBAC, audit logs, or compliance features in V1. We serve small teams first.

--- a/site/compare.html
+++ b/site/compare.html
@@ -3,25 +3,25 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>AgentGuard vs LangSmith vs Langfuse vs Portkey — AI Agent Cost Tracking Comparison</title>
-    <meta name="description" content="Compare AgentGuard with LangSmith, Langfuse, and Portkey. Runtime budget enforcement, loop detection, and cost tracking for AI agents. Free, zero dependencies, MIT licensed." />
+    <title>Why AgentGuard for AI Cost Control? — vs LangSmith, Langfuse, Portkey</title>
+    <meta name="description" content="Other tools show you the damage after it happens. AgentGuard stops it. Compare budget enforcement, cost tracking, and spend visibility side by side." />
     <link rel="canonical" href="https://agentguard47.com/compare.html" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛡️</text></svg>" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://agentguard47.com/compare.html" />
-    <meta property="og:title" content="AgentGuard vs LangSmith vs Langfuse vs Portkey" />
-    <meta property="og:description" content="The only tool that kills agents mid-run when they exceed spend limits. Compare features, pricing, and integrations." />
+    <meta property="og:title" content="Why AgentGuard for AI Cost Control?" />
+    <meta property="og:description" content="Other tools show you the damage after it happens. AgentGuard stops it. Compare budget enforcement and spend visibility." />
     <meta property="og:image" content="https://opengraph.githubassets.com/1/bmdhodl/agent47" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="AgentGuard vs LangSmith vs Langfuse vs Portkey" />
-    <meta name="twitter:description" content="The only tool that kills agents mid-run when they exceed spend limits. Compare features, pricing, and integrations." />
+    <meta name="twitter:title" content="Why AgentGuard for AI Cost Control?" />
+    <meta name="twitter:description" content="Other tools show you the damage after it happens. AgentGuard stops it. Compare budget enforcement and spend visibility." />
 
     <!-- SEO keywords -->
-    <meta name="keywords" content="langsmith alternative, langfuse alternative, ai agent cost tracking, agent budget enforcement, ai agent observability, langchain cost tracking" />
+    <meta name="keywords" content="langsmith alternative, langfuse alternative, ai agent cost control, agent budget enforcement, ai agent spend tracking, langchain cost tracking, ai agent budget limits" />
 
     <script defer src="/_vercel/insights/script.js"></script>
     <style>
@@ -118,8 +118,8 @@
         <span>Compare</span>
       </nav>
 
-      <h1>AgentGuard vs LangSmith vs Langfuse vs Portkey</h1>
-      <p class="muted">The only AI agent observability tool with runtime budget enforcement. Compare features, pricing, and integrations side-by-side.</p>
+      <h1>Why AgentGuard for AI cost control?</h1>
+      <p class="muted">Other tools show you the damage after it happens. AgentGuard stops it. Compare budget enforcement, cost tracking, and spend visibility side by side.</p>
 
       <div class="cta">
         <a class="btn" href="https://github.com/bmdhodl/agent47" target="_blank" rel="noopener noreferrer">View on GitHub</a>
@@ -129,16 +129,16 @@
       <!-- Key differentiators -->
       <div class="highlights">
         <div class="highlight-card">
-          <strong>Runtime intervention</strong>
+          <strong>Stops agents, not just tracks them</strong>
           <p class="muted">AgentGuard kills agents mid-run when they exceed spend limits. Others only report after the damage is done.</p>
         </div>
         <div class="highlight-card">
-          <strong>Zero dependencies</strong>
-          <p class="muted">Pure Python stdlib. One package, nothing to audit. No supply chain risk, no dependency conflicts.</p>
+          <strong>Hosted policy management</strong>
+          <p class="muted">Set budget caps, loop limits, and timeouts from the dashboard. No code changes to update limits.</p>
         </div>
         <div class="highlight-card">
-          <strong>Free and open source</strong>
-          <p class="muted">MIT-licensed SDK. No per-trace pricing for local use. Dashboard optional.</p>
+          <strong>Free OSS + flat-rate hosted</strong>
+          <p class="muted">MIT-licensed SDK works offline. Hosted dashboard starts free, scales with flat monthly pricing. No per-trace charges.</p>
         </div>
       </div>
 
@@ -178,14 +178,7 @@
               <td><span class="no">No</span></td>
             </tr>
             <tr>
-              <td>Cost tracking</td>
-              <td class="col-ag"><span class="yes">Yes</span></td>
-              <td><span class="yes">Yes</span></td>
-              <td><span class="yes">Yes</span></td>
-              <td><span class="yes">Yes</span></td>
-            </tr>
-            <tr>
-              <td>Tracing / spans</td>
+              <td>Cost tracking per run</td>
               <td class="col-ag"><span class="yes">Yes</span></td>
               <td><span class="yes">Yes</span></td>
               <td><span class="yes">Yes</span></td>
@@ -199,18 +192,18 @@
               <td><span class="partial">Partial</span> &mdash; gateway-level only</td>
             </tr>
             <tr>
-              <td>Rate limit guard</td>
-              <td class="col-ag"><span class="yes">Yes</span> &mdash; per-minute throttling</td>
-              <td><span class="no">No</span></td>
-              <td><span class="no">No</span></td>
-              <td><span class="yes">Yes</span> &mdash; gateway-level</td>
+              <td>Spend visibility dashboard</td>
+              <td class="col-ag"><span class="yes">Yes</span> &mdash; per model, per day</td>
+              <td><span class="yes">Yes</span></td>
+              <td><span class="yes">Yes</span></td>
+              <td><span class="yes">Yes</span></td>
             </tr>
             <tr>
-              <td>Runtime dependencies</td>
-              <td class="col-ag"><span class="yes">Zero</span></td>
-              <td>5+</td>
-              <td>3+</td>
-              <td>3+</td>
+              <td>Policy management (hosted)</td>
+              <td class="col-ag"><span class="yes">Yes</span> &mdash; budget caps, loop limits</td>
+              <td><span class="no">No</span></td>
+              <td><span class="no">No</span></td>
+              <td><span class="partial">Partial</span> &mdash; gateway config only</td>
             </tr>
             <tr>
               <td>Open source SDK</td>
@@ -220,46 +213,11 @@
               <td><span class="partial">Partial</span></td>
             </tr>
             <tr>
-              <td>Self-hosted option</td>
-              <td class="col-ag"><span class="yes">Yes</span> &mdash; SDK works fully offline</td>
-              <td><span class="no">No</span></td>
-              <td><span class="yes">Yes</span></td>
-              <td><span class="no">No</span></td>
-            </tr>
-            <tr>
-              <td>CI cost gates</td>
-              <td class="col-ag"><span class="yes">Yes</span> &mdash; GitHub Action included</td>
-              <td><span class="no">No</span></td>
-              <td><span class="no">No</span></td>
-              <td><span class="no">No</span></td>
-            </tr>
-            <tr>
-              <td>LangChain integration</td>
-              <td class="col-ag"><span class="yes">Yes</span></td>
-              <td><span class="yes">Yes</span> &mdash; native</td>
-              <td><span class="yes">Yes</span></td>
-              <td><span class="yes">Yes</span></td>
-            </tr>
-            <tr>
-              <td>LangGraph integration</td>
-              <td class="col-ag"><span class="yes">Yes</span> &mdash; guarded_node decorator</td>
-              <td><span class="yes">Yes</span> &mdash; native</td>
-              <td><span class="partial">Partial</span></td>
-              <td><span class="no">No</span></td>
-            </tr>
-            <tr>
-              <td>CrewAI integration</td>
-              <td class="col-ag"><span class="yes">Yes</span></td>
-              <td><span class="no">No</span></td>
-              <td><span class="partial">Partial</span></td>
-              <td><span class="no">No</span></td>
-            </tr>
-            <tr>
-              <td>OpenAI/Anthropic auto-patch</td>
-              <td class="col-ag"><span class="yes">Yes</span> &mdash; one-line patching</td>
-              <td><span class="partial">Via wrapper</span></td>
-              <td><span class="yes">Yes</span></td>
-              <td><span class="yes">Yes</span> &mdash; gateway proxy</td>
+              <td>Zero dependencies</td>
+              <td class="col-ag"><span class="yes">Yes</span> &mdash; Python stdlib only</td>
+              <td>5+ deps</td>
+              <td>3+ deps</td>
+              <td>3+ deps</td>
             </tr>
           </tbody>
         </table>
@@ -312,28 +270,28 @@
       </div>
 
       <!-- Detail sections -->
-      <h2>Why AgentGuard for budget enforcement?</h2>
+      <h2>Why teams choose AgentGuard for cost control</h2>
       <div class="detail-grid">
         <div class="detail-card">
           <h3>LangSmith tracks costs. AgentGuard enforces them.</h3>
-          <p class="muted">LangSmith shows you what an agent spent after it finishes. AgentGuard raises <code>BudgetExceeded</code> at the dollar limit you set and stops the agent immediately. The difference between a dashboard alert and a circuit breaker.</p>
+          <p class="muted">LangSmith shows you what an agent spent after it finishes. AgentGuard raises <code>BudgetExceeded</code> at the dollar limit you set and stops the agent immediately. The difference between a report and a circuit breaker.</p>
         </div>
         <div class="detail-card">
-          <h3>Langfuse is open source. So is AgentGuard.</h3>
-          <p class="muted">Both are MIT-licensed. Langfuse focuses on tracing and prompt management. AgentGuard adds runtime guards &mdash; budget limits, loop detection, and timeout enforcement that stop agents before they cause damage.</p>
+          <h3>Langfuse traces. AgentGuard controls spend.</h3>
+          <p class="muted">Both are MIT-licensed. Langfuse focuses on tracing and prompt management. AgentGuard focuses on cost control &mdash; budget limits, loop detection, and spend visibility that keep your AI bill predictable.</p>
         </div>
         <div class="detail-card">
-          <h3>Portkey is a gateway. AgentGuard is a library.</h3>
-          <p class="muted">Portkey proxies all LLM traffic through their servers. AgentGuard runs in your process with zero network calls. No latency overhead, no data leaving your infrastructure, no single point of failure.</p>
+          <h3>Portkey proxies traffic. AgentGuard runs in-process.</h3>
+          <p class="muted">Portkey routes all LLM calls through their gateway. AgentGuard runs in your process &mdash; no latency, no data leaving your infrastructure, no single point of failure.</p>
         </div>
         <div class="detail-card">
-          <h3>Zero dependencies means zero risk.</h3>
-          <p class="muted">Every dependency is supply chain attack surface. AgentGuard uses Python stdlib only. One package to install, one package to audit. No transitive vulnerabilities, no version conflicts.</p>
+          <h3>Hosted dashboard, not just an SDK.</h3>
+          <p class="muted">The SDK enforces limits locally. The dashboard gives your team spend visibility, policy management, and alert feeds &mdash; without building your own infrastructure.</p>
         </div>
       </div>
 
       <!-- Code example -->
-      <h2>Add budget enforcement in 3 lines</h2>
+      <h2>Add cost control in 3 lines</h2>
       <p class="muted">No signup required. No API keys. Works offline.</p>
 <pre class="code"><span class="kw">from</span> agentguard <span class="kw">import</span> Tracer, BudgetGuard, patch_openai
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,22 +3,22 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>AgentGuard — Runtime Guardrails for AI Agents</title>
-    <meta name="description" content="Stop runaway agents, track costs per call, and replay failures deterministically. Zero dependencies." />
+    <title>AgentGuard — AI Agent Cost Control | Budget Limits &amp; Spend Visibility</title>
+    <meta name="description" content="Stop runaway AI bills before they happen. Set hard spend limits, catch looping agents, and see cost per run. Open-source SDK + hosted dashboard." />
     <link rel="canonical" href="https://agentguard47.com/" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛡️</text></svg>" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://agentguard47.com/" />
-    <meta property="og:title" content="AgentGuard — Runtime Guardrails for AI Agents" />
-    <meta property="og:description" content="Stop runaway AI agents before they drain your budget. Loop detection, budget enforcement, cost tracking. Zero dependencies." />
+    <meta property="og:title" content="AgentGuard — AI Agent Cost Control" />
+    <meta property="og:description" content="Stop runaway AI bills before they happen. Set hard spend limits, catch looping agents, and see cost per run." />
     <meta property="og:image" content="https://opengraph.githubassets.com/1/bmdhodl/agent47" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="AgentGuard — Runtime Guardrails for AI Agents" />
-    <meta name="twitter:description" content="Stop runaway AI agents before they drain your budget. Loop detection, budget enforcement, cost tracking. Zero dependencies." />
+    <meta name="twitter:title" content="AgentGuard — AI Agent Cost Control" />
+    <meta name="twitter:description" content="Stop runaway AI bills before they happen. Set hard spend limits, catch looping agents, and see cost per run." />
     <meta name="twitter:image" content="https://opengraph.githubassets.com/1/bmdhodl/agent47" />
 
     <script defer src="/_vercel/insights/script.js"></script>
@@ -195,9 +195,9 @@
   </head>
   <body>
     <div class="wrap">
-      <span class="badge">Zero Dependencies &middot; OSS SDK + Hosted Dashboard</span>
-      <h1>Your agents are running. Do you know what they're spending?</h1>
-      <p>AgentGuard stops runaway AI agents before they drain your budget. Runtime loop detection, hard dollar caps, and cost tracking per LLM call. Three lines of code. Zero dependencies.</p>
+      <span class="badge">Open Source &middot; Cost Control for AI Agents</span>
+      <h1>Stop runaway AI bills before they happen.</h1>
+      <p>Set hard spend limits, catch looping agents, and see cost per run. Open-source SDK + hosted dashboard.</p>
 
       <div class="cta">
         <a class="btn" href="https://app.agentguard47.com/sign-up">Get Started — it's free</a>
@@ -233,32 +233,20 @@
 
       <div class="grid">
         <div class="card">
-          <strong>Budget enforcement</strong>
-          <p class="muted">Set a dollar limit. Agent stops when it's hit. No more surprise invoices.</p>
+          <strong>Hard budget caps</strong>
+          <p class="muted">Set a dollar limit per project or agent. Runs stop when the cap is hit. No surprise invoices.</p>
         </div>
         <div class="card">
-          <strong>Loop detection</strong>
-          <p class="muted">Catch repeated tool calls before they compound. Automatic circuit breaker.</p>
+          <strong>Loop &amp; runaway detection</strong>
+          <p class="muted">Catch repeated tool calls and stuck agents automatically. Circuit breaker built in.</p>
         </div>
         <div class="card">
-          <strong>Cost tracking</strong>
-          <p class="muted">See exactly what each agent run costs, per call. Dollar amounts, not guesses.</p>
+          <strong>Spend visibility</strong>
+          <p class="muted">See cost per agent run, per model, per day. Know where every dollar goes.</p>
         </div>
         <div class="card">
-          <strong>Zero dependencies</strong>
-          <p class="muted">Pure Python stdlib. One package, nothing to audit. No supply chain risk.</p>
-        </div>
-        <div class="card">
-          <strong>Auto-instrument</strong>
-          <p class="muted">Patch OpenAI/Anthropic in one line. Costs and traces flow automatically.</p>
-        </div>
-        <div class="card">
-          <strong>Replay tests</strong>
-          <p class="muted">Record real runs and replay deterministically for regression tests.</p>
-        </div>
-        <div class="card">
-          <strong>Timeline viewer</strong>
-          <p class="muted">Gantt visualization with color-coded spans and click-to-expand details.</p>
+          <strong>Policy management</strong>
+          <p class="muted">Configure budget caps, loop limits, and timeouts from the dashboard. Push enforcement to your SDK.</p>
         </div>
       </div>
 
@@ -266,18 +254,18 @@
       <div class="steps">
         <div class="step">
           <div class="num">1</div>
-          <p><strong>Install the SDK</strong></p>
-          <p class="muted">pip install agentguard47</p>
+          <p><strong>Create a project</strong></p>
+          <p class="muted">Sign up free. Name your project. Get an ingestion key.</p>
         </div>
         <div class="step">
           <div class="num">2</div>
-          <p><strong>Add 3 lines</strong></p>
-          <p class="muted">Wrap your agent with Tracer and HttpSink</p>
+          <p><strong>Connect the SDK</strong></p>
+          <p class="muted">pip install agentguard47. Add 4 lines. Costs flow automatically.</p>
         </div>
         <div class="step">
           <div class="num">3</div>
-          <p><strong>See traces</strong></p>
-          <p class="muted">Gantt timelines, alerts, and usage in the dashboard</p>
+          <p><strong>Set limits, see spend</strong></p>
+          <p class="muted">Configure budget caps in the dashboard. See every dollar in real time.</p>
         </div>
       </div>
 
@@ -316,34 +304,37 @@ guard = <span class="fn">BudgetGuard</span>(max_cost_usd=<span class="str">5.00<
       <div class="pricing-grid">
         <div class="pricing-card">
           <h3>Free</h3>
+          <p class="muted" style="margin:0 0 4px;font-size:14px">For solo builders</p>
           <div class="price">$0</div>
           <ul>
             <li>10,000 events/month</li>
-            <li>7-day retention</li>
-            <li>2 API keys</li>
-            <li>1 user</li>
+            <li>7-day history</li>
+            <li>See your spend, set basic caps</li>
+            <li>2 API keys &middot; 1 user</li>
           </ul>
           <a class="btn btn-sm secondary" href="https://app.agentguard47.com/sign-up">Start Free</a>
         </div>
         <div class="pricing-card highlight">
           <h3>Pro</h3>
+          <p class="muted" style="margin:0 0 4px;font-size:14px">For production agents</p>
           <div class="price">$39<span style="font-size:16px;font-weight:400">/mo</span></div>
           <ul>
             <li>500,000 events/month</li>
-            <li>30-day retention</li>
-            <li>5 API keys</li>
-            <li>1 user</li>
+            <li>30-day history</li>
+            <li>Full policy management, email alerts</li>
+            <li>5 API keys &middot; 1 user</li>
           </ul>
           <a class="btn btn-sm" href="https://app.agentguard47.com/sign-up">Get Pro</a>
         </div>
         <div class="pricing-card">
           <h3>Team</h3>
+          <p class="muted" style="margin:0 0 4px;font-size:14px">For teams</p>
           <div class="price">$79<span style="font-size:16px;font-weight:400">/mo</span></div>
           <ul>
             <li>5,000,000 events/month</li>
-            <li>90-day retention</li>
-            <li>20 API keys</li>
-            <li>10 users</li>
+            <li>90-day history</li>
+            <li>Multiple projects, shared policies</li>
+            <li>20 API keys &middot; 10 users</li>
           </ul>
           <a class="btn btn-sm secondary" href="https://app.agentguard47.com/sign-up">Get Team</a>
         </div>


### PR DESCRIPTION
## Summary

- Rewrites landing page hero, feature cards (7→4), how-it-works, and pricing tiers to position AgentGuard as a **cost control surface** — not a full observability platform
- Narrows compare page from "vs LangSmith/Langfuse/Portkey observability" to "why AgentGuard for cost control" — trims table to cost-relevant rows only
- Updates NORTHSTAR to include dashboard positioning and explicit non-goals (no full observability, no enterprise governance in V1)

**New hero:** "Stop runaway AI bills before they happen."  
**New feature cards:** Hard budget caps, Loop & runaway detection, Spend visibility, Policy management  
**Cut from hero:** Zero dependencies, Auto-instrument, Replay tests, Timeline viewer (moved to trust section or SDK-only)

## Context

This is Phase 1 of the dashboard pivot plan. Full plan: `.claude/plans/tidy-mixing-teacup.md`

Phases 2-4 (nav pruning, event model alignment, onboarding flow) will happen in the dashboard repo.

## Test plan

- [ ] `site/index.html` renders correctly, all links work
- [ ] `site/compare.html` renders correctly, all links work
- [ ] No broken references to removed feature cards
- [ ] Copy consistently says "cost control" not "observability"
- [ ] `make check` passes (SDK unaffected — 503 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)