### PR TITLE
Log queue README datapoint PR

### DIFF
--- a/inbox/log.md
+++ b/inbox/log.md
@@ -55,6 +55,18 @@
 ### Blockers
 - None.
 
+## 2026-05-01 | Codex
+
+### What shipped
+- Merged PR `#402` to add a sourced Uber AI-budget overrun datapoint to the README and generated PyPI README.
+- Captured docs validation proof under `proof/queue-uber-readme-2026-05-01/`.
+
+### Decisions made
+- Kept this as SDK positioning only: no runtime behavior changes, no dashboard work, and no unsupported claims beyond the cited Briefs report.
+
+### Blockers
+- None for the Uber README queue item.
+
 ## 2026-04-02 | Codex
 
 ### What shipped

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -3,6 +3,18 @@
 
 ---
 
+## 2026-05-01 | Codex
+
+### What shipped
+- Merged PR `#402` to add a sourced Uber AI-budget overrun datapoint to the README and generated PyPI README.
+- Captured docs validation proof under `proof/queue-uber-readme-2026-05-01/`.
+
+### Decisions made
+- Kept this as SDK positioning only: no runtime behavior changes, no dashboard work, and no unsupported claims beyond the cited Briefs report.
+
+### Blockers
+- None for the Uber README queue item.
+
 ## 2026-04-20 | Codex
 
 ### What shipped
@@ -54,18 +66,6 @@
 
 ### Blockers
 - None.
-
-## 2026-05-01 | Codex
-
-### What shipped
-- Merged PR `#402` to add a sourced Uber AI-budget overrun datapoint to the README and generated PyPI README.
-- Captured docs validation proof under `proof/queue-uber-readme-2026-05-01/`.
-
-### Decisions made
-- Kept this as SDK positioning only: no runtime behavior changes, no dashboard work, and no unsupported claims beyond the cited Briefs report.
-
-### Blockers
-- None for the Uber README queue item.
 
 ## 2026-04-02 | Codex
 


### PR DESCRIPTION
## Summary
- Adds the required concise inbox handoff after merged PR #402.

## Scope
- `inbox/log.md` only.
- No SDK behavior, docs copy, or package metadata changes.

## Validation
- `python scripts/sdk_release_guard.py`
- `git diff --check` -> only CRLF normalization warning