### PR TITLE
chore: guard pytest dependabot updates for py39 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
     directory: "/sdk"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/.github/requirements"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # pytest 9.x requires Python >=3.10. The SDK still promises and tests
+      # Python 3.9 support, so keep pytest on the latest compatible 8.x line
+      # until Python 3.9 support is intentionally retired.
+      - dependency-name: "pytest"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- add Dependabot coverage for the CI tools manifest under /.github/requirements
- ignore pytest semver-major updates there while the SDK still supports Python 3.9
- document the reason inline: pytest 9.x requires Python >=3.10, but AgentGuard currently promises Python 3.9+

## Validation
- parsed .github/dependabot.yml with PyYAML
- python -m pip install --dry-run --require-hashes -r .github/requirements/ci-tools.txt

## Risk
- Config-only change. Does not alter SDK runtime code, published package metadata, or CI tool pins.
- This preserves Python 3.9 compatibility instead of making a breaking support drop just to satisfy a CI-only test-tool alert.

Closes #367