### PR TITLE
Refresh SDK ops docs

### DIFF
--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -4,11 +4,14 @@
 
 ## High-level shape
 
-AgentGuard has three repo-relevant product surfaces:
+This public repo has three shipped surfaces:
 
 1. A zero-dependency Python SDK that enforces runtime guardrails locally.
 2. A read-only MCP server that lets agent clients inspect retained AgentGuard data.
-3. A hosted dashboard, reached through `HttpSink`, that adds team visibility and control-plane features.
+3. A static public site under `site/`.
+
+The hosted dashboard is a separate private product surface. The SDK reaches it
+only through explicit hosted integration points such as `HttpSink`.
 
 The SDK must stand on its own. It should be usable offline, auditable from source, and credible in production even when the hosted dashboard is not configured.
 

--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -1,11 +1,14 @@
 # Architecture
 
+**Last reviewed:** 2026-05-02
+
 ## High-level shape
 
-AgentGuard has two product surfaces:
+AgentGuard has three repo-relevant product surfaces:
 
 1. A zero-dependency Python SDK that enforces runtime guardrails locally.
-2. A hosted dashboard, reached through `HttpSink`, that adds team visibility and control-plane features.
+2. A read-only MCP server that lets agent clients inspect retained AgentGuard data.
+3. A hosted dashboard, reached through `HttpSink`, that adds team visibility and control-plane features.
 
 The SDK must stand on its own. It should be usable offline, auditable from source, and credible in production even when the hosted dashboard is not configured.
 
@@ -23,6 +26,19 @@ Sinks:
   - HttpSink for hosted dashboard ingestion
   - OtelTraceSink for OpenTelemetry bridges
 ```
+
+Current boundary:
+
+- Local guards are authoritative for stopping agents in-process.
+- `HttpSink` mirrors supported trace and decision events to hosted ingest; it
+  does not poll or execute remote kill signals.
+- Decision traces are ordinary SDK events named `decision.proposed`,
+  `decision.edited`, `decision.overridden`, `decision.approved`, and
+  `decision.bound`.
+- The MCP server is read-only and exposes retained traces, decisions, alerts,
+  usage, costs, and budget health from the read API.
+- Dashboard code, billing, retained history, alerts, team workflows, and remote
+  control management stay outside this public SDK repo.
 
 ## Module dependency DAG
 
@@ -99,6 +115,19 @@ These modules improve the local SDK experience without blurring the hosted contr
 | `quickstart.py` | Prints framework-specific starter snippets for raw, OpenAI, Anthropic, LangChain, LangGraph, and CrewAI via `agentguard quickstart` |
 | `repo_config.py` | Loads the nearest repo-local `.agentguard.json` file so local defaults stay static, auditable, dashboard-free, and friendly to coding agents |
 
+## Local proof surfaces
+
+The SDK uses deterministic local proof before hosted adoption:
+
+- `agentguard doctor` verifies install and local trace writing.
+- `agentguard demo` proves budget, loop, and retry enforcement without network calls.
+- `agentguard quickstart` and `examples/starters/` provide minimal stack-specific starters.
+- `examples/coding_agent_review_loop.py` demonstrates a coding-agent review/refinement loop stopped by `BudgetGuard` and a patch retry storm stopped by `RetryGuard`.
+- `agentguard report` and `agentguard incident` turn local traces into readable proof artifacts.
+
+These proof surfaces should stay offline by default and must not require the
+hosted dashboard.
+
 ## Test layout
 
 The SDK test suite is intentionally layered:
@@ -107,6 +136,8 @@ The SDK test suite is intentionally layered:
 - Structural tests in `test_architecture.py` enforce the Golden Principles and import graph invariants.
 - Integration-style tests use the local ingest server in `tests/conftest.py` instead of depending on a hosted dashboard.
 - Production-shaped smoke and DX coverage live in `test_production.py`, `test_dx.py`, and the `e2e_*` files.
+- Example tests run deterministic local examples in temporary directories so onboarding proofs do not rot.
+- Hosted ingest contract tests assert dashboard-facing trace shape without requiring dashboard code in this repo.
 
 Pytest is configured with strict marker and strict config enforcement so stale test configuration fails fast instead of warning.
 

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -11,11 +11,13 @@ they directly strengthen coding-agent adoption.
   hardening and activation, not a new feature push.
 - Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`;
   keep MCP narrow and read-only while Glama remains blocked.
-- Dashboard alignment is current for hosted ingest, decision traces, and the
-  remote-kill boundary: the SDK emits events and enforces local guards, while
-  the dashboard owns retained history, alerts, and team operations.
-- The strongest local proof path is now `doctor` -> `demo` -> `quickstart` /
-  starters plus the coding-agent review-loop proof.
+- Dashboard alignment is current for hosted ingest and decision traces. The
+  remote-kill boundary is documented: the SDK emits events and enforces local
+  guards, while the dashboard owns retained history, alerts, and team
+  operations.
+- The strongest package-installed proof path is `doctor` -> `demo` ->
+  `quickstart`; repo checkouts also have starters and the coding-agent
+  review-loop proof.
 
 ## Recently Completed
 
@@ -38,7 +40,7 @@ they directly strengthen coding-agent adoption.
 | Coding-agent skillpack generation | Done - `agentguard skillpack` now generates `.agentguard.json` plus repo-local instructions for Codex, Claude Code, Copilot, and Cursor so coding-agent onboarding no longer depends on manual snippet copying |
 | Managed-agent session correlation | Done - `session_id` now lets disposable harnesses or short-lived workers emit separate traces that still roll up under one higher-level local session for coding-agent and managed-agent runtimes |
 | Budget-aware escalation guard | Done - `BudgetAwareEscalation` now lets apps keep a cheaper default model and escalate hard turns using token, confidence, tool-depth, or custom-rule signals without provider-specific SDK routing |
-| Dashboard contract alignment for v1.2.9 | Done - hosted ingest shape, decision-trace defaults, and remote-kill boundaries are documented and covered by tests |
+| Dashboard contract alignment for v1.2.9 | Done - hosted ingest shape and decision-trace defaults are documented and covered by tests; remote-kill boundaries are documented |
 | Coding-agent review-loop proof | Done - `examples/coding_agent_review_loop.py` demonstrates local budget and retry stops for review/refinement loops without API keys or network calls |
 | Follow-up handoff | Done - `FOLLOWUP.md` records next hygiene and activation-metrics work without burying it in PR notes |
 
@@ -46,7 +48,7 @@ they directly strengthen coding-agent adoption.
 
 | Item | Success Signal |
 |------|---------------|
-| Activation proof polish | A fresh local flow from `pip install` to `agentguard doctor`, `agentguard demo`, `agentguard quickstart`, starter runs, and `examples/coding_agent_review_loop.py` stays deterministic, offline, and easy to copy into real repos |
+| Activation proof polish | A fresh local flow from `pip install` to `agentguard doctor`, `agentguard demo`, and `agentguard quickstart` stays deterministic; repo-only examples and starters remain offline and easy to copy into real repos |
 | MCP distribution hygiene | Official MCP Registry metadata remains current; Glama and `awesome-mcp-servers` stay tracked without building unrelated features to route around the blocker |
 | Dashboard contract drift checks | Hosted ingest, decision-trace event names, required fields, and remote-kill boundaries remain documented and covered by tests before any release |
 | Ops/doc freshness | `ops/02-ARCHITECTURE.md`, this roadmap, `FOLLOWUP.md`, and memory files stay concise and current enough that agents do not start from stale assumptions |

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,6 +3,20 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
+**Last reviewed:** 2026-05-02
+
+## Current Focus Notes
+
+- Latest shipped SDK release is `v1.2.9`; current work is post-release
+  hardening and activation, not a new feature push.
+- Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`;
+  keep MCP narrow and read-only while Glama remains blocked.
+- Dashboard alignment is current for hosted ingest, decision traces, and the
+  remote-kill boundary: the SDK emits events and enforces local guards, while
+  the dashboard owns retained history, alerts, and team operations.
+- The strongest local proof path is now `doctor` -> `demo` -> `quickstart` /
+  starters plus the coding-agent review-loop proof.
+
 ## Recently Completed
 
 | Item | Status |
@@ -24,15 +38,18 @@ they directly strengthen coding-agent adoption.
 | Coding-agent skillpack generation | Done - `agentguard skillpack` now generates `.agentguard.json` plus repo-local instructions for Codex, Claude Code, Copilot, and Cursor so coding-agent onboarding no longer depends on manual snippet copying |
 | Managed-agent session correlation | Done - `session_id` now lets disposable harnesses or short-lived workers emit separate traces that still roll up under one higher-level local session for coding-agent and managed-agent runtimes |
 | Budget-aware escalation guard | Done - `BudgetAwareEscalation` now lets apps keep a cheaper default model and escalate hard turns using token, confidence, tool-depth, or custom-rule signals without provider-specific SDK routing |
+| Dashboard contract alignment for v1.2.9 | Done - hosted ingest shape, decision-trace defaults, and remote-kill boundaries are documented and covered by tests |
+| Coding-agent review-loop proof | Done - `examples/coding_agent_review_loop.py` demonstrates local budget and retry stops for review/refinement loops without API keys or network calls |
+| Follow-up handoff | Done - `FOLLOWUP.md` records next hygiene and activation-metrics work without burying it in PR notes |
 
 ## Now (next 2 weeks)
 
 | Item | Success Signal |
 |------|---------------|
-| Coding-agent positioning and package metadata hardening | PyPI metadata, SDK README, and generated PyPI README all consistently position AgentGuard as zero-dependency runtime guardrails for coding-agent safety |
-| MCP registry readiness | `mcp-server` package metadata and `server.json` are ready for official MCP registry publication without extra repo cleanup |
-| Install-to-first-guard proof hardening | A fresh local flow from `pip install` to `agentguard doctor`, `agentguard demo`, `agentguard quickstart`, and a starter run works without undocumented steps or hosted assumptions |
-| Coding-agent starter polish | Checked-in starter files and repo-local `.agentguard.json` guidance stay deterministic, local-first, and safe to copy into real repos without hidden network behavior |
+| Activation proof polish | A fresh local flow from `pip install` to `agentguard doctor`, `agentguard demo`, `agentguard quickstart`, starter runs, and `examples/coding_agent_review_loop.py` stays deterministic, offline, and easy to copy into real repos |
+| MCP distribution hygiene | Official MCP Registry metadata remains current; Glama and `awesome-mcp-servers` stay tracked without building unrelated features to route around the blocker |
+| Dashboard contract drift checks | Hosted ingest, decision-trace event names, required fields, and remote-kill boundaries remain documented and covered by tests before any release |
+| Ops/doc freshness | `ops/02-ARCHITECTURE.md`, this roadmap, `FOLLOWUP.md`, and memory files stay concise and current enough that agents do not start from stale assumptions |
 
 ## Next (next month)
 
@@ -41,6 +58,7 @@ they directly strengthen coding-agent adoption.
 | Streaming support in patches | `patch_openai` / `patch_anthropic` capture streamed responses without losing final token and cost totals |
 | Coding-agent profile v2 | Built-in coding-agent defaults cover streamed calls, fuzzy loop patterns, and stronger repo-local safety without increasing setup complexity |
 | Cost model alias cleanup | Common provider aliases map cleanly onto canonical model pricing entries without warning spam |
+| Opt-in activation metrics design | A short design explains what, if anything, could be measured without default telemetry, payload capture, or local-only privacy drift |
 
 ## Later (ideas bucket)
 


### PR DESCRIPTION
## Summary
- refresh stale roadmap and architecture docs for current SDK state
- record v1.2.9, official MCP registry listing, dashboard contract alignment, decision traces, and local review-loop proof
- keep scope docs-only and SDK-only

Closes #382.

## Validation
- `python scripts/sdk_preflight.py`
- `python scripts/sdk_release_guard.py`
- `git diff --check`

Note: Windows shell reports LF/CRLF working-copy warnings only.