### PR TITLE
Add executable framework starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ agentguard quickstart --framework langgraph --json
 install command, the smallest credible starter file, and the next commands to
 run after you validate the SDK locally.
 
+Prefer a real file over printed output? Matching starter files live in
+`examples/starters/`, including:
+- `examples/starters/agentguard_raw_quickstart.py`
+- `examples/starters/agentguard_openai_quickstart.py`
+- `examples/starters/agentguard_langgraph_quickstart.py`
+
 ## Try it in 60 seconds
 
 No API keys. No dashboard. No network calls. Just run it:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -46,6 +46,9 @@ This is intentionally high-signal:
 It gives you the install command, the starter file contents, and the next
 commands to run.
 
+If you want a ready-made file instead of printed output, use the matching files
+under `examples/starters/`.
+
 ## Offline demo
 
 Before wiring a real agent, prove the SDK locally:

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,19 @@
 
 Working examples showing AgentGuard integrated with popular AI agent frameworks.
 
+## Start Here
+
+If you want the smallest runnable file for a given stack, start in
+[`examples/starters/`](./starters):
+
+```bash
+python examples/starters/agentguard_raw_quickstart.py
+python examples/starters/agentguard_langgraph_quickstart.py
+```
+
+These starter files match the output from `agentguard quickstart` and are meant
+for first-run onboarding by both humans and coding agents.
+
 ## Examples
 
 | File | Framework | What it shows |
@@ -17,6 +30,7 @@ Working examples showing AgentGuard integrated with popular AI agent frameworks.
 pip install agentguard47
 agentguard doctor
 agentguard quickstart --framework raw
+python examples/starters/agentguard_raw_quickstart.py
 
 # Then print the starter for your real stack
 agentguard quickstart --framework openai

--- a/examples/starters/README.md
+++ b/examples/starters/README.md
@@ -1,0 +1,31 @@
+# Starter Files
+
+These are the executable counterparts to `agentguard quickstart`.
+
+Each file is intentionally small:
+- one supported stack
+- one obvious install command
+- one obvious run command
+- local traces by default
+
+## Files
+
+| File | Stack | Local-first behavior |
+|------|-------|----------------------|
+| `agentguard_raw_quickstart.py` | Raw Python | Fully offline. No API keys or network calls. |
+| `agentguard_openai_quickstart.py` | OpenAI | Local traces via `local_only=True`; OpenAI call still uses `OPENAI_API_KEY`. |
+| `agentguard_anthropic_quickstart.py` | Anthropic | Local traces via `local_only=True`; Anthropic call still uses `ANTHROPIC_API_KEY`. |
+| `agentguard_langchain_quickstart.py` | LangChain | Explicit callback wiring with local traces. |
+| `agentguard_langgraph_quickstart.py` | LangGraph | Fully local graph example with node guards. |
+| `agentguard_crewai_quickstart.py` | CrewAI | Explicit callback wiring with local traces. |
+
+## Suggested flow
+
+```bash
+pip install agentguard47
+agentguard doctor
+python examples/starters/agentguard_raw_quickstart.py
+agentguard report traces.jsonl
+```
+
+Then move to the file that matches your real stack.

--- a/examples/starters/agentguard_anthropic_quickstart.py
+++ b/examples/starters/agentguard_anthropic_quickstart.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+
+import agentguard
+
+
+def main() -> None:
+    try:
+        from anthropic import Anthropic
+    except ImportError as exc:
+        raise SystemExit("Install with: pip install agentguard47 anthropic") from exc
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("Set ANTHROPIC_API_KEY before running this starter.")
+
+    agentguard.init(
+        service="my-agent",
+        budget_usd=5.00,
+        trace_file="traces.jsonl",
+        local_only=True,
+    )
+
+    try:
+        client = Anthropic()
+        response = client.messages.create(
+            model="claude-3-5-sonnet-20241022",
+            max_tokens=128,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Give me a one-line summary of AgentGuard.",
+                }
+            ],
+        )
+        print(response.content[0].text)
+    finally:
+        agentguard.shutdown()
+
+    print("Traces saved to traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/agentguard_crewai_quickstart.py
+++ b/examples/starters/agentguard_crewai_quickstart.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+
+from agentguard import BudgetGuard, JsonlFileSink, LoopGuard, Tracer
+from agentguard.integrations.crewai import AgentGuardCrewHandler
+
+
+def main() -> None:
+    try:
+        from crewai import Agent, Crew, Task
+    except ImportError as exc:
+        raise SystemExit(
+            "Install with: pip install agentguard47[crewai] crewai"
+        ) from exc
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("Set OPENAI_API_KEY before running this starter.")
+
+    tracer = Tracer(
+        sink=JsonlFileSink("traces.jsonl"),
+        service="my-agent",
+    )
+    loop_guard = LoopGuard(max_repeats=3, window=6)
+    budget_guard = BudgetGuard(max_cost_usd=5.00, max_calls=20)
+    handler = AgentGuardCrewHandler(
+        tracer=tracer,
+        loop_guard=loop_guard,
+        budget_guard=budget_guard,
+    )
+
+    agent = Agent(
+        role="researcher",
+        goal="Answer one short question clearly.",
+        backstory="You are concise and careful.",
+        llm="gpt-4o-mini",
+        step_callback=handler.step_callback,
+        verbose=True,
+    )
+    task = Task(
+        description="Explain what AgentGuard does in one short paragraph.",
+        agent=agent,
+        callback=handler.task_callback,
+    )
+
+    result = Crew(agents=[agent], tasks=[task], verbose=True).kickoff()
+    print(result)
+    print("Traces saved to traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/agentguard_langchain_quickstart.py
+++ b/examples/starters/agentguard_langchain_quickstart.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+
+from agentguard import BudgetGuard, JsonlFileSink, LoopGuard, Tracer
+from agentguard.integrations.langchain import AgentGuardCallbackHandler
+
+
+def main() -> None:
+    try:
+        from langchain_openai import ChatOpenAI
+    except ImportError as exc:
+        raise SystemExit(
+            "Install with: pip install agentguard47[langchain] langchain langchain-openai"
+        ) from exc
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("Set OPENAI_API_KEY before running this starter.")
+
+    tracer = Tracer(
+        sink=JsonlFileSink("traces.jsonl"),
+        service="my-agent",
+    )
+    loop_guard = LoopGuard(max_repeats=3, window=6)
+    budget_guard = BudgetGuard(max_cost_usd=5.00, max_calls=20)
+    handler = AgentGuardCallbackHandler(
+        tracer=tracer,
+        loop_guard=loop_guard,
+        budget_guard=budget_guard,
+    )
+
+    response = ChatOpenAI(model="gpt-4o-mini", temperature=0).invoke(
+        "Give me a one-line summary of AgentGuard.",
+        config={"callbacks": [handler]},
+    )
+    print(response.content)
+    print("Traces saved to traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/agentguard_langgraph_quickstart.py
+++ b/examples/starters/agentguard_langgraph_quickstart.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from agentguard import BudgetGuard, JsonlFileSink, LoopGuard, Tracer
+from agentguard.integrations.langgraph import guard_node
+
+
+def main() -> None:
+    try:
+        from langgraph.graph import END, START, StateGraph
+    except ImportError as exc:
+        raise SystemExit(
+            "Install with: pip install agentguard47[langgraph] langgraph"
+        ) from exc
+
+    tracer = Tracer(
+        sink=JsonlFileSink("traces.jsonl"),
+        service="my-agent",
+    )
+    loop_guard = LoopGuard(max_repeats=3, window=6)
+    budget_guard = BudgetGuard(max_cost_usd=5.00, max_calls=20)
+
+    def research_node(state: dict) -> dict:
+        question = state["question"]
+        return {"question": question, "answer": f"local answer for {question}"}
+
+    builder = StateGraph(dict)
+    builder.add_node(
+        "research",
+        guard_node(
+            research_node,
+            tracer=tracer,
+            loop_guard=loop_guard,
+            budget_guard=budget_guard,
+        ),
+    )
+    builder.add_edge(START, "research")
+    builder.add_edge("research", END)
+
+    graph = builder.compile()
+    result = graph.invoke({"question": "What is AgentGuard?"})
+    print(result["answer"])
+    print("Traces saved to traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/agentguard_openai_quickstart.py
+++ b/examples/starters/agentguard_openai_quickstart.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+
+import agentguard
+
+
+def main() -> None:
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise SystemExit("Install with: pip install agentguard47 openai") from exc
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("Set OPENAI_API_KEY before running this starter.")
+
+    agentguard.init(
+        service="my-agent",
+        budget_usd=5.00,
+        trace_file="traces.jsonl",
+        local_only=True,
+    )
+
+    try:
+        client = OpenAI()
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Give me a one-line summary of AgentGuard.",
+                }
+            ],
+        )
+        print(response.choices[0].message.content)
+    finally:
+        agentguard.shutdown()
+
+    print("Traces saved to traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/agentguard_raw_quickstart.py
+++ b/examples/starters/agentguard_raw_quickstart.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import agentguard
+
+
+def main() -> None:
+    tracer = agentguard.init(
+        service="my-agent",
+        budget_usd=5.00,
+        trace_file="traces.jsonl",
+        local_only=True,
+        auto_patch=False,
+    )
+
+    @agentguard.trace_tool(tracer)
+    def search_docs(query: str) -> str:
+        return f"results for {query}"
+
+    try:
+        with tracer.trace("agent.run") as span:
+            result = search_docs("agentguard starter")
+            span.event("agent.answer", data={"result": result})
+    finally:
+        agentguard.shutdown()
+
+    print("Completed local raw starter run.")
+    print("Traces saved to traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -12,6 +12,7 @@ SDK code changes only. No README, docs, blog, or marketing items.
 | Offline demo | Done - `agentguard demo` proves budget, loop, and retry enforcement without API keys or network access |
 | Incident reporting | Done - `agentguard incident` renders local Markdown/HTML summaries from trace files |
 | Install doctor / local validation | Done - `agentguard doctor` verifies the local SDK setup path without network or dashboard access |
+| Executable framework starters | Done - matching starter files now live under `examples/starters/` for raw, OpenAI, Anthropic, LangChain, LangGraph, and CrewAI |
 
 ## Now (next 2 weeks)
 
@@ -19,7 +20,6 @@ SDK code changes only. No README, docs, blog, or marketing items.
 |------|---------------|
 | Framework quickstart generator | `agentguard quickstart --framework <stack>` prints the smallest credible starter snippet for raw, OpenAI, Anthropic, LangChain, LangGraph, and CrewAI |
 | Repo-local `.agentguard.json` manifest | Agents and humans can declare local SDK defaults in a tiny static config file without dashboard coupling |
-| Executable framework starters | Each supported stack has a minimal runnable example that proves the integration path with AgentGuard |
 
 ## Next (next month)
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -31,6 +31,8 @@ agentguard quickstart --framework langchain --json
 Use this when you already know the stack you want to wire. It prints the
 install command, a minimal starter file, and the next verification commands.
 
+If you want the same content as an actual file, see `examples/starters/`.
+
 ## Quickstart
 
 ```python

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from agentguard.quickstart import FRAMEWORK_CHOICES, _build_quickstart_payload
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STARTERS_ROOT = REPO_ROOT / "examples" / "starters"
+
+
+def test_quickstart_payloads_have_matching_starter_files() -> None:
+    for framework in FRAMEWORK_CHOICES:
+        payload = _build_quickstart_payload(
+            framework=framework,
+            service="my-agent",
+            budget_usd=5.0,
+            trace_file="traces.jsonl",
+        )
+        starter_path = STARTERS_ROOT / payload["filename"]
+        assert starter_path.exists(), f"Missing starter file for {framework}: {starter_path}"
+        compile(starter_path.read_text(encoding="utf-8"), str(starter_path), "exec")
+
+
+def test_raw_starter_runs_and_writes_trace() -> None:
+    starter_path = STARTERS_ROOT / "agentguard_raw_quickstart.py"
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    sdk_path = str(REPO_ROOT / "sdk")
+    env["PYTHONPATH"] = (
+        sdk_path
+        if not existing_pythonpath
+        else os.pathsep.join([sdk_path, existing_pythonpath])
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [sys.executable, str(starter_path)],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "Completed local raw starter run." in result.stdout
+        assert Path(tmpdir, "traces.jsonl").exists()


### PR DESCRIPTION
## Summary
- add runnable starter files under `examples/starters/` for raw, OpenAI, Anthropic, LangChain, LangGraph, and CrewAI
- keep the files small and auditable, with clear install/env failure messages instead of surprise import errors
- connect the examples back to `agentguard quickstart` and update docs/roadmap pointers

## Proof
- full local suite passed: `557 passed`, coverage `93.92%`
- structural tests passed
- bandit passed
- raw starter subprocess proof bundle:
  - `.codex-proof/framework-starters/raw-starter-run.json`
  - `.codex-proof/framework-starters/raw-run/traces.jsonl`
- full validation artifacts:
  - `.codex-proof/framework-starters-pytest-full.txt`
  - `.codex-proof/framework-starters-structural.txt`
  - `.codex-proof/framework-starters-ruff.txt`
  - `.codex-proof/framework-starters-bandit.txt`
- visible desktop proof screenshot:
  - `.codex-proof/framework-starters-visible.png`

## Notes
- this PR is intentionally stacked on #274 because the starter filenames are the executable counterparts to the quickstart generator output