### PR TITLE
docs: reframe README from cost-savings to runtime governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # AgentGuard
 
-**Your coding agent just started looping through retries and shell calls. AgentGuard stops it before it burns budget.**
+**Your coding agent just started looping through retries and shell calls. AgentGuard stops it before it goes off the rails.**
 
-Local-first runtime guardrails for coding agents. Stop loops, retry storms, and budget burn with a zero-dependency Python SDK, then expose traces and incident context through MCP when your tooling needs read access.
+Local-first runtime governance for AI agents. Budget, loops, timeouts, rates — four static guards that stop an agent before it runs away, with a zero-dependency Python SDK. Traces and incident context exposed through MCP when your tooling needs read access.
+
+> When tokens cost 12 cents per million, the bottleneck isn't cost. It's control. AgentGuard is the governance layer that keeps agents inside the rails you set — no matter how cheap the tokens get.
 
 [![PyPI](https://img.shields.io/pypi/v/agentguard47)](https://pypi.org/project/agentguard47/)
 [![Downloads](https://img.shields.io/pypi/dm/agentguard47)](https://pypi.org/project/agentguard47/)

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -2,9 +2,11 @@
 
 # AgentGuard
 
-**Your coding agent just started looping through retries and shell calls. AgentGuard stops it before it burns budget.**
+**Your coding agent just started looping through retries and shell calls. AgentGuard stops it before it goes off the rails.**
 
-Local-first runtime guardrails for coding agents. Stop loops, retry storms, and budget burn with a zero-dependency Python SDK, then expose traces and incident context through MCP when your tooling needs read access.
+Local-first runtime governance for AI agents. Budget, loops, timeouts, rates — four static guards that stop an agent before it runs away, with a zero-dependency Python SDK. Traces and incident context exposed through MCP when your tooling needs read access.
+
+> When tokens cost 12 cents per million, the bottleneck isn't cost. It's control. AgentGuard is the governance layer that keeps agents inside the rails you set — no matter how cheap the tokens get.
 
 [![PyPI](https://img.shields.io/pypi/v/agentguard47)](https://pypi.org/project/agentguard47/)
 [![Downloads](https://img.shields.io/pypi/dm/agentguard47)](https://pypi.org/project/agentguard47/)


### PR DESCRIPTION
## Summary

- Reframe README hero + subtitle from "cost and safety guardrails" / "budget burn" to runtime governance framing
- Add a one-line callout tying the framing to the Blackwell token-deflation narrative ($0.12/1M tokens)
- Same four guards, same SDK — durability-of-framing update, not a behavior change

## Why

Token inference costs are dropping 35x with NVIDIA Blackwell vs Hopper. Cost-savings framing depreciates as tokens deflate; governance framing stays durable. The behavioral failure mode (runaway loops, retry storms) doesn't care about unit economics.

## Test plan

- [ ] Render README on GitHub to confirm formatting
- [ ] No code changes — docs-only, no CI impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)