### PR TITLE
Principle 1: Remove import-time SDK side effects

### DIFF
--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -44,7 +44,9 @@ except PackageNotFoundError:  # pragma: no cover
 
 # Libraries should not configure logging; only add a NullHandler so
 # consumers do not see "No handler found" warnings.
-logging.getLogger("agentguard").addHandler(logging.NullHandler())
+_logger = logging.getLogger("agentguard")
+if not any(isinstance(handler, logging.NullHandler) for handler in _logger.handlers):
+    _logger.addHandler(logging.NullHandler())
 
 __all__ = [
     "AgentGuardError",

--- a/sdk/tests/test_first_run.py
+++ b/sdk/tests/test_first_run.py
@@ -1,6 +1,7 @@
 """Tests that importing agentguard has no user-visible side effects."""
 
 import importlib
+import os
 import sys
 from unittest import mock
 
@@ -36,7 +37,11 @@ class TestImportSideEffects:
         fake_home = tmp_path / "home"
         fake_home.mkdir()
 
-        with mock.patch("pathlib.Path.home", return_value=fake_home):
+        with mock.patch("pathlib.Path.home", return_value=fake_home), mock.patch.dict(
+            os.environ,
+            {"HOME": str(fake_home), "USERPROFILE": str(fake_home)},
+            clear=False,
+        ):
             _reimport_agentguard()
 
         assert list(fake_home.iterdir()) == []


### PR DESCRIPTION
## Summary
- remove the first-import star prompt and marker-file write from the SDK import path
- keep gentguard import silent and side-effect free for trust and auditability
- replace the old first-run tests with silent-import and no-home-directory-side-effects coverage

## Why
This is the first PR in the 5-principles series. Principle 1 is to question requirements. A runtime-guard SDK should not print marketing copy or write to ~/.agentguard just because it was imported.

## Validation
- python -m pytest sdk/tests/test_first_run.py -v
- python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
- python -m pytest sdk/tests/test_architecture.py -v
- python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
- python -m ruff check sdk/agentguard/__init__.py sdk/tests/test_first_run.py
