### PR TITLE
Refresh stale SDK docs and test hygiene

### DIFF
--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -1,71 +1,64 @@
 # Architecture
 
-## High-level diagram
+## High-level shape
 
-```
-┌─────────────────────────────────────────────────┐
-│                  Your Agent Code                 │
-│  (LangChain / CrewAI / OpenAI / custom)          │
-└──────────────┬──────────────────────────────────┘
-               │
-     ┌─────────▼─────────┐
-     │   AgentGuard SDK   │
-     │                    │
-     │  ┌──────────────┐  │
-     │  │   Tracer      │  │  ← spans, events, cost tracking
-     │  └──────┬───────┘  │
-     │         │          │
-     │  ┌──────▼───────┐  │
-     │  │   Guards      │  │  ← LoopGuard, BudgetGuard, TimeoutGuard, RateLimitGuard
-     │  │  (auto_check) │  │    raise exceptions on violations
-     │  └──────────────┘  │
-     │         │          │
-     │  ┌──────▼───────┐  │
-     │  │    Sinks      │  │  ← where traces go
-     │  │  File│HTTP│OTel│  │
-     │  └──────────────┘  │
-     └────────────────────┘
-               │
-    ┌──────────┼──────────────┐
-    ▼          ▼              ▼
- .jsonl    Dashboard      Grafana/
- files     (HttpSink)     Datadog
-                          (OtelSink)
+AgentGuard has two product surfaces:
+
+1. A zero-dependency Python SDK that enforces runtime guardrails locally.
+2. A hosted dashboard, reached through `HttpSink`, that adds team visibility and control-plane features.
+
+The SDK must stand on its own. It should be usable offline, auditable from source, and credible in production even when the hosted dashboard is not configured.
+
+## Runtime flow
+
+```text
+Your agent code
+  -> Tracer / instrumentation
+  -> Guards evaluate events in-process
+  -> Exceptions stop bad behavior immediately
+  -> Sinks emit traces
+
+Sinks:
+  - JsonlFileSink / StdoutSink for local, offline operation
+  - HttpSink for hosted dashboard ingestion
+  - OtelTraceSink for OpenTelemetry bridges
 ```
 
 ## Module dependency DAG
 
-Core modules form a DAG — no cycles, no reverse dependencies:
+Core modules form a DAG with no reverse dependencies:
 
-```
+```text
 __init__.py (public API surface)
-    ├── setup.py ──→ tracing.py, guards.py, instrument.py, sinks/http.py
-    ├── tracing.py (standalone)
-    ├── guards.py (standalone)
-    ├── instrument.py ──→ guards.py, cost.py
-    ├── atracing.py ──→ tracing.py
-    ├── cost.py (standalone)
-    ├── evaluation.py (standalone)
-    ├── export.py ──→ evaluation.py
-    ├── cli.py ──→ evaluation.py
-    └── sinks/http.py ──→ tracing.py
+  -> setup.py -> tracing.py, guards.py, instrument.py, sinks/http.py
+  -> tracing.py
+  -> guards.py
+  -> instrument.py -> guards.py, cost.py
+  -> atracing.py -> tracing.py
+  -> cost.py
+  -> evaluation.py
+  -> export.py -> evaluation.py
+  -> reporting.py -> evaluation.py
+  -> demo.py -> guards.py, tracing.py
+  -> cli.py -> evaluation.py, reporting.py, demo.py
+  -> sinks/http.py -> tracing.py
 
 Integrations (import core, never the reverse):
-    integrations/langchain.py ──→ guards.py, tracing.py
-    integrations/langgraph.py ──→ guards.py, tracing.py
-    integrations/crewai.py ──→ guards.py, tracing.py
-    sinks/otel.py ──→ tracing.py
+  integrations/langchain.py -> guards.py, tracing.py
+  integrations/langgraph.py -> guards.py, tracing.py
+  integrations/crewai.py -> guards.py, tracing.py
+  sinks/otel.py -> tracing.py
 ```
 
 ## Public API surface
 
-41 exports from `sdk/agentguard/__init__.py`:
+42 exports from `sdk/agentguard/__init__.py`:
 
 | Group | Exports |
 |-------|---------|
 | Tracing | `Tracer`, `TraceSink`, `JsonlFileSink`, `StdoutSink`, `HttpSink`, `summarize_trace` |
-| Guards | `BaseGuard`, `LoopGuard`, `FuzzyLoopGuard`, `BudgetGuard`, `TimeoutGuard`, `RateLimitGuard` |
-| Exceptions | `AgentGuardError`, `LoopDetected`, `BudgetExceeded`, `BudgetWarning`, `TimeoutExceeded` |
+| Guards | `BaseGuard`, `LoopGuard`, `FuzzyLoopGuard`, `BudgetGuard`, `TimeoutGuard`, `RateLimitGuard`, `RetryGuard` |
+| Exceptions | `AgentGuardError`, `LoopDetected`, `BudgetExceeded`, `BudgetWarning`, `TimeoutExceeded`, `RetryLimitExceeded` |
 | Instrumentation | `trace_agent`, `trace_tool`, `patch_openai`, `patch_anthropic`, `unpatch_openai`, `unpatch_anthropic` |
 | Async | `AsyncTracer`, `AsyncTraceContext`, `async_trace_agent`, `async_trace_tool`, `patch_openai_async`, `patch_anthropic_async`, `unpatch_openai_async`, `unpatch_anthropic_async` |
 | Cost | `estimate_cost` |
@@ -73,7 +66,7 @@ Integrations (import core, never the reverse):
 | Setup | `init`, `get_tracer`, `get_budget_guard`, `shutdown` |
 | Meta | `__version__` |
 
-Integration modules (separate imports):
+Integration modules remain separate imports:
 
 | Module | Exports |
 |--------|---------|
@@ -82,14 +75,34 @@ Integration modules (separate imports):
 | `integrations.crewai` | `AgentGuardCrewHandler` |
 | `sinks.otel` | `OtelTraceSink` |
 
+## SDK support modules
+
+These modules improve the local SDK experience without blurring the hosted control-plane boundary:
+
+| Module | Purpose |
+|--------|---------|
+| `reporting.py` | Renders local incident summaries from trace files via `agentguard incident` |
+| `demo.py` | Runs a deterministic offline proof of budget, loop, and retry enforcement via `agentguard demo` |
+
+## Test layout
+
+The SDK test suite is intentionally layered:
+
+- Unit and behavior tests cover guards, tracing, instrumentation, evaluation, export, reporting, and the offline demo.
+- Structural tests in `test_architecture.py` enforce the Golden Principles and import graph invariants.
+- Integration-style tests use the local ingest server in `tests/conftest.py` instead of depending on a hosted dashboard.
+- Production-shaped smoke and DX coverage live in `test_production.py`, `test_dx.py`, and the `e2e_*` files.
+
+Pytest is configured with strict marker and strict config enforcement so stale test configuration fails fast instead of warning.
+
 ## Thread safety
 
-All guards and file sinks use `threading.Lock()` on mutable state. Enforced by `test_architecture.py` (`THREAD_SAFE_CLASSES`).
+All stateful guards and file sinks use `threading.Lock()` on mutable state. This is enforced by `test_architecture.py` through `THREAD_SAFE_CLASSES`.
 
 ## Extension points
 
-- **Custom guard:** Subclass `BaseGuard`, implement `check()` + `auto_check()`.
-- **Custom sink:** Subclass `TraceSink`, implement `emit(event: Dict)`.
-- **Custom integration:** Import core modules, wire to framework callbacks.
+- Custom guard: subclass `BaseGuard`, implement `check()` and `auto_check()`.
+- Custom sink: subclass `TraceSink`, implement `emit(event: Dict[str, Any]) -> None`.
+- Custom integration: import core modules and wire them to framework callbacks.
 
-Full architectural rules: see [`GOLDEN_PRINCIPLES.md`](../GOLDEN_PRINCIPLES.md) (10 rules, all CI-enforced).
+Full architectural rules live in [`GOLDEN_PRINCIPLES.md`](../GOLDEN_PRINCIPLES.md).

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -8,26 +8,30 @@ SDK code changes only. No README, docs, blog, or marketing items.
 |------|--------|
 | Eval assertion expansion | Done - `EvalSuite` now has >=12 built-in assertions |
 | `estimate_cost` pricing refresh | Done - Anthropic and Google pricing refreshed on 2026-03-26; OpenAI entries retained pending direct re-verification from this environment |
+| `RetryGuard` - cap retry attempts per tool | Done - configurable per-tool retry ceilings now raise `RetryLimitExceeded` |
+| Offline demo | Done - `agentguard demo` proves budget, loop, and retry enforcement without API keys or network access |
+| Incident reporting | Done - `agentguard incident` renders local Markdown/HTML summaries from trace files |
 
 ## Now (next 2 weeks)
 
 | Item | Success Signal |
 |------|---------------|
-| `RetryGuard` - cap retry attempts per tool | New guard class, raises `RetryLimitExceeded` after a configurable per-tool retry ceiling |
+| Streaming support in patches | `patch_openai` / `patch_anthropic` capture streamed responses without losing final token and cost totals |
+| Install doctor / quickstart validation | One local command validates the SDK setup path and prints the minimal next step without any dashboard dependency |
 
 ## Next (next month)
 
 | Item | Success Signal |
 |------|---------------|
-| Streaming support in patches | `patch_openai` traces streaming responses with incremental token counts |
 | OpenTelemetry Collector sink improvements | `OtelTraceSink` supports custom resource attributes and span links |
+| `ContentGuard` - detect PII/sensitive data in agent outputs | New guard class, raises `ContentViolation`, regex-based (no deps) |
 
 ## Later (ideas bucket)
 
 | Item | Success Signal |
 |------|---------------|
-| `ContentGuard` - detect PII/sensitive data in agent outputs | New guard class, raises `ContentViolation`, regex-based (no deps) |
 | TypeScript SDK | npm package with parity: LoopGuard, BudgetGuard, TimeoutGuard, Tracer |
 | Cost model alias cleanup | Common provider aliases map cleanly onto canonical model pricing entries without warning spam |
+| Policy bundle import/export | Guard and sink settings can be serialized and applied across environments without a hosted control plane |
 
 Each "Later" item stays here until it earns a "Now" or "Next" slot. Items can be deleted without ceremony.

--- a/ops/04-DEFINITION_OF_DONE.md
+++ b/ops/04-DEFINITION_OF_DONE.md
@@ -2,11 +2,12 @@
 
 ## Every PR
 
-- [ ] `make check` passes (pytest + ruff lint). Coverage >= 80%.
+- [ ] `make check` passes (pytest + ruff lint). Coverage >= 80%. If `make` is unavailable, run the equivalent direct commands.
 - [ ] New functionality has tests.
 - [ ] No new hard dependencies in core SDK. Integration deps guarded by `try/except ImportError`.
 - [ ] `make structural` passes (10 Golden Principles).
 - [ ] `make security` passes (bandit scan).
+- [ ] Test runs are clean - no persistent pytest config warnings.
 - [ ] No hardcoded absolute paths.
 - [ ] If `__init__.py` exports changed, it was intentional.
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -102,5 +102,4 @@ markers = [
     "integration: Tests with servers or external deps",
     "structural: Architectural invariant tests",
 ]
-strict_markers = true
-addopts = "-v --tb=short"
+addopts = "-v --tb=short --strict-markers --strict-config"

--- a/sdk/tests/test_cost.py
+++ b/sdk/tests/test_cost.py
@@ -1,6 +1,6 @@
 import unittest
 
-from agentguard.cost import LAST_UPDATED, CostTracker, estimate_cost
+from agentguard.cost import LAST_UPDATED, CostTracker, UnknownModelWarning, estimate_cost
 
 
 class TestEstimateCost(unittest.TestCase):
@@ -14,7 +14,8 @@ class TestEstimateCost(unittest.TestCase):
         self.assertAlmostEqual(cost, 0.0075, places=6)
 
     def test_unknown_model_returns_zero(self) -> None:
-        cost = estimate_cost("nonexistent-model", input_tokens=1000, output_tokens=500)
+        with self.assertWarns(UnknownModelWarning):
+            cost = estimate_cost("nonexistent-model", input_tokens=1000, output_tokens=500)
         self.assertEqual(cost, 0.0)
 
     def test_anthropic_model(self) -> None:
@@ -37,7 +38,8 @@ class TestEstimateCost(unittest.TestCase):
         self.assertEqual(cost, 0.0)
 
     def test_wrong_provider(self) -> None:
-        cost = estimate_cost("gpt-4o", input_tokens=1000, output_tokens=500, provider="anthropic")
+        with self.assertWarns(UnknownModelWarning):
+            cost = estimate_cost("gpt-4o", input_tokens=1000, output_tokens=500, provider="anthropic")
         self.assertEqual(cost, 0.0)
 
 
@@ -68,7 +70,8 @@ class TestCostTracker(unittest.TestCase):
 
     def test_unknown_model_adds_zero(self) -> None:
         tracker = CostTracker()
-        cost = tracker.add("fake-model", input_tokens=1000, output_tokens=1000)
+        with self.assertWarns(UnknownModelWarning):
+            cost = tracker.add("fake-model", input_tokens=1000, output_tokens=1000)
         self.assertEqual(cost, 0.0)
         self.assertEqual(tracker.total, 0.0)
 

--- a/sdk/tests/test_langchain_integration.py
+++ b/sdk/tests/test_langchain_integration.py
@@ -4,9 +4,10 @@ import tempfile
 import unittest
 import uuid
 
+from agentguard.cost import UnknownModelWarning
 from agentguard.guards import BudgetGuard, LoopDetected, LoopGuard
-from agentguard.tracing import JsonlFileSink, Tracer
 from agentguard.integrations.langchain import AgentGuardCallbackHandler
+from agentguard.tracing import JsonlFileSink, Tracer
 
 
 class TestLangChainIntegration(unittest.TestCase):
@@ -70,7 +71,10 @@ class TestLangChainIntegration(unittest.TestCase):
 
         llm_id = uuid.uuid4()
         handler.on_llm_start({}, ["prompt"], run_id=llm_id)
-        handler.on_llm_end(_MockResponse(tokens=80), run_id=llm_id)
+        handler.on_llm_end(
+            _MockResponseWithModel(model="gpt-4o", input_t=40, output_t=40),
+            run_id=llm_id,
+        )
 
         self.assertEqual(guard.state.tokens_used, 80)
 
@@ -137,10 +141,11 @@ class TestLangChainIntegration(unittest.TestCase):
 
         llm_id = uuid.uuid4()
         handler.on_llm_start({}, ["prompt"], run_id=llm_id)
-        handler.on_llm_end(
-            _MockResponseWithModel(model="totally-fake-model-xyz", input_t=100, output_t=50),
-            run_id=llm_id,
-        )
+        with self.assertWarns(UnknownModelWarning):
+            handler.on_llm_end(
+                _MockResponseWithModel(model="totally-fake-model-xyz", input_t=100, output_t=50),
+                run_id=llm_id,
+            )
         handler.on_chain_end({}, run_id=chain_id)
 
         events = self._read_events()


### PR DESCRIPTION
## Summary
- refresh stale SDK ops docs so the roadmap, architecture, and done criteria match the current codebase
- make pytest config strict via real CLI flags and document the direct-command fallback when `make` is unavailable
- tighten warning-producing tests so the suite finishes cleanly instead of emitting avoidable warning noise

## Why
The roadmap and architecture docs had drifted behind recent SDK work, and the test suite still carried stale pytest config plus warning-summary noise. This maintenance pass brings the docs back in sync and makes the test signal cleaner.

## Validation
- `python -m ruff check sdk/agentguard/`
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`
- `python -m pytest sdk/tests/test_architecture.py -v`
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`

## Proof
- full suite now ends cleanly at `541 passed` with no pytest config warning and no warning summary
- docs reflect shipped features including RetryGuard, incident reporting, and the offline demo