### PR TITLE
Fix MCP dependency audit and close stale issue noise

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -426,12 +426,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -638,9 +638,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/proof/issue-audit-2026-04-17/README.md
+++ b/proof/issue-audit-2026-04-17/README.md
@@ -1,0 +1,15 @@
+Issue audit proof for 2026-04-17.
+
+Scope:
+- issue #278: vulnerable MCP server transitive dependencies
+- stale/noise issue disposition review for #343, #357, #295, and #142
+
+Artifacts:
+- `npm-audit.json`: `npm audit --json` after the lockfile refresh
+- `mcp-test.txt`: `npm test` output for the MCP server
+- `lockfile-diff.txt`: exact lockfile delta showing the transitive dependency refresh
+
+Result:
+- `npm audit` reports 0 vulnerabilities
+- MCP server build and tests pass
+- the only repo code change is the `mcp-server/package-lock.json` refresh

--- a/proof/issue-audit-2026-04-17/lockfile-diff.txt
+++ b/proof/issue-audit-2026-04-17/lockfile-diff.txt
@@ -1,4 +1,4 @@
-﻿diff --git a/mcp-server/package-lock.json b/mcp-server/package-lock.json
+diff --git a/mcp-server/package-lock.json b/mcp-server/package-lock.json
 index 7bdc826..4cb2b81 100644
 --- a/mcp-server/package-lock.json
 +++ b/mcp-server/package-lock.json

--- a/proof/issue-audit-2026-04-17/lockfile-diff.txt
+++ b/proof/issue-audit-2026-04-17/lockfile-diff.txt
@@ -1,0 +1,73 @@
+﻿diff --git a/mcp-server/package-lock.json b/mcp-server/package-lock.json
+index 7bdc826..4cb2b81 100644
+--- a/mcp-server/package-lock.json
++++ b/mcp-server/package-lock.json
+@@ -21,9 +21,9 @@
+       }
+     },
+     "node_modules/@hono/node-server": {
+-      "version": "1.19.9",
+-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
++      "version": "1.19.14",
++      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
++      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+       "license": "MIT",
+       "engines": {
+         "node": ">=18.14.1"
+@@ -33,9 +33,9 @@
+       }
+     },
+     "node_modules/@modelcontextprotocol/sdk": {
+-      "version": "1.26.0",
+-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
++      "version": "1.29.0",
++      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
++      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+       "license": "MIT",
+       "dependencies": {
+         "@hono/node-server": "^1.19.9",
+@@ -426,12 +426,12 @@
+       }
+     },
+     "node_modules/express-rate-limit": {
+-      "version": "8.2.1",
+-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
++      "version": "8.3.2",
++      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
++      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+       "license": "MIT",
+       "dependencies": {
+-        "ip-address": "10.0.1"
++        "ip-address": "10.1.0"
+       },
+       "engines": {
+         "node": ">= 16"
+@@ -587,9 +587,9 @@
+       }
+     },
+     "node_modules/hono": {
+-      "version": "4.12.0",
+-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
++      "version": "4.12.14",
++      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
++      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+       "license": "MIT",
+       "engines": {
+         "node": ">=16.9.0"
+@@ -638,9 +638,9 @@
+       "license": "ISC"
+     },
+     "node_modules/ip-address": {
+-      "version": "10.0.1",
+-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
++      "version": "10.1.0",
++      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
++      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+       "license": "MIT",
+       "engines": {
+         "node": ">= 12"

--- a/proof/issue-audit-2026-04-17/mcp-test.txt
+++ b/proof/issue-audit-2026-04-17/mcp-test.txt
@@ -1,0 +1,43 @@
+﻿
+> @agentguard47/mcp-server@0.2.2 test
+> npm run build && node --test dist/__tests__/*.test.js
+
+
+> @agentguard47/mcp-server@0.2.2 build
+> tsc
+
+TAP version 13
+# Subtest: isDecisionEvent recognizes decision lifecycle events
+ok 1 - isDecisionEvent recognizes decision lifecycle events
+  ---
+  duration_ms: 0.4559
+  ...
+# Subtest: extractDecisionPayload normalizes trace and event fields
+ok 2 - extractDecisionPayload normalizes trace and event fields
+  ---
+  duration_ms: 0.1168
+  ...
+# Subtest: extractDecisionEvents filters by workflow and trace
+ok 3 - extractDecisionEvents filters by workflow and trace
+  ---
+  duration_ms: 0.1607
+  ...
+# Subtest: buildToolShape supports string, number, and boolean fields
+ok 4 - buildToolShape supports string, number, and boolean fields
+  ---
+  duration_ms: 1.3784
+  ...
+# Subtest: get_trace_decisions returns normalized decision payloads
+ok 5 - get_trace_decisions returns normalized decision payloads
+  ---
+  duration_ms: 0.8667
+  ...
+1..5
+# tests 5
+# suites 0
+# pass 5
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 71.1224

--- a/proof/issue-audit-2026-04-17/mcp-test.txt
+++ b/proof/issue-audit-2026-04-17/mcp-test.txt
@@ -1,4 +1,4 @@
-﻿
+
 > @agentguard47/mcp-server@0.2.2 test
 > npm run build && node --test dist/__tests__/*.test.js
 

--- a/proof/issue-audit-2026-04-17/npm-audit.json
+++ b/proof/issue-audit-2026-04-17/npm-audit.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "auditReportVersion": 2,
   "vulnerabilities": {},
   "metadata": {

--- a/proof/issue-audit-2026-04-17/npm-audit.json
+++ b/proof/issue-audit-2026-04-17/npm-audit.json
@@ -1,0 +1,22 @@
+﻿{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 92,
+      "dev": 3,
+      "optional": 0,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 94
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the MCP server lockfile to clear transitive vulnerabilities flagged in issue #278
- keep the public manifest unchanged and avoid widening the MCP surface
- attach local proof for the audit/test results under `proof/issue-audit-2026-04-17/`

## Proof
- `npm --prefix mcp-server audit --json` -> 0 vulnerabilities
- `npm --prefix mcp-server test` -> build + 5 tests passing
- lockfile diff captured in `proof/issue-audit-2026-04-17/lockfile-diff.txt`

## Issue audit disposition
- closed #343 as stale
- closed #357 as scout output noise
- closed #295 because the owning scout automation does not live in this repo
- closed #142 as out-of-scope for the public SDK repo
- leaves #324, #282, #279 open intentionally

Closes #278