### PR TITLE
Docs: sharpen the coding-agent wedge with current adoption signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Local-first runtime guardrails for coding agents. Stop loops, retry storms, and 
 pip install agentguard47
 ```
 
+## Why this wedge
+
+AgentGuard stays focused on coding-agent safety on purpose.
+
+As of April 8, 2026, a16z reported that `29%` of the Fortune 500 and about
+`19%` of the Global 2000 are live paying customers of leading AI startups, with
+coding described as the dominant enterprise AI use case and support/search next
+behind it. They also cited repeated reports of `10-20x` productivity gains from
+AI coding tools. Source:
+[AI Adoption by the Numbers](https://www.a16z.news/p/ai-adoption-by-the-numbers).
+
+That supports the public SDK strategy in this repo:
+- stay narrow on coding-agent runtime safety
+- make the first proof local, cheap, and easy to trust
+- reuse the same runtime patterns for adjacent managed-agent workflows later,
+  without turning the SDK into a generic observability platform
+
 ## Verify your install
 
 Before wiring a real agent, validate the local SDK path:

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ pip install agentguard47
 
 AgentGuard stays focused on coding-agent safety on purpose.
 
-As of April 8, 2026, a16z reported that `29%` of the Fortune 500 and about
-`19%` of the Global 2000 are live paying customers of leading AI startups, with
-coding described as the dominant enterprise AI use case and support/search next
-behind it. They also cited repeated reports of `10-20x` productivity gains from
-AI coding tools. Source:
+In an April 2026 report, a16z said that `29%` of the Fortune 500 and about
+`19%` of the Global 2000 were live paying customers of leading AI startups,
+with coding described as the dominant enterprise AI use case and support/search
+next behind it. The report also cited repeated claims of `10-20x`
+productivity gains from AI coding tools. Source:
 [AI Adoption by the Numbers](https://www.a16z.news/p/ai-adoption-by-the-numbers).
 
 That supports the public SDK strategy in this repo:

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -8,6 +8,24 @@ looping, retrying forever, and burning budget. Keep the first integration local
 and auditable, then add the hosted dashboard later only if you need operational
 visibility.
 
+## Why this matters now
+
+This repo stays anchored to coding agents because that is where enterprise AI
+pull is strongest right now.
+
+On April 8, 2026, a16z published data indicating that `29%` of the Fortune 500
+and about `19%` of the Global 2000 are already live paying customers of leading
+AI startups, with coding called out as the dominant use case by nearly an order
+of magnitude. They also reported repeated `10-20x` productivity claims for AI
+coding tools. Source:
+[AI Adoption by the Numbers](https://www.a16z.news/p/ai-adoption-by-the-numbers).
+
+That does not mean AgentGuard should widen into a generic AI SDK here. It means
+the coding-agent wedge is real:
+- more coding agents running in real repos
+- more retry loops, runaway tool calls, and unattended spend risk
+- more pressure to prove local safety before asking a team to adopt hosted ops
+
 If you want ready-to-copy repo instructions for specific coding agents, start
 with [`coding-agent-safety-pack.md`](coding-agent-safety-pack.md).
 

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -13,11 +13,12 @@ visibility.
 This repo stays anchored to coding agents because that is where enterprise AI
 pull is strongest right now.
 
-On April 8, 2026, a16z published data indicating that `29%` of the Fortune 500
-and about `19%` of the Global 2000 are already live paying customers of leading
-AI startups, with coding called out as the dominant use case by nearly an order
-of magnitude. They also reported repeated `10-20x` productivity claims for AI
-coding tools. Source:
+Industry reporting continues to point to coding as one of the clearest early
+production use cases for AI. In an April 2026 report, a16z estimated that
+`29%` of the Fortune 500 and about `19%` of the Global 2000 were live paying
+customers of leading AI startups, with coding called out as the dominant use
+case by nearly an order of magnitude. They also cited repeated `10-20x`
+productivity claims for AI coding tools. Source:
 [AI Adoption by the Numbers](https://www.a16z.news/p/ai-adoption-by-the-numbers).
 
 That does not mean AgentGuard should widen into a generic AI SDK here. It means

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -19,6 +19,23 @@ Local-first runtime guardrails for coding agents. Stop loops, retry storms, and 
 pip install agentguard47
 ```
 
+## Why this wedge
+
+AgentGuard stays focused on coding-agent safety on purpose.
+
+As of April 8, 2026, a16z reported that `29%` of the Fortune 500 and about
+`19%` of the Global 2000 are live paying customers of leading AI startups, with
+coding described as the dominant enterprise AI use case and support/search next
+behind it. They also cited repeated reports of `10-20x` productivity gains from
+AI coding tools. Source:
+[AI Adoption by the Numbers](https://www.a16z.news/p/ai-adoption-by-the-numbers).
+
+That supports the public SDK strategy in this repo:
+- stay narrow on coding-agent runtime safety
+- make the first proof local, cheap, and easy to trust
+- reuse the same runtime patterns for adjacent managed-agent workflows later,
+  without turning the SDK into a generic observability platform
+
 ## Verify your install
 
 Before wiring a real agent, validate the local SDK path:

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -23,11 +23,11 @@ pip install agentguard47
 
 AgentGuard stays focused on coding-agent safety on purpose.
 
-As of April 8, 2026, a16z reported that `29%` of the Fortune 500 and about
-`19%` of the Global 2000 are live paying customers of leading AI startups, with
-coding described as the dominant enterprise AI use case and support/search next
-behind it. They also cited repeated reports of `10-20x` productivity gains from
-AI coding tools. Source:
+In an April 2026 report, a16z said that `29%` of the Fortune 500 and about
+`19%` of the Global 2000 were live paying customers of leading AI startups,
+with coding described as the dominant enterprise AI use case and support/search
+next behind it. The report also cited repeated claims of `10-20x`
+productivity gains from AI coding tools. Source:
 [AI Adoption by the Numbers](https://www.a16z.news/p/ai-adoption-by-the-numbers).
 
 That supports the public SDK strategy in this repo:


### PR DESCRIPTION
## Summary
- add a sourced "why this wedge" note to the public README and coding-agent guide
- keep the repo positioned on coding-agent runtime safety even while acknowledging broader enterprise AI adoption
- regenerate the PyPI README so package metadata stays aligned with the same message

## Why
The a16z April 8, 2026 adoption data is a strong market signal, but this public repo should use it to reinforce the coding-agent wedge, not to drift into generic AI positioning.

## Scope
- README.md
- docs/guides/coding-agents.md
- sdk/PYPI_README.md

## Proof
- python scripts/generate_pypi_readme.py --check
- python -m pytest sdk/tests/test_pypi_readme_sync.py -v
- python scripts/sdk_preflight.py
