### PR TITLE
Add runtime safety proof points to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@ That supports the public SDK strategy in this repo:
 - reuse the same runtime patterns for adjacent managed-agent workflows later,
   without turning the SDK into a generic observability platform
 
+## Why runtime safety matters now
+
+Agents are getting more autonomous. The guardrails around them are not keeping up.
+
+- **Unchecked token burn is real.** Meta's internal "Claudeonomics" leaderboard
+  tracked 60 trillion tokens consumed by 85,000 employees in 30 days. Some
+  employees left agents running for hours just to climb the rankings. Meta shut
+  the dashboard down days after it leaked. ([source](https://fortune.com/2026/04/09/meta-killed-employee-ai-token-dashboard/))
+- **Self-improving agents need guardrails that don't self-improve.** Cursor's
+  Bugbot has auto-generated 44,000+ learned rules across 110,000+ repos. When
+  agents write their own rules, the safety layer has to be external and
+  deterministic. Not another model. Not another prompt.
+  ([source](https://cursor.com/blog/bugbot-learning))
+- **Layered agent architectures are the default now.** Orchestrators spawn
+  sub-agents that spawn tool calls. Every layer multiplies the blast radius of a
+  stuck loop or a retry storm. You need a guard that runs in-process, at every
+  layer, and kills the run before it compounds.
+
+AgentGuard is that layer. Zero dependencies. No network calls required. Raises
+an exception and stops the agent mid-run.
+
 ## Verify your install
 
 Before wiring a real agent, validate the local SDK path:

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -36,6 +36,27 @@ That supports the public SDK strategy in this repo:
 - reuse the same runtime patterns for adjacent managed-agent workflows later,
   without turning the SDK into a generic observability platform
 
+## Why runtime safety matters now
+
+Agents are getting more autonomous. The guardrails around them are not keeping up.
+
+- **Unchecked token burn is real.** Meta's internal "Claudeonomics" leaderboard
+  tracked 60 trillion tokens consumed by 85,000 employees in 30 days. Some
+  employees left agents running for hours just to climb the rankings. Meta shut
+  the dashboard down days after it leaked. ([source](https://fortune.com/2026/04/09/meta-killed-employee-ai-token-dashboard/))
+- **Self-improving agents need guardrails that don't self-improve.** Cursor's
+  Bugbot has auto-generated 44,000+ learned rules across 110,000+ repos. When
+  agents write their own rules, the safety layer has to be external and
+  deterministic. Not another model. Not another prompt.
+  ([source](https://cursor.com/blog/bugbot-learning))
+- **Layered agent architectures are the default now.** Orchestrators spawn
+  sub-agents that spawn tool calls. Every layer multiplies the blast radius of a
+  stuck loop or a retry storm. You need a guard that runs in-process, at every
+  layer, and kills the run before it compounds.
+
+AgentGuard is that layer. Zero dependencies. No network calls required. Raises
+an exception and stops the agent mid-run.
+
 ## Verify your install
 
 Before wiring a real agent, validate the local SDK path:


### PR DESCRIPTION
## Summary
- Adds a "Why runtime safety matters now" section to README.md with three industry proof points
- Meta burned 60T tokens in 30 days via their "Claudeonomics" leaderboard (Fortune, Apr 2026)
- Cursor Bugbot auto-generated 44K+ rules across 110K+ repos. Self-improving agents need external, deterministic guardrails
- Layered agent architectures multiply blast radius of stuck loops and retry storms
- Regenerated sdk/PYPI_README.md to stay in sync

## Test plan
- [x] All 672 tests pass (`python -m pytest sdk/tests/ -v`)
- [x] PyPI README regenerated and sync test passes
- [x] No code changes, docs only
- [x] Both claims verified via web search (Fortune, Cursor blog)
- [x] Voice rules followed: no em dashes, no forbidden words, builder tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)