### PR TITLE
Add repo-root architecture guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,84 @@
+# ARCHITECTURE.md
+
+## 1. System Overview
+
+AgentGuard is the public SDK wedge in the BMD Pat LLC portfolio: a zero-dependency Python runtime-safety SDK plus a small TypeScript MCP server and static public site. This repo exists to make coding-agent safety easy to adopt, easy to trust, and easy to prove locally. The hosted dashboard/control plane is a separate private repo; this repo's job is to ship the free MIT SDK, the MCP bridge, and the public docs/examples that drive distribution.
+
+## 2. Core Principles
+
+- Zero-dependency core SDK stays zero-dependency. Core Python modules under [`sdk/agentguard/`](sdk/agentguard/) must use stdlib only.
+- Runtime enforcement beats observability sprawl. The SDK exists to stop loops, retries, timeout overruns, and budget burn while the agent is still running.
+- Local-first proof comes before hosted follow-through. `doctor`, `demo`, `quickstart`, starter files, JSONL traces, and local reports must work without API keys or dashboard access.
+- Public API stability flows through [`sdk/agentguard/__init__.py`](sdk/agentguard/__init__.py). Internal refactors are fine; user-facing import paths should not drift casually.
+- This repo is the public SDK distribution asset, not the private dashboard. If a change primarily belongs to hosted pricing, dashboard UI, policy management, or control-plane behavior, it belongs elsewhere.
+
+## 3. Directory Map
+
+- [`sdk/`](sdk/): Python package source, tests, packaging metadata, and generated PyPI README snapshot.
+- [`sdk/agentguard/`](sdk/agentguard/): core SDK modules, CLI helpers, integrations, and sinks.
+- [`sdk/tests/`](sdk/tests/): behavioral, structural, hardening, DX, and integration-style tests for the SDK.
+- [`mcp-server/`](mcp-server/): published read-only MCP server that exposes AgentGuard traces, decision events, alerts, usage, and cost data through MCP.
+- [`examples/`](examples/): runnable local examples, checked-in starter files, notebooks, and proof-oriented onboarding paths.
+- [`docs/`](docs/): public guides for getting started, coding-agent onboarding, smoke tests, incident/report flows, and decision/session patterns.
+- [`site/`](site/): static public landing/docs pages that describe the public SDK surface only; not the source of truth for private dashboard behavior.
+- [`memory/`](memory/): SDK-only ground truth for current state, blockers, decisions, and distribution priorities.
+- [`ops/`](ops/): operating docs, north star, roadmap, definition of done, and secondary architecture notes.
+- [`scripts/`](scripts/): release guards, preflight logic, generated-readme tooling, and maintenance automation.
+- [`proof/`](proof/): saved artifacts that demonstrate local proof for specific PRs or flows.
+- [`inbox/`](inbox/): short SDK-only cofounder handoff log after merged PRs.
+
+## 4. Data Flow
+
+```mermaid
+flowchart TD
+    U["User code or coding agent"] --> S["agentguard.init() / Tracer / AsyncTracer"]
+    S --> G["Guards evaluate runtime events in-process"]
+    G -->|violation| X["Raise AgentGuard exception and stop the run"]
+    G -->|allowed| T["TraceContext emits JSON-safe span/event records"]
+    T --> L["Local sinks: JsonlFileSink / StdoutSink"]
+    T --> H["HttpSink to private dashboard ingest"]
+    L --> R["CLI proof surfaces: doctor / demo / report / incident / decisions / eval"]
+    H --> D["Private dashboard repo and hosted API"]
+    D --> M["MCP server reads hosted traces, incidents, decisions, alerts"]
+    M --> C["Codex / Claude Code / Cursor / other MCP clients"]
+```
+
+## 5. Key Abstractions
+
+- `Tracer` / `AsyncTracer`: the runtime event spine. They create traces, propagate span context, run guards on events, and emit records into sinks.
+- `TraceContext` / `AsyncTraceContext`: the scoped unit of work inside a trace. Most runtime instrumentation, decision tracing, and examples build on these.
+- Guards: `LoopGuard`, `FuzzyLoopGuard`, `BudgetGuard`, `TimeoutGuard`, `RateLimitGuard`, and `RetryGuard`. Guards raise exceptions instead of returning booleans.
+- Sinks: `JsonlFileSink`, `StdoutSink`, `HttpSink`, and `OtelTraceSink`. This is the boundary between runtime evidence and its destination.
+- Local proof surfaces: `doctor`, `demo`, `quickstart`, checked-in starters, `report`, `incident`, `decisions`, and `EvalSuite`. These are part of the product, not just internal tooling.
+
+## 6. Boundaries
+
+- This repo does not own the private hosted dashboard UI, billing, team policy controls, or remote control-plane workflows. Those live in `agent47-dashboard`.
+- This repo does not become a general agent framework. It instruments and guards agent runtimes that already exist.
+- This repo does not optimize prompts, orchestrate workflows, or ship heavyweight eval/observability platforms.
+- This repo does not add paid-only features to the SDK. The SDK remains free, MIT, and safe to adopt without hosted commitments.
+- This repo should not be the place where dashboard marketing, pricing pages, or speculative hosted-product claims get built.
+
+## 7. Adding New Features
+
+1. Does the change respect zero-dependency core rules and one-way import direction?
+2. Is it clearly inside the public SDK/MCP/site boundary, or is it actually dashboard work?
+3. Which layer does it belong in: core SDK, optional integration, CLI/proof surface, MCP server, docs/examples, or release tooling?
+4. Can it reuse existing patterns like `TraceSink`, guard exceptions, repo-local `.agentguard.json`, or CLI proof flows instead of inventing a parallel path?
+5. What proof is required?
+   - SDK code: targeted tests plus `sdk_preflight.py`
+   - public behavior: runnable example, saved proof artifact, or command output
+   - release-facing docs: regenerated [`sdk/PYPI_README.md`](sdk/PYPI_README.md) and sync tests
+6. If the change evolves the architecture, update this file in the same PR.
+
+## 8. Known Technical Debt
+
+- Architecture knowledge is currently split between this new root doc and [`ops/02-ARCHITECTURE.md`](ops/02-ARCHITECTURE.md). They are close, but duplication can drift if only one gets updated.
+- The public repo still contains [`site/`](site/), which creates recurring boundary confusion because the private dashboard repo also owns hosted product surfaces.
+- Some tests still intentionally import private tracing helpers for hardening coverage, so internal refactors need compatibility shims or test cleanup rather than assuming internals are free to disappear.
+- The MCP server is a separate package with its own tool/runtime contract, but release and architecture understanding still skews heavily toward the Python SDK.
+- Local PR proof is strong, but some supporting repo tooling around GitHub review/check inspection is fragile on Windows shells and depends on manual `gh` fallbacks.
+
+## 9. Change Log
+
+- 2026-04-09: Created root `ARCHITECTURE.md` as the repo-level architecture law for future nightshift and PR work.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,11 @@
 
 ## 1. System Overview
 
-AgentGuard is the public SDK wedge in the BMD Pat LLC portfolio: a zero-dependency Python runtime-safety SDK plus a small TypeScript MCP server and static public site. This repo exists to make coding-agent safety easy to adopt, easy to trust, and easy to prove locally. The hosted dashboard/control plane is a separate private repo; this repo's job is to ship the free MIT SDK, the MCP bridge, and the public docs/examples that drive distribution.
+AgentGuard is the public SDK wedge in the BMD PAT LLC portfolio: a zero-dependency Python runtime-safety SDK plus a small TypeScript MCP server and static public site. This repo exists to make coding-agent safety easy to adopt, easy to trust, and easy to prove locally. The hosted dashboard/control plane is a separate private repo; this repo's job is to ship the free MIT SDK, the MCP bridge, and the public docs/examples that drive distribution.
 
 ## 2. Core Principles
 
-- Zero-dependency core SDK stays zero-dependency. Core Python modules under [`sdk/agentguard/`](sdk/agentguard/) must use stdlib only.
+- Zero-dependency core SDK stays zero-dependency. The default/core Python path under [`sdk/agentguard/`](sdk/agentguard/) must not introduce hard runtime dependencies; optional integrations may use guarded optional imports when they are not required for local-first SDK use.
 - Runtime enforcement beats observability sprawl. The SDK exists to stop loops, retries, timeout overruns, and budget burn while the agent is still running.
 - Local-first proof comes before hosted follow-through. `doctor`, `demo`, `quickstart`, starter files, JSONL traces, and local reports must work without API keys or dashboard access.
 - Public API stability flows through [`sdk/agentguard/__init__.py`](sdk/agentguard/__init__.py). Internal refactors are fine; user-facing import paths should not drift casually.
@@ -39,7 +39,7 @@ flowchart TD
     T --> H["HttpSink to private dashboard ingest"]
     L --> R["CLI proof surfaces: doctor / demo / report / incident / decisions / eval"]
     H --> D["Private dashboard repo and hosted API"]
-    D --> M["MCP server reads hosted traces, incidents, decisions, alerts"]
+    D --> M["MCP server reads hosted traces, decisions, alerts, usage, costs, and budget health"]
     M --> C["Codex / Claude Code / Cursor / other MCP clients"]
 ```
 

--- a/MORNING_REPORT.md
+++ b/MORNING_REPORT.md
@@ -1,27 +1,23 @@
 # Morning Report
 
 ## Mission
-Turn the managed-agent note into one real SDK-side onboarding and proof improvement without leaving the public repo boundary.
+Create a root architecture guide that explains the public SDK repo clearly enough for future nightshift work and PR review.
 
 ## What shipped
-- added optional `session_id` support to `Tracer`, `AsyncTracer`, and `agentguard.init(...)`
-- added a local example that simulates two disposable harnesses writing separate traces under one shared managed-agent session
-- updated README and guide-level onboarding docs so session correlation is documented as a runtime concern, not a repo-config value
-- regenerated `sdk/PYPI_README.md`
+- added `ARCHITECTURE.md` at the repo root
+- documented the public repo boundary versus the private dashboard
+- mapped the main data flow from runtime guards to local proof surfaces, hosted ingest, and MCP clients
+- documented key abstractions, feature-placement rules, and known technical debt
 
 ## Why it matters
-- the SDK already handled append-only traces well, but it assumed one tracer instance per local process
-- managed-agent and disposable-harness runtimes break that assumption unless there is a shared correlation key above `trace_id`
-- `session_id` gives app developers a minimal, zero-dependency way to preserve that relationship while staying local-first and sink-compatible
+- the repo is easy to drift in because SDK, MCP, site, and private-dashboard references all exist nearby
+- a single current architecture doc reduces repeated recon work and lowers the chance of scope mistakes
+- future PRs now have a concrete place to update when the repo shape changes
 
 ## Validation
-- focused lint/tests passed
-- `sdk_preflight` passed
-- `sdk_release_guard.py` passed
-- bandit passed
-- full SDK suite passed
-- proof artifacts saved under `proof/session-id/`
+- `python scripts/sdk_preflight.py` passed with docs-only output
+- local proof files saved under `proof/architecture-doc/`
 
 ## Notes
-- local validation used `PYTHONPATH=<repo>/sdk` because another editable install exists on this machine
-- `session_id` is intentionally runtime-only; there is no `.agentguard.json` key or environment variable for it because it should be generated per managed session
+- this is a docs-only PR
+- `ops/02-ARCHITECTURE.md` still exists, so architectural guidance is intentionally duplicated until one source is retired

--- a/PR_DRAFT.md
+++ b/PR_DRAFT.md
@@ -1,38 +1,33 @@
 # PR Draft
 
 ## Title
-Add session-level trace correlation for disposable managed-agent harnesses
+Add repo-root architecture guide for SDK nightshift and PR work
 
 ## Summary
-- add optional `session_id` support to `Tracer`, `AsyncTracer`, and `agentguard.init(...)` so one higher-level agent session can span multiple disposable harnesses without losing local correlation
-- keep the feature local-first and provider-agnostic: no new sink types, no Anthropic-specific code, and no repo-config or hosted dependency changes
-- add guide/example proof so developers can model a managed-agent session with two independent tracer instances in one local file
+- add a new root `ARCHITECTURE.md` that explains the current public repo in one place
+- make the repo boundary explicit: public SDK, MCP server, public site, and private dashboard split
+- document the main data flow, core abstractions, technical debt, and feature-placement rules for future work
 
 ## Scope
-- core tracer plumbing in `sdk/agentguard/tracing.py`, `sdk/agentguard/atracing.py`, and `sdk/agentguard/setup.py`
-- focused tests in `sdk/tests/test_tracing.py`, `sdk/tests/test_atracing.py`, `sdk/tests/test_init.py`, and `sdk/tests/test_example_starters.py`
-- onboarding docs in `README.md`, `docs/guides/getting-started.md`, `docs/guides/coding-agents.md`, and `docs/guides/managed-agent-sessions.md`
-- example updates in `examples/disposable_harness_session.py` and `examples/README.md`
-- generated `sdk/PYPI_README.md`
-- proof artifacts under `proof/session-id/`
+- new `ARCHITECTURE.md` at the repo root
+- no SDK runtime code changes
+- no MCP behavior changes
+- no dashboard or landing-page work
 
 ## Non-goals
-- no dashboard work
-- no Anthropic-managed-agent adapter or vendor-specific instrumentation
-- no repo-level persistent `session_id` config in `.agentguard.json`
-- no new runtime dependencies
-- no trace schema redesign beyond adding an optional correlation field
+- no feature work
+- no architecture refactor
+- no packaging or release changes
+- no private dashboard documentation
 
 ## Proof
-- `python -m ruff check sdk/agentguard/tracing.py sdk/agentguard/atracing.py sdk/agentguard/setup.py sdk/tests/test_tracing.py sdk/tests/test_atracing.py sdk/tests/test_init.py sdk/tests/test_example_starters.py`
-- `python -m pytest sdk/tests/test_tracing.py sdk/tests/test_atracing.py sdk/tests/test_init.py sdk/tests/test_example_starters.py -v`
 - `python scripts/sdk_preflight.py`
-- `python -m pytest sdk/tests -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`
-- `python scripts/sdk_release_guard.py`
-- `python -m bandit -r sdk/agentguard -s B101,B110,B112,B311 -q`
+- manual inspection of `ARCHITECTURE.md`
 - proof files:
-  - `proof/session-id/example-output.txt`
-  - `proof/session-id/managed_session_traces.jsonl`
+  - `proof/architecture-doc/preflight.txt`
+  - `proof/architecture-doc/status.txt`
 
-## Operator note
-- local validation pinned `PYTHONPATH=<repo>/sdk` because this machine has another editable `agentguard47` install that can shadow branch code
+## Why now
+- the repo had architecture knowledge split across `ops/` notes and agent instructions
+- queue guidance explicitly called for a real `ARCHITECTURE.md`
+- future PRs need a stable repo-level reference to reduce boundary mistakes and duplicated rediscovery

--- a/proof/architecture-doc/preflight.txt
+++ b/proof/architecture-doc/preflight.txt
@@ -1,0 +1,1 @@
+No SDK-relevant changes detected; preflight has nothing to run.

--- a/proof/architecture-doc/status.txt
+++ b/proof/architecture-doc/status.txt
@@ -1,4 +1,1 @@
- M MORNING_REPORT.md
- M PR_DRAFT.md
-?? ARCHITECTURE.md
-?? proof/architecture-doc/
+ M ARCHITECTURE.md

--- a/proof/architecture-doc/status.txt
+++ b/proof/architecture-doc/status.txt
@@ -1,0 +1,4 @@
+ M MORNING_REPORT.md
+ M PR_DRAFT.md
+?? ARCHITECTURE.md
+?? proof/architecture-doc/


### PR DESCRIPTION
# PR Draft

## Title
Add repo-root architecture guide for SDK nightshift and PR work

## Summary
- add a new root `ARCHITECTURE.md` that explains the current public repo in one place
- make the repo boundary explicit: public SDK, MCP server, public site, and private dashboard split
- document the main data flow, core abstractions, technical debt, and feature-placement rules for future work

## Scope
- new `ARCHITECTURE.md` at the repo root
- no SDK runtime code changes
- no MCP behavior changes
- no dashboard or landing-page work

## Non-goals
- no feature work
- no architecture refactor
- no packaging or release changes
- no private dashboard documentation

## Proof
- `python scripts/sdk_preflight.py`
- manual inspection of `ARCHITECTURE.md`
- proof files:
  - `proof/architecture-doc/preflight.txt`
  - `proof/architecture-doc/status.txt`

## Why now
- the repo had architecture knowledge split across `ops/` notes and agent instructions
- queue guidance explicitly called for a real `ARCHITECTURE.md`
- future PRs need a stable repo-level reference to reduce boundary mistakes and duplicated rediscovery
