### PR TITLE
Log PR 406 and update follow-up

### DIFF
--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -3,9 +3,8 @@
 ## From PR #404
 
 1. Refresh stale roadmap and architecture docs in a separate hygiene PR.
-   - `ops/03-ROADMAP_NOW_NEXT_LATER.md` was 2 weeks old during the PR.
-   - `ops/02-ARCHITECTURE.md` was 3 weeks old during the PR.
-   - Keep this as repo hygiene; do not turn it into feature expansion.
+   - Done in PR `#406`.
+   - Keep future ops-doc updates concise and SDK-only.
 
 2. Design opt-in activation metrics before adding any telemetry.
    - No default SDK telemetry.
@@ -19,6 +18,7 @@
 
 ## Next Recommended PR
 
-Refresh the stale roadmap and architecture docs so they match the current
-runtime-control positioning, v1.2.9 package state, MCP listing state, and recent
-local-proof additions.
+Write a short opt-in activation metrics design note. Do not implement telemetry
+yet. The design should define what would be useful to measure, what must never
+be collected, where consent would be explicit, and how this stays compatible
+with the SDK's zero-dependency, local-first promise.

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -164,4 +164,3 @@
 
 ### Blockers
 - None.
-

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -148,3 +148,19 @@
 
 ### Blockers
 - None.
+
+## 2026-05-02 | Codex
+
+### What shipped
+- Merged PR `#406` to refresh stale SDK roadmap and architecture docs.
+- Updated current focus around `v1.2.9`, official MCP Registry listing,
+  dashboard contract boundaries, decision traces, and local proof surfaces.
+
+### Decisions made
+- Keep ops docs SDK-only and concise.
+- Treat remote kill as a documented dashboard boundary, not an SDK behavior
+  claim.
+- Keep repo-only examples distinct from package-installed CLI proof paths.
+
+### Blockers
+- None.

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -3,6 +3,38 @@
 
 ---
 
+## 2026-05-02 | Codex
+
+### What shipped
+- Merged PR `#406` to refresh stale SDK roadmap and architecture docs.
+- Updated current focus around `v1.2.9`, official MCP Registry listing,
+  dashboard contract boundaries, decision traces, and local proof surfaces.
+
+### Decisions made
+- Keep ops docs SDK-only and concise.
+- Treat remote kill as a documented dashboard boundary, not an SDK behavior
+  claim.
+- Keep repo-only examples distinct from package-installed CLI proof paths.
+
+### Blockers
+- None.
+
+## 2026-05-02 | Codex
+
+### What shipped
+- Merged PR `#404` to add a local coding-agent review-loop proof.
+- Added `examples/coding_agent_review_loop.py`, docs links, PyPI README sync,
+  focused regression coverage, proof artifacts, and `FOLLOWUP.md`.
+
+### Decisions made
+- Keep activation work focused on local runtime proof: budget stops, retry
+  stops, and incident reports.
+- Defer stale roadmap/architecture refresh and opt-in activation metrics design
+  to follow-up work.
+
+### Blockers
+- None.
+
 ## 2026-05-01 | Codex
 
 ### What shipped
@@ -133,34 +165,3 @@
 ### Blockers
 - None.
 
-## 2026-05-02 | Codex
-
-### What shipped
-- Merged PR `#404` to add a local coding-agent review-loop proof.
-- Added `examples/coding_agent_review_loop.py`, docs links, PyPI README sync,
-  focused regression coverage, proof artifacts, and `FOLLOWUP.md`.
-
-### Decisions made
-- Keep activation work focused on local runtime proof: budget stops, retry
-  stops, and incident reports.
-- Defer stale roadmap/architecture refresh and opt-in activation metrics design
-  to follow-up work.
-
-### Blockers
-- None.
-
-## 2026-05-02 | Codex
-
-### What shipped
-- Merged PR `#406` to refresh stale SDK roadmap and architecture docs.
-- Updated current focus around `v1.2.9`, official MCP Registry listing,
-  dashboard contract boundaries, decision traces, and local proof surfaces.
-
-### Decisions made
-- Keep ops docs SDK-only and concise.
-- Treat remote kill as a documented dashboard boundary, not an SDK behavior
-  claim.
-- Keep repo-only examples distinct from package-installed CLI proof paths.
-
-### Blockers
-- None.


### PR DESCRIPTION
## Summary
- add required inbox handoff for merged PR #406
- mark stale ops-doc refresh complete in FOLLOWUP.md
- tee up the next shot: opt-in activation metrics design, not telemetry implementation

## Validation
- `python scripts/sdk_preflight.py`
- `git diff --check`