### PR TITLE
Prepare v1.2.4 release

### DIFF
--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -33,7 +33,7 @@ Project ID: `PVT_kwHOALAnAM4BOnP3`
 
 ## Current Focus
 
-Latest shipped SDK release: `v1.2.2`.
+Latest shipped SDK release: `v1.2.4`.
 
 Source of truth for planning:
 - `ops/00-NORTHSTAR.md`

--- a/.claude/agents/sdk-dev.md
+++ b/.claude/agents/sdk-dev.md
@@ -18,7 +18,7 @@ gh issue list --repo bmdhodl/agent47 --label component:sdk --state open --limit 
 
 ## Current Focus
 
-Latest shipped SDK release: `v1.2.3`.
+Latest shipped SDK release: `v1.2.4`.
 
 Source of truth for priorities:
 - `ops/00-NORTHSTAR.md`

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: sdk-version
     attributes:
       label: AgentGuard version
-      placeholder: "1.2.0"
+      placeholder: "1.2.4"
     validations:
       required: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ AgentGuard — a lightweight observability and runtime-guards SDK for multi-agen
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.3)
+- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.4)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -165,7 +165,7 @@ Read .Codex/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** latest shipped SDK release is v1.2.3. Phase 1 complete. Active: **Phase 2 — Traction.**
+**Current:** latest shipped SDK release is v1.2.4. Phase 1 complete. Active: **Phase 2 — Traction.**
 
 ## Phase 1 — Foundation (COMPLETE, 2026-02-16)
 
@@ -245,7 +245,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** latest shipped release is 1.2.3. Check `sdk/pyproject.toml` for the branch version under preparation.
+- **Version:** latest shipped release is 1.2.4. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.2.4
+
+### Coding-Agent Onboarding
+- Added repo-local `.agentguard.json` support so humans and coding agents can share static SDK defaults without dashboard coupling.
+- Added the built-in `coding-agent` profile with tighter loop and retry defaults for repo automation and coding workflows.
+- Added executable starter files under `examples/starters/` and aligned `agentguard doctor` / `agentguard quickstart` around `.agentguard/traces.jsonl`.
+- Added the `docs/guides/coding-agents.md` onboarding guide plus doc updates across the README, SDK README, examples, architecture doc, roadmap, and generated PyPI README.
+
+### SDK Hardening
+- `JsonlFileSink` now creates parent directories automatically so repo-local trace paths like `.agentguard/traces.jsonl` work out of the box.
+- Repo-config parsing now rejects boolean values in numeric fields to keep local defaults deterministic and auditable.
+- `init()` now still honors repo-level profile defaults when service, budget, or trace path are passed explicitly but guard-profile values are left implicit.
+- Invalid `AGENTGUARD_BUDGET_USD` values now fall back to a valid repo-local `budget_usd` instead of silently dropping budget enforcement.
+
 ## 1.2.3
 
 ### Release Hardening

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ AgentGuard — a lightweight observability and runtime-guards SDK for multi-agen
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.3)
+- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.4)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -163,7 +163,7 @@ Read .claude/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** latest shipped SDK release is v1.2.3. Phase 1 complete. Active: **Phase 2 — Traction.**
+**Current:** latest shipped SDK release is v1.2.4. Phase 1 complete. Active: **Phase 2 — Traction.**
 
 ## Phase 1 — Foundation (COMPLETE, 2026-02-16)
 
@@ -243,7 +243,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** latest shipped release is 1.2.3. Check `sdk/pyproject.toml` for the branch version under preparation.
+- **Version:** latest shipped release is 1.2.4. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -17,12 +17,11 @@ SDK code changes only. No README, docs, blog, or marketing items.
 | Coding-agent local profile | Done - `profile=\"coding-agent\"` ships tighter loop and retry defaults for repo automation and coding agents |
 | Repo-local `.agentguard.json` manifest | Done - humans and coding agents can share static local SDK defaults without dashboard coupling |
 | Executable framework starters | Done - each supported stack now has a minimal runnable starter file in `examples/starters/` |
+| Release stabilization for coding-agent onboarding | Done - docs, release metadata, package artifacts, and publish checks were aligned for `v1.2.4` |
 
 ## Now (next 2 weeks)
 
-| Item | Success Signal |
-|------|---------------|
-| Release stabilization for coding-agent onboarding | Full docs, proof artifacts, release metadata, and publish path stay aligned for the next SDK release |
+No active SDK code changes. Hold here until post-release issue triage promotes the next item.
 
 ## Next (next month)
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -11,7 +11,7 @@ Set a dollar budget. Get warnings at 80%. Kill the agent when it exceeds the lim
 [![Python](https://img.shields.io/pypi/pyversions/agentguard47)](https://pypi.org/project/agentguard47/)
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.3/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.4/LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bmdhodl/agent47/badge)](https://scorecard.dev/viewer/?uri=github.com/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
@@ -64,12 +64,12 @@ automatically. Keep it local and static: no secrets, no API keys, no dashboard
 settings.
 
 Every `agentguard quickstart --framework ...` payload also has a matching
-runnable file under [`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.3/examples/starters). Those starter
+runnable file under [`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.4/examples/starters). Those starter
 files live in the repo for copy-paste onboarding and coding-agent setup; they
 are not shipped inside the PyPI wheel.
 
 For the repo-first onboarding flow, see
-[`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.3/docs/guides/coding-agents.md).
+[`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.4/docs/guides/coding-agents.md).
 
 ## Try it in 60 seconds
 
@@ -103,7 +103,7 @@ Prefer the example script instead of the CLI? This does the same local demo:
 python examples/try_it_now.py
 ```
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.3/examples/quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.4/examples/quickstart.ipynb)
 
 ## Quickstart: Stop Runaway Costs in 4 Lines
 
@@ -364,7 +364,7 @@ Fail your CI pipeline if an agent run exceeds a cost budget. No competitor offer
     assertions: "no_errors,max_cost:5.00"
 ```
 
-Full workflow: [`docs/ci/cost-gate-workflow.yml`](https://github.com/bmdhodl/agent47/blob/v1.2.3/docs/ci/cost-gate-workflow.yml)
+Full workflow: [`docs/ci/cost-gate-workflow.yml`](https://github.com/bmdhodl/agent47/blob/v1.2.4/docs/ci/cost-gate-workflow.yml)
 
 ## Incident Reports
 
@@ -462,23 +462,24 @@ Your Agent Code
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/bmdhodl/agent47/blob/v1.2.3/CONTRIBUTING.md) for dev setup, test commands, and PR guidelines.
+See [CONTRIBUTING.md](https://github.com/bmdhodl/agent47/blob/v1.2.4/CONTRIBUTING.md) for dev setup, test commands, and PR guidelines.
 
 ## License
 
 MIT (BMD PAT LLC)
 
-## Latest Release Notes (1.2.3)
+## Latest Release Notes (1.2.4)
 
-### Release Hardening
-- Removed the dashboard API key prefix from `examples/cost_guardrail.py` log output.
-- Replaced insecure `tempfile.mktemp()` usage in `sdk/tests/e2e_v110.py` with secure named temp files.
-- Pinned GitHub Actions by commit SHA across CI, publish, CodeQL, Scorecard, and maintenance workflows.
+### Coding-Agent Onboarding
+- Added repo-local `.agentguard.json` support so humans and coding agents can share static SDK defaults without dashboard coupling.
+- Added the built-in `coding-agent` profile with tighter loop and retry defaults for repo automation and coding workflows.
+- Added executable starter files under `examples/starters/` and aligned `agentguard doctor` / `agentguard quickstart` around `.agentguard/traces.jsonl`.
+- Added the `docs/guides/coding-agents.md` onboarding guide plus doc updates across the README, SDK README, examples, architecture doc, roadmap, and generated PyPI README.
 
-### Docs and Release Hygiene
-- Refreshed stale docs and agent instructions to point at the latest shipped release (`v1.2.2`) instead of `v1.2.1`.
-- Replaced dead `agentguard view` references with supported `agentguard report` / `agentguard incident` commands.
-- Added explicit release criteria to `ops/04-DEFINITION_OF_DONE.md`.
-- Updated the SDK roadmap to reflect the feature freeze and release-hardening focus.
+### SDK Hardening
+- `JsonlFileSink` now creates parent directories automatically so repo-local trace paths like `.agentguard/traces.jsonl` work out of the box.
+- Repo-config parsing now rejects boolean values in numeric fields to keep local defaults deterministic and auditable.
+- `init()` now still honors repo-level profile defaults when service, budget, or trace path are passed explicitly but guard-profile values are left implicit.
+- Invalid `AGENTGUARD_BUDGET_USD` values now fall back to a valid repo-local `budget_usd` instead of silently dropping budget enforcement.
 
-Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.3/CHANGELOG.md)
+Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.4/CHANGELOG.md)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentguard47"
-version = "1.2.3"
+version = "1.2.4"
 description = "Zero-dependency observability and runtime guards for AI agents — loop detection, budget enforcement, cost tracking, and structured tracing"
 readme = "PYPI_README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- bump the SDK package metadata to v1.2.4 and add release notes for the coding-agent onboarding work
- refresh shipped-version references, generated PyPI README links, roadmap status, and bug-report template defaults
- ship the release metadata only after the full SDK gate, release guard, build, and twine checks pass

## Validation
- python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py
- python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
- python -m pytest sdk/tests/test_architecture.py -v
- python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
- python scripts/sdk_release_guard.py
- python -m build sdk
- python -m twine check sdk/dist/*