### PR TITLE
chore(deps-dev): consolidate sdk optional dependency updates

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -56,9 +56,9 @@ Changelog = "https://github.com/bmdhodl/agent47/releases"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.3.84"]
-langgraph = ["langgraph>=0.1"]
+langgraph = ["langgraph>=0.6.11"]
 crewai = ["crewai>=0.28"]
-otel = ["opentelemetry-api>=1.41.0", "opentelemetry-sdk>=1.20"]
+otel = ["opentelemetry-api>=1.41.0", "opentelemetry-sdk>=1.41.0"]
 
 [project.scripts]
 agentguard = "agentguard.cli:main"


### PR DESCRIPTION
## Summary
- update optional LangGraph extra to langgraph>=0.6.11
- update optional OpenTelemetry SDK extra to opentelemetry-sdk>=1.41.0
- supersedes conflicting Dependabot PRs #338 and #339 after the other SDK dependency PRs merged

## Validation
- python -m pip install -e './sdk[langgraph,otel]' succeeded
- python -m pytest tests/test_langgraph_integration.py tests/test_otel_sink.py tests/test_quickstart.py: 36 passed

## Risk
- Core SDK remains zero-runtime-dependency; this only changes optional extras.