### PR TITLE
Add repo-local SDK config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ agentguard quickstart --framework langgraph --json
 install command, the smallest credible starter file, and the next commands to
 run after you validate the SDK locally.
 
+## Optional repo-local defaults
+
+If you want humans and coding agents to share the same local defaults, add a
+tiny `.agentguard.json` file to the repo:
+
+```json
+{
+  "service": "support-agent",
+  "trace_file": ".agentguard/traces.jsonl",
+  "budget_usd": 5.0
+}
+```
+
+`agentguard.init()` and `agentguard doctor` will pick this up automatically.
+Keep it local and static: no secrets, no API keys, no dashboard settings.
+
 ## Try it in 60 seconds
 
 No API keys. No dashboard. No network calls. Just run it:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -46,6 +46,32 @@ This is intentionally high-signal:
 It gives you the install command, the starter file contents, and the next
 commands to run.
 
+## Optional repo-local defaults
+
+If you want a repo to carry safe local defaults, create `.agentguard.json`:
+
+```json
+{
+  "service": "support-agent",
+  "trace_file": ".agentguard/traces.jsonl",
+  "budget_usd": 5.0
+}
+```
+
+This stays intentionally narrow:
+- safe local defaults only
+- no secrets
+- no API keys
+- no hosted control-plane behavior
+
+After that, `agentguard.init()` can stay minimal:
+
+```python
+import agentguard
+
+agentguard.init()
+```
+
 ## Offline demo
 
 Before wiring a real agent, prove the SDK locally:

--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -30,7 +30,7 @@ Core modules form a DAG with no reverse dependencies:
 
 ```text
 __init__.py (public API surface)
-  -> setup.py -> tracing.py, guards.py, instrument.py, sinks/http.py
+  -> setup.py -> repo_config.py, tracing.py, guards.py, instrument.py, sinks/http.py
   -> tracing.py
   -> guards.py
   -> instrument.py -> guards.py, cost.py
@@ -40,8 +40,9 @@ __init__.py (public API surface)
   -> export.py -> evaluation.py
   -> reporting.py -> evaluation.py
   -> demo.py -> guards.py, tracing.py
-  -> doctor.py -> evaluation.py, setup.py
+  -> doctor.py -> evaluation.py, repo_config.py, setup.py
   -> quickstart.py
+  -> repo_config.py
   -> cli.py -> evaluation.py, reporting.py, demo.py, doctor.py, quickstart.py
   -> sinks/http.py -> tracing.py
 
@@ -87,6 +88,7 @@ These modules improve the local SDK experience without blurring the hosted contr
 | `demo.py` | Runs a deterministic offline proof of budget, loop, and retry enforcement via `agentguard demo` |
 | `doctor.py` | Verifies the local SDK install path and prints the minimal local-only onboarding snippet via `agentguard doctor` |
 | `quickstart.py` | Prints framework-specific starter snippets for raw, OpenAI, Anthropic, LangChain, LangGraph, and CrewAI via `agentguard quickstart` |
+| `repo_config.py` | Loads the nearest repo-local `.agentguard.json` file so local defaults stay static, auditable, and dashboard-free |
 
 ## Test layout
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -31,6 +31,22 @@ agentguard quickstart --framework langchain --json
 Use this when you already know the stack you want to wire. It prints the
 install command, a minimal starter file, and the next verification commands.
 
+## Optional repo-local defaults
+
+Use `.agentguard.json` when you want a repo-local, auditable config that both
+humans and coding agents can share:
+
+```json
+{
+  "service": "support-agent",
+  "trace_file": ".agentguard/traces.jsonl",
+  "budget_usd": 5.0
+}
+```
+
+`agentguard.init()` and `agentguard doctor` read this automatically. Keep it
+strictly local: no secrets, no API keys, no hosted dashboard settings.
+
 ## Quickstart
 
 ```python

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any, Dict, List, Optional, TextIO, Tuple
 
 from agentguard.evaluation import _load_events
+from agentguard.repo_config import load_repo_config
 from agentguard.setup import get_tracer, init, shutdown
 
 _OPTIONAL_MODULES: Tuple[Tuple[str, str, str], ...] = (
@@ -74,6 +75,7 @@ def _run_checks(trace_path: str) -> Dict[str, Any]:
             "agentguard doctor must run before agentguard.init() or in a separate process."
         )
 
+    repo_config_path, repo_config = load_repo_config()
     detected, hints = _detect_optional_integrations()
     normalized_path = _prepare_trace_path(trace_path)
     events_written = _verify_local_init(normalized_path)
@@ -84,13 +86,15 @@ def _run_checks(trace_path: str) -> Dict[str, Any]:
         "package_version": _package_version(),
         "trace_file": normalized_path,
         "events_written": events_written,
+        "repo_config_path": repo_config_path,
+        "repo_config": repo_config,
         "detected_integrations": detected,
         "integration_hints": hints,
         "next_commands": [
             "agentguard demo",
             f"agentguard report {normalized_path}",
         ],
-        "recommended_snippet": _recommended_snippet(),
+        "recommended_snippet": _recommended_snippet(repo_config_path is not None),
     }
 
 
@@ -164,7 +168,16 @@ def _package_version() -> str:
         return "0.0.0-dev"
 
 
-def _recommended_snippet() -> str:
+def _recommended_snippet(repo_config_present: bool = False) -> str:
+    if repo_config_present:
+        return "\n".join(
+            [
+                "import agentguard",
+                "",
+                "agentguard.init()",
+            ]
+        )
+
     return "\n".join(
         [
             "import agentguard",
@@ -181,6 +194,8 @@ def _recommended_snippet() -> str:
 def _render_text(result: Dict[str, Any], out: TextIO) -> None:
     detected = result["detected_integrations"]
     hints = result["integration_hints"]
+    repo_config_path = result["repo_config_path"]
+    repo_config = result["repo_config"]
 
     _print(out, "AgentGuard doctor")
     _print(out, "No dashboard. No network calls. Local verification only.")
@@ -191,6 +206,11 @@ def _render_text(result: Dict[str, Any], out: TextIO) -> None:
         out,
         f"[ok] init(local_only=True): wrote {result['events_written']} events to {result['trace_file']}",
     )
+    if repo_config_path:
+        _print(out, f"[ok] Repo config: {repo_config_path}")
+        if repo_config:
+            config_bits = [f"{key}={value}" for key, value in repo_config.items()]
+            _print(out, f"     {' '.join(config_bits)}")
     if detected:
         _print(out, f"[ok] Optional integrations detected: {', '.join(detected)}")
     else:

--- a/sdk/agentguard/repo_config.py
+++ b/sdk/agentguard/repo_config.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+CONFIG_FILE_NAME = ".agentguard.json"
+
+
+def find_repo_config(start_path: Optional[str] = None) -> Optional[str]:
+    """Find the nearest repo-local AgentGuard config file."""
+    current = Path(start_path or os.getcwd()).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for directory in (current, *current.parents):
+        candidate = directory / CONFIG_FILE_NAME
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def load_repo_config(start_path: Optional[str] = None) -> Tuple[Optional[str], Dict[str, Any]]:
+    """Load supported AgentGuard defaults from the nearest repo config file."""
+    config_path = find_repo_config(start_path)
+    if not config_path:
+        return None, {}
+
+    with open(config_path, encoding="utf-8") as handle:
+        raw = json.load(handle)
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"{CONFIG_FILE_NAME} must contain a JSON object")
+
+    config_dir = os.path.dirname(config_path)
+    parsed: Dict[str, Any] = {}
+
+    service = raw.get("service")
+    if service is not None:
+        if not isinstance(service, str) or not service.strip():
+            raise ValueError("service in .agentguard.json must be a non-empty string")
+        parsed["service"] = service.strip()
+
+    trace_file = raw.get("trace_file")
+    if trace_file is not None:
+        if not isinstance(trace_file, str) or not trace_file.strip():
+            raise ValueError("trace_file in .agentguard.json must be a non-empty string")
+        normalized_trace = trace_file.strip()
+        if not os.path.isabs(normalized_trace):
+            normalized_trace = os.path.normpath(os.path.join(config_dir, normalized_trace))
+        parsed["trace_file"] = normalized_trace
+
+    budget_usd = raw.get("budget_usd")
+    if budget_usd is not None:
+        if not isinstance(budget_usd, (int, float)) or budget_usd < 0:
+            raise ValueError("budget_usd in .agentguard.json must be a non-negative number")
+        parsed["budget_usd"] = float(budget_usd)
+
+    return config_path, parsed

--- a/sdk/agentguard/setup.py
+++ b/sdk/agentguard/setup.py
@@ -98,10 +98,14 @@ def init(
             "(possible HTTP header injection)"
         )
 
-    # --- Resolve config: kwargs > env vars > defaults ---
+    from agentguard.repo_config import load_repo_config
+
+    _, repo_config = load_repo_config()
+
+    # --- Resolve config: kwargs > env vars > repo config > defaults ---
     resolved_key = None if local_only else (api_key or os.environ.get("AGENTGUARD_API_KEY"))
-    resolved_service = service or os.environ.get("AGENTGUARD_SERVICE", "default")
-    resolved_file = trace_file or os.environ.get("AGENTGUARD_TRACE_FILE", "traces.jsonl")
+    resolved_service = service or os.environ.get("AGENTGUARD_SERVICE") or repo_config.get("service") or "default"
+    resolved_file = trace_file or os.environ.get("AGENTGUARD_TRACE_FILE") or repo_config.get("trace_file") or "traces.jsonl"
 
     resolved_budget: Optional[float] = budget_usd
     if resolved_budget is None:
@@ -113,6 +117,8 @@ def init(
                 logger.warning(
                     "Invalid AGENTGUARD_BUDGET_USD=%r, ignoring", env_budget
                 )
+        elif "budget_usd" in repo_config:
+            resolved_budget = float(repo_config["budget_usd"])
 
     # --- Build sink ---
     if resolved_key:

--- a/sdk/tests/test_architecture.py
+++ b/sdk/tests/test_architecture.py
@@ -35,6 +35,7 @@ CORE_MODULES = [
     "guards.py",
     "instrument.py",
     "quickstart.py",
+    "repo_config.py",
     "setup.py",
     "tracing.py",
     "sinks/http.py",

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -81,6 +81,33 @@ class TestDoctor(unittest.TestCase):
             self.assertTrue(os.path.exists(trace_path))
             self.assertIn("AgentGuard doctor", buf.getvalue())
 
+    def test_run_doctor_reports_repo_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trace_path = os.path.join(tmpdir, "doctor.jsonl")
+            config_path = os.path.join(tmpdir, ".agentguard.json")
+            with open(config_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "service": "repo-agent",
+                        "trace_file": ".agentguard/traces.jsonl",
+                        "budget_usd": 7.5,
+                    },
+                    handle,
+                )
+
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                buf = io.StringIO()
+                result = run_doctor(trace_path=trace_path, stream=buf, json_output=True)
+            finally:
+                os.chdir(old_cwd)
+
+            self.assertEqual(result, 0)
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload["repo_config"]["service"], "repo-agent")
+            self.assertEqual(payload["recommended_snippet"], "import agentguard\n\nagentguard.init()")
+
     def test_run_doctor_fails_without_tearing_down_existing_tracer(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             live_trace = os.path.join(tmpdir, "live.jsonl")

--- a/sdk/tests/test_init.py
+++ b/sdk/tests/test_init.py
@@ -1,6 +1,7 @@
 """Tests for agentguard.init() one-liner setup."""
 from __future__ import annotations
 
+import json
 import os
 import sys
 import tempfile
@@ -101,6 +102,59 @@ class TestInitEnvVars:
         with patch.dict(os.environ, {"AGENTGUARD_SERVICE": "env-svc"}):
             tracer = agentguard.init(service="kwarg-svc", auto_patch=False)
             assert tracer._service == "kwarg-svc"
+
+    def test_repo_config_applies_when_kwargs_and_env_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".agentguard.json")
+            trace_path = os.path.join(tmpdir, ".agentguard", "traces.jsonl")
+            with open(config_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "service": "repo-svc",
+                        "trace_file": ".agentguard/traces.jsonl",
+                        "budget_usd": 7.5,
+                    },
+                    handle,
+                )
+
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                tracer = agentguard.init(auto_patch=False)
+                assert tracer._service == "repo-svc"
+                assert tracer._sink._path == trace_path
+                assert agentguard.get_budget_guard()._max_cost_usd == 7.5
+            finally:
+                os.chdir(old_cwd)
+
+    def test_env_overrides_repo_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".agentguard.json")
+            with open(config_path, "w", encoding="utf-8") as handle:
+                json.dump({"service": "repo-svc"}, handle)
+
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                with patch.dict(os.environ, {"AGENTGUARD_SERVICE": "env-svc"}):
+                    tracer = agentguard.init(auto_patch=False)
+                assert tracer._service == "env-svc"
+            finally:
+                os.chdir(old_cwd)
+
+    def test_kwargs_override_repo_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".agentguard.json")
+            with open(config_path, "w", encoding="utf-8") as handle:
+                json.dump({"service": "repo-svc"}, handle)
+
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                tracer = agentguard.init(service="kwarg-svc", auto_patch=False)
+                assert tracer._service == "kwarg-svc"
+            finally:
+                os.chdir(old_cwd)
 
     def test_local_only_ignores_api_key_env(self):
         with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:

--- a/sdk/tests/test_repo_config.py
+++ b/sdk/tests/test_repo_config.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from agentguard.repo_config import find_repo_config, load_repo_config
+
+
+def test_find_repo_config_walks_upward() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, ".agentguard.json")
+        nested_dir = os.path.join(tmpdir, "src", "agent")
+        os.makedirs(nested_dir, exist_ok=True)
+        with open(config_path, "w", encoding="utf-8") as handle:
+            json.dump({"service": "repo-agent"}, handle)
+
+        found = find_repo_config(nested_dir)
+
+        assert found == config_path
+
+
+def test_load_repo_config_resolves_relative_trace_path() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, ".agentguard.json")
+        with open(config_path, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "service": "repo-agent",
+                    "trace_file": ".agentguard/traces.jsonl",
+                    "budget_usd": 3.25,
+                },
+                handle,
+            )
+
+        path, config = load_repo_config(tmpdir)
+
+        assert path == config_path
+        assert config["service"] == "repo-agent"
+        assert config["trace_file"] == os.path.join(
+            tmpdir,
+            ".agentguard",
+            "traces.jsonl",
+        )
+        assert config["budget_usd"] == 3.25
+
+
+def test_load_repo_config_ignores_unknown_keys() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, ".agentguard.json")
+        with open(config_path, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "service": "repo-agent",
+                    "api_key": "ag_not_allowed",
+                    "dashboard_url": "https://example.com",
+                },
+                handle,
+            )
+
+        _, config = load_repo_config(tmpdir)
+
+        assert config == {"service": "repo-agent"}
+
+
+def test_load_repo_config_rejects_invalid_service() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, ".agentguard.json")
+        with open(config_path, "w", encoding="utf-8") as handle:
+            json.dump({"service": ""}, handle)
+
+        with pytest.raises(ValueError, match="service"):
+            load_repo_config(tmpdir)
+
+
+def test_load_repo_config_rejects_invalid_top_level_shape() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, ".agentguard.json")
+        with open(config_path, "w", encoding="utf-8") as handle:
+            json.dump(["not", "an", "object"], handle)
+
+        with pytest.raises(ValueError, match="JSON object"):
+            load_repo_config(tmpdir)


### PR DESCRIPTION
## Summary
- add stdlib-only `.agentguard.json` support for safe repo-local SDK defaults
- let `agentguard.init()` and `agentguard doctor` read the nearest repo config without introducing dashboard coupling
- document the boundary clearly: local defaults only, no secrets, no API keys, no hosted control-plane behavior

## Proof
- full local suite passed: `564 passed`, coverage `93.60%`
- structural tests passed
- bandit passed
- real local proof repo written under `.codex-proof/repo-config/`
- proof artifacts:
  - `.codex-proof/repo-config/doctor.json`
  - `.codex-proof/repo-config/agent-run.json`
  - `.codex-proof/repo-config/repo/.agentguard/traces.jsonl`
  - `.codex-proof/repo-config-pytest-full.txt`
  - `.codex-proof/repo-config-structural.txt`
  - `.codex-proof/repo-config-ruff.txt`
  - `.codex-proof/repo-config-bandit.txt`

## Notes
- this PR is intentionally stacked on #274 because the branch split happened after `codex/quickstart` was already in flight