### PR TITLE
Release prep for v1.2.3

### DIFF
--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -31,87 +31,23 @@ Project ID: `PVT_kwHOALAnAM4BOnP3`
 | Dashboard Dev | Dashboard + API | Issues in agent47-dashboard |
 | Marketing | Docs, README, outreach | `component:infra` (docs subset) |
 
-## Current Focus: Strategic Execution Plan (3-Phase)
+## Current Focus
 
-**Goal:** 0 to $5K MRR in 90 days. Solo dev, self-serve, passive revenue.
+Latest shipped SDK release: `v1.2.2`.
 
-**Tracks:** R = Revenue, G = Growth, P = Production, S = Security
+Source of truth for planning:
+- `ops/00-NORTHSTAR.md`
+- `ops/03-ROADMAP_NOW_NEXT_LATER.md`
+- `ops/04-DEFINITION_OF_DONE.md`
+- the GitHub project board
 
-### Phase 1: Foundation (Weeks 1-3) — Ship, secure, launch
+Current emphasis is release hardening and cleanup:
+- keep SDK and dashboard boundaries sharp
+- prioritize release blockers, documentation drift, and security findings
+- ticket non-blocking findings instead of letting them float
 
-**Critical path:** T01 → T02 → T07 → T08 → **LAUNCH (Show HN)**
+Do not rely on historical phase tables when they conflict with the current ops docs.
 
-| Ticket | Title | Track | Repo | Priority |
-|--------|-------|-------|------|----------|
-| T01 | Publish v1.2.1 GitHub Release | G | SDK | Critical |
-| T02 | README rewrite: cost guardrail hero (SDK #139) | G | SDK | Critical |
-| T07 | 30-second demo GIF | G | SDK | Critical |
-| T08 | Show HN post draft + launch prep | G | SDK | Critical |
-| T03 | Zod validation on 7 POST routes (Dash #45) | S | Dashboard | High |
-| T04 | Split queries.ts (Dash #44) | P | Dashboard | High |
-| T05 | Move SQL from 8 routes (Dash #46) | S | Dashboard | High |
-| T06 | CSP header + Sentry monitoring | P | Dashboard | High |
-| T09 | Welcome email drip (3 emails) | R | Dashboard | High |
-| T10 | Audit logging foundation | S | Dashboard | High |
-| T11 | CLAUDE.md + agent file updates | P | Both | High |
-
-### Phase 2: Traction (Weeks 4-6) — First 10 paying users
-
-| Ticket | Title | Track | Repo |
-|--------|-------|-------|------|
-| T12 | Weekly digest email | R | Dashboard |
-| T13 | Upgrade nudges at 70% usage | R | Dashboard |
-| T14 | Annual pricing ($390/$790) | R | Dashboard |
-| T15 | SEO blog posts (3 posts) | G | SDK |
-| T16 | API key expiration + rotation | S | Dashboard |
-| T17 | RBAC lite (admin/member/viewer) | S | Dashboard |
-| T18 | LangChain community engagement | G | SDK |
-| T19 | GitHub Discussions + templates | G | SDK |
-| T20 | SDK examples expansion (3 examples) | G | SDK |
-
-### Phase 3: Scale (Weeks 7-12) — Revenue machine
-
-| Ticket | Title | Track | Repo |
-|--------|-------|-------|------|
-| T21 | Usage-based billing ($0.50/10K overage) | R | Dashboard |
-| T22 | Redis rate limiting (Upstash) | P | Dashboard |
-| T23 | Per-team rate limits (plan-based) | S | Dashboard |
-| T24 | Uptime monitoring + status page | P | Dashboard |
-| T25 | Incident playbook + cron monitoring | P | Dashboard |
-| T26 | SDK virality watermark | G | SDK |
-| T27 | Secrets rotation docs | S | Dashboard |
-| T28 | DB backup verification + DR test | P | Dashboard |
-
-### Dependency Graph
-
-```
-PHASE 1 CRITICAL PATH:
-T01 (PyPI) → T02 (README) → T07 (GIF) → T08 (Show HN) → LAUNCH
-
-PHASE 1 SECURITY PATH:
-T03 (Zod) → T09 (Email drip)
-T04 (queries split) → T05 (SQL to queries) → T10 (Audit log)
-T06 (CSP + Sentry)
-
-PHASE 2:
-T09 → T12 (Weekly digest)
-T03 → T14 (Annual pricing)
-T05, T10 → T17 (RBAC)
-T08 → T18 (Community)
-
-PHASE 3:
-T14, T13 → T21 (Usage billing)
-T22 (Redis) → T23 (Per-team limits)
-T24 (Uptime) → T25 (Incident playbook)
-```
-
-### Phase Verification
-
-**Phase 1 done when:** README hero is cost guardrail, demo GIF embedded, Show HN drafted, `make structural` zero exemptions (both repos), Sentry receiving, audit log recording, email drip firing.
-
-**Phase 2 done when:** 10+ free signups, 1+ Stripe subscription, weekly digest sending, 3 blog posts indexed, API key expiration working, RBAC restricting actions.
-
-**Phase 3 done when:** Usage billing live, Redis rate limiting in prod, status page public, $5K MRR or clear pivot data.
 
 ### Labels
 

--- a/.claude/agents/sdk-dev.md
+++ b/.claude/agents/sdk-dev.md
@@ -16,34 +16,22 @@ https://github.com/users/bmdhodl/projects/4
 gh issue list --repo bmdhodl/agent47 --label component:sdk --state open --limit 50
 ```
 
-## Current Focus: Strategic Execution Plan — Phase 1
+## Current Focus
 
-v1.2.1 is shipped. The active work is the 3-phase strategic plan to get to $5K MRR.
+Latest shipped SDK release: `v1.2.2`.
 
-### Phase 1 SDK Tickets (current)
+Source of truth for priorities:
+- `ops/00-NORTHSTAR.md`
+- `ops/03-ROADMAP_NOW_NEXT_LATER.md`
+- `ops/04-DEFINITION_OF_DONE.md`
+- the GitHub project board
 
-| Ticket | Title | Priority |
-|--------|-------|----------|
-| T02 | README rewrite: cost guardrail as hero (#139) | Critical |
-| T07 | 30-second demo GIF: BudgetGuard kills agent | Critical |
-| T08 | Show HN post draft + launch prep | Critical |
+Current emphasis is release hardening and cleanup before the next PyPI release:
+- docs and roadmap drift
+- code scanning and workflow hygiene
+- test cleanliness and release readiness
 
-### Phase 2 SDK Tickets (next)
-
-| Ticket | Title | Priority |
-|--------|-------|----------|
-| T15 | SEO blog posts (3 targeting cost keywords) | High |
-| T18 | LangChain community engagement plan | High |
-| T19 | GitHub Discussions + issue templates | Medium |
-| T20 | SDK examples expansion (3 real-world) | Medium |
-
-### Phase 3 SDK Tickets
-
-| Ticket | Title | Priority |
-|--------|-------|----------|
-| T26 | SDK virality watermark | Medium |
-
-**Critical path:** T02 (README) → T07 (GIF) → T08 (Show HN) → **LAUNCH**
+Do not rely on old phase-ticket tables when they conflict with the ops docs.
 
 ## Workflow
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.9","3.12"]') || fromJSON('["3.9","3.10","3.11","3.12"]') }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -32,7 +32,7 @@ jobs:
             --cov-fail-under=80
       - name: Upload coverage artifact
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-report
           path: coverage.xml
@@ -40,8 +40,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: 'pip'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,8 +16,8 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/entropy.yml
+++ b/.github/workflows/entropy.yml
@@ -12,8 +12,8 @@ jobs:
   entropy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: 'pip'

--- a/.github/workflows/ops-cadence.yml
+++ b/.github/workflows/ops-cadence.yml
@@ -13,7 +13,7 @@ jobs:
   staleness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -31,12 +31,12 @@ jobs:
           SOURCE_DATE_EPOCH: "0"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: sdk/dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: sdk/dist/
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -13,7 +13,7 @@ jobs:
   announce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # full history for changelog
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,14 +15,14 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           sarif_file: results.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ AgentGuard — a lightweight observability and runtime-guards SDK for multi-agen
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (v1.2.1)
+- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.2)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -160,7 +160,7 @@ Read .Codex/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** v1.2.1 shipped. Phase 1 complete. Active: **Phase 2 — Traction.**
+**Current:** latest shipped SDK release is v1.2.2. Phase 1 complete. Active: **Phase 2 — Traction.**
 
 ## Phase 1 — Foundation (COMPLETE, 2026-02-16)
 
@@ -240,7 +240,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** 1.2.1
+- **Version:** latest shipped release is 1.2.2. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.2.3
+
+### Release Hardening
+- Removed the dashboard API key prefix from `examples/cost_guardrail.py` log output.
+- Replaced insecure `tempfile.mktemp()` usage in `sdk/tests/e2e_v110.py` with secure named temp files.
+- Pinned GitHub Actions by commit SHA across CI, publish, CodeQL, Scorecard, and maintenance workflows.
+
+### Docs and Release Hygiene
+- Refreshed stale docs and agent instructions to point at the latest shipped release (`v1.2.2`) instead of `v1.2.1`.
+- Replaced dead `agentguard view` references with supported `agentguard report` / `agentguard incident` commands.
+- Added explicit release criteria to `ops/04-DEFINITION_OF_DONE.md`.
+- Updated the SDK roadmap to reflect the feature freeze and release-hardening focus.
+
+## 1.2.2
+
+### SDK Reliability
+- Added `RetryGuard` to stop retry storms with a dedicated `RetryLimitExceeded` exception.
+- Refreshed built-in Anthropic and Google pricing entries used by `estimate_cost()`.
+- Expanded evaluation assertions and incident reporting for local trace analysis.
+
+### Local Proof and Onboarding
+- Added `agentguard demo` for a deterministic offline proof of budget, loop, and retry enforcement.
+- Added `agentguard doctor` for local-only install verification and minimal next-step guidance.
+
 ## 1.1.0
 
 ### Cost Guardrail Pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ AgentGuard — a lightweight observability and runtime-guards SDK for multi-agen
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (v1.2.1)
+- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.2)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -24,6 +24,9 @@ AgentGuard — a lightweight observability and runtime-guards SDK for multi-agen
    - **(d) Done criteria** — how do we know it's done? (reference `ops/04-DEFINITION_OF_DONE.md`)
 4. **Structured output.** Every task must include: **plan → diff summary → tests → docs updates needed**.
 5. **Check staleness.** Run `git log -1 --format='%cr' -- ops/03-ROADMAP_NOW_NEXT_LATER.md` and `git log -1 --format='%cr' -- ops/02-ARCHITECTURE.md`. If ROADMAP is >5 days old or ARCHITECTURE is >14 days old, warn the user before starting any task.
+6. **PR proof is required.** Every PR must include concrete proof that the change works: command output, targeted runtime evidence, screenshots when applicable, or saved artifacts under a local proof folder.
+7. **Always do the post-PR review loop.** After opening a PR: wait for CI, verify the relevant preview/deployment health, wait a few minutes for automated review, inspect the full PR timeline plus review comments/threads, address feedback, rerun checks, and only then call the PR ready.
+8. **Use matching built-in skills by default.** When the task matches them, use `playwright` for browser automation and screenshot proof, `playwright-interactive` when persistent browser state helps, `gh-address-comments` for PR review/comment sweeps, and `vercel-deploy` for deployment work. Do not skip these when the task clearly fits.
 
 ## Commands
 
@@ -40,6 +43,8 @@ make lines       # module line counts (entropy check)
 make install     # pip install SDK + dev tools
 make clean       # remove build artifacts
 ```
+
+If `make` is unavailable in the local shell, run the equivalent underlying commands directly and capture their output as proof.
 
 ### Running specific tests
 
@@ -107,7 +112,7 @@ Integration modules (allowed to import core, never the reverse):
 | Module | Purpose |
 |--------|---------|
 | `tracing.py` | Tracer, TraceSink, TraceContext, JsonlFileSink, StdoutSink |
-| `guards.py` | LoopGuard, FuzzyLoopGuard, BudgetGuard, TimeoutGuard, RateLimitGuard + exceptions |
+| `guards.py` | LoopGuard, FuzzyLoopGuard, BudgetGuard, TimeoutGuard, RateLimitGuard, RetryGuard + exceptions |
 | `instrument.py` | @trace_agent, @trace_tool, patch_openai, patch_anthropic |
 | `sinks/http.py` | HttpSink (batched, gzip, retry, SSRF protection) |
 | `sinks/otel.py` | OtelTraceSink (OpenTelemetry bridge) |
@@ -124,7 +129,7 @@ Integration modules (allowed to import core, never the reverse):
 
 - **Zero dependencies.** Stdlib only. Optional extras: `langchain-core`, `langgraph`, `crewai`, `opentelemetry-api`.
 - **Trace format:** JSONL — `{service, kind, phase, trace_id, span_id, parent_id, name, ts, duration_ms, data, error, cost_usd}`
-- **Guards raise exceptions:** `LoopDetected`, `BudgetExceeded`, `TimeoutExceeded`, `RateLimitExceeded`
+- **Guards raise exceptions:** `LoopDetected`, `BudgetExceeded`, `TimeoutExceeded`, `RetryLimitExceeded`
 - **TraceSink interface:** All sinks implement `emit(event: Dict)`
 
 ## CI/CD
@@ -155,7 +160,7 @@ Read .claude/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** v1.2.1 shipped. Phase 1 complete. Active: **Phase 2 — Traction.**
+**Current:** latest shipped SDK release is v1.2.2. Phase 1 complete. Active: **Phase 2 — Traction.**
 
 ## Phase 1 — Foundation (COMPLETE, 2026-02-16)
 
@@ -235,7 +240,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** 1.2.1
+- **Version:** latest shipped release is 1.2.2. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/docs/blog/001-why-agents-loop.md
+++ b/docs/blog/001-why-agents-loop.md
@@ -69,10 +69,10 @@ AgentGuard report
 
 The guard caught the loop on the third identical call. No tokens wasted. No silent failure.
 
-Open the trace viewer to see the full event timeline in your browser:
+Render an incident summary when a run loops or fails:
 
 ```bash
-agentguard view traces.jsonl
+agentguard incident traces.jsonl
 ```
 
 ## Why this matters

--- a/docs/blog/PUBLISHING.md
+++ b/docs/blog/PUBLISHING.md
@@ -41,7 +41,7 @@ Step-by-step instructions for cross-posting AgentGuard blog posts to Dev.to, Has
 
 Before publishing each post:
 
-- [ ] All code examples run against `agentguard47==1.2.1`
+- [ ] All code examples run against the current release version from `sdk/pyproject.toml`
 - [ ] `canonical_url` points to the GitHub source file
 - [ ] Links to repo (`github.com/bmdhodl/agent47`) are correct
 - [ ] `pip install agentguard47` command is correct

--- a/docs/examples/langchain_example.md
+++ b/docs/examples/langchain_example.md
@@ -40,7 +40,7 @@ print(response)
 
 ```bash
 agentguard report traces.jsonl
-agentguard view traces.jsonl
+agentguard incident traces.jsonl
 ```
 
 ## Notes

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -60,7 +60,7 @@ Docs: https://agentguard47.com
 
 ## Pre-Launch Checklist
 
-- [ ] `pip install agentguard47==1.2.1` works
+- [ ] `pip install agentguard47==<release-version>` works for the tag being shipped
 - [ ] README hero is cost guardrail (done)
 - [x] Try-it-now terminal output in README
 - [ ] All README links resolve (no 404s)

--- a/examples/cost_guardrail.py
+++ b/examples/cost_guardrail.py
@@ -53,7 +53,7 @@ if api_key:
         url="https://app.agentguard47.com/api/ingest",
         api_key=api_key,
     )
-    print(f"Sending traces to dashboard (key: {api_key[:8]}...)")
+    print("Sending traces to dashboard via HttpSink")
 else:
     sink = JsonlFileSink("cost_guardrail_traces.jsonl")
     print("Sending traces to cost_guardrail_traces.jsonl")

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -2,6 +2,8 @@
 
 SDK code changes only. No README, docs, blog, or marketing items.
 
+Release note: feature freeze is in effect until the next PyPI cleanup release ships.
+
 ## Recently Completed
 
 | Item | Status |
@@ -11,18 +13,20 @@ SDK code changes only. No README, docs, blog, or marketing items.
 | `RetryGuard` - cap retry attempts per tool | Done - configurable per-tool retry ceilings now raise `RetryLimitExceeded` |
 | Offline demo | Done - `agentguard demo` proves budget, loop, and retry enforcement without API keys or network access |
 | Incident reporting | Done - `agentguard incident` renders local Markdown/HTML summaries from trace files |
+| Install doctor / local validation | Done - `agentguard doctor` verifies local setup, trace writing, and the next minimal integration step |
 
 ## Now (next 2 weeks)
 
 | Item | Success Signal |
 |------|---------------|
-| Streaming support in patches | `patch_openai` / `patch_anthropic` capture streamed responses without losing final token and cost totals |
-| Install doctor / quickstart validation | One local command validates the SDK setup path and prints the minimal next step without any dashboard dependency |
+| Release hardening and code-scanning cleanup | No open SDK/example/workflow findings remain that block a clean PyPI release, and release metadata matches the shipped tag |
 
 ## Next (next month)
 
 | Item | Success Signal |
 |------|---------------|
+| Streaming support in patches | `patch_openai` / `patch_anthropic` capture streamed responses without losing final token and cost totals |
+| Framework quickstart generator | One local command prints the exact minimal snippet for the user's framework without any dashboard dependency |
 | OpenTelemetry Collector sink improvements | `OtelTraceSink` supports custom resource attributes and span links |
 | `ContentGuard` - detect PII/sensitive data in agent outputs | New guard class, raises `ContentViolation`, regex-based (no deps) |
 
@@ -31,6 +35,7 @@ SDK code changes only. No README, docs, blog, or marketing items.
 | Item | Success Signal |
 |------|---------------|
 | TypeScript SDK | npm package with parity: LoopGuard, BudgetGuard, TimeoutGuard, Tracer |
+| Repo-local `.agentguard.json` manifest | AI coding agents and humans can declare service name, trace path, and guard defaults without a hosted control plane |
 | Cost model alias cleanup | Common provider aliases map cleanly onto canonical model pricing entries without warning spam |
 | Policy bundle import/export | Guard and sink settings can be serialized and applied across environments without a hosted control plane |
 

--- a/ops/04-DEFINITION_OF_DONE.md
+++ b/ops/04-DEFINITION_OF_DONE.md
@@ -10,6 +10,15 @@
 - [ ] Test runs are clean - no persistent pytest config warnings.
 - [ ] No hardcoded absolute paths.
 - [ ] If `__init__.py` exports changed, it was intentional.
+- [ ] If the change ships user-visible behavior or release prep, docs and roadmap were reviewed for drift.
+
+## Cutting a release
+
+- [ ] `sdk/pyproject.toml` version matches the intended tag.
+- [ ] `CHANGELOG.md` has an entry for the version being shipped.
+- [ ] GitHub Releases has an entry for the tag, not just a git tag.
+- [ ] PyPI version matches the Git tag after publish.
+- [ ] Release notes link to the correct docs, repo, and package name.
 
 ## Adding a new guard
 

--- a/scripts/run_demo.sh
+++ b/scripts/run_demo.sh
@@ -6,6 +6,6 @@ SDK_DIR="$ROOT_DIR/sdk"
 DEMO_PY="$SDK_DIR/examples/demo_agent.py"
 TRACES="$SDK_DIR/examples/traces.jsonl"
 
-python3 -m pip install -e "$SDK_DIR"
+python3 -m pip install --no-deps -e "$SDK_DIR"
 python3 "$DEMO_PY"
 python3 -m agentguard.cli report "$TRACES"

--- a/sdk/examples/async_openai_agent.py
+++ b/sdk/examples/async_openai_agent.py
@@ -50,7 +50,7 @@ async def main():
     result = await agent("how to detect agent loops")
     print(result)
     print("\nTrace written to async_traces.jsonl")
-    print("Run: agentguard view async_traces.jsonl")
+    print("Run: agentguard report async_traces.jsonl")
 
 
 if __name__ == "__main__":

--- a/sdk/examples/crewai_example.py
+++ b/sdk/examples/crewai_example.py
@@ -99,4 +99,4 @@ if __name__ == "__main__":
     print("\n" + "=" * 60)
     print(result)
     print("=" * 60)
-    print(f"\n[agentguard] Trace saved. Run: agentguard view {here}/crewai_traces.jsonl")
+    print(f"\n[agentguard] Trace saved. Run: agentguard report {here}/crewai_traces.jsonl")

--- a/sdk/examples/loop_failure_demo.py
+++ b/sdk/examples/loop_failure_demo.py
@@ -6,7 +6,7 @@ Run:
 
 Then inspect the traces:
     agentguard report sdk/examples/loop_traces.jsonl
-    agentguard view sdk/examples/loop_traces.jsonl
+    agentguard incident sdk/examples/loop_traces.jsonl
 """
 
 from agentguard.tracing import Tracer, JsonlFileSink

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentguard47"
-version = "1.2.2"
+version = "1.2.3"
 description = "Zero-dependency observability and runtime guards for AI agents — loop detection, budget enforcement, cost tracking, and structured tracing"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/tests/e2e_v110.py
+++ b/sdk/tests/e2e_v110.py
@@ -50,9 +50,15 @@ def check(name, condition, detail=""):
         print(f"  [FAIL] {name} — {detail}")
 
 
+def _temp_trace_path():
+    """Create a closed named temp file path that can be reopened on Windows."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as handle:
+        return handle.name
+
+
 def main():
     global PASS, FAIL
-    trace_path = tempfile.mktemp(suffix=".jsonl")
+    trace_path = _temp_trace_path()
 
     print("=" * 60)
     print("SDK v1.1.0 End-to-End Verification")
@@ -123,7 +129,7 @@ def main():
                 raise RuntimeError(f"Tool {event_name} is blocked!")
 
     blocker = ToolBlocker("tool.dangerous")
-    trace_path2 = tempfile.mktemp(suffix=".jsonl")
+    trace_path2 = _temp_trace_path()
 
     blocked = False
     with Tracer(sink=JsonlFileSink(trace_path2), guards=[blocker]) as tracer:
@@ -141,7 +147,7 @@ def main():
 
     # ── 5. LoopGuard auto_check via Tracer ────────────────────
     print("\n5. LoopGuard auto_check via Tracer")
-    trace_path3 = tempfile.mktemp(suffix=".jsonl")
+    trace_path3 = _temp_trace_path()
     loop_guard = LoopGuard(max_repeats=3)
 
     loop_caught = False
@@ -206,7 +212,7 @@ def main():
 
     # ── 8. Name truncation ────────────────────────────────────
     print("\n8. Name truncation (1000 char limit)")
-    trace_path4 = tempfile.mktemp(suffix=".jsonl")
+    trace_path4 = _temp_trace_path()
     long_name = "x" * 2000
 
     with Tracer(sink=JsonlFileSink(trace_path4), service="truncation-test") as tracer:


### PR DESCRIPTION
## Summary
- prepare the next SDK release as `1.2.3` with docs, roadmap, and changelog cleanup
- fix the current CodeQL findings in `examples/cost_guardrail.py` and `sdk/tests/e2e_v110.py`
- pin GitHub Actions by commit SHA and tighten the local demo install path

## Release prep scope
- bump `sdk/pyproject.toml` to `1.2.3`
- add `1.2.3` and `1.2.2` entries to `CHANGELOG.md`
- refresh stale docs and agent instruction files that still referenced `v1.2.1` or `agentguard view`
- update the roadmap and definition of done for release freeze / release criteria
- pin action SHAs in CI, publish, CodeQL, Scorecard, and maintenance workflows

## Issue cleanup
- closed #141 because remote budget/config pull no longer fits the A.SDK vs A.D boundary
- closed #277 as automation noise during release cleanup
- opened #278 to track vulnerable `mcp-server` dependencies
- opened #279 to track remaining repo-level Scorecard governance findings

## Validation
- `python -m ruff check sdk/agentguard/`
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`
- `python -m pytest sdk/tests/test_architecture.py -v`
- `python -m pytest sdk/tests/test_init.py sdk/tests/e2e_v110.py -v`
- `python -m build ./sdk`
- `python -m twine check sdk/dist/*`

## Proof
- `.codex-proof/release-ruff.txt`
- `.codex-proof/release-bandit.txt`
- `.codex-proof/release-pytest.txt`
- `.codex-proof/release-structural.txt`
- `.codex-proof/release-targeted.txt`
- `.codex-proof/release-build.txt`
- `.codex-proof/release-twine.txt`