### PR TITLE
fix: skip release discussion when categories unavailable

### DIFF
--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -61,15 +61,21 @@ jobs:
 
           REPOSITORY_ID="$(gh api repos/bmdhodl/agent47 --jq '.node_id')"
           CATEGORY_ID=""
+          CATEGORY_ERR_FILE="$(mktemp)"
           if CATEGORY_ID="$(
             gh api repos/bmdhodl/agent47/discussions/categories \
               --jq 'if type == "array" then .[] | select(.name=="Announcements") | .node_id else empty end' \
-              2>/dev/null
+              2>"$CATEGORY_ERR_FILE"
           )"; then
             CATEGORY_ID="$(printf '%s' "$CATEGORY_ID" | tr -d '\r')"
-          else
+          elif grep -q 'HTTP 404' "$CATEGORY_ERR_FILE"; then
             CATEGORY_ID=""
+          else
+            cat "$CATEGORY_ERR_FILE" >&2
+            rm -f "$CATEGORY_ERR_FILE"
+            exit 1
           fi
+          rm -f "$CATEGORY_ERR_FILE"
 
           if [ -z "$CATEGORY_ID" ] || [ "$CATEGORY_ID" = "null" ]; then
             echo "Discussion creation skipped (Discussions disabled or Announcements category missing)"

--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -60,10 +60,19 @@ jobs:
           } > "$BODY_FILE"
 
           REPOSITORY_ID="$(gh api repos/bmdhodl/agent47 --jq '.node_id')"
-          CATEGORY_ID="$(gh api repos/bmdhodl/agent47/discussions/categories --jq '.[] | select(.name=="Announcements") | .node_id' 2>/dev/null || true)"
+          CATEGORY_ID=""
+          if CATEGORY_ID="$(
+            gh api repos/bmdhodl/agent47/discussions/categories \
+              --jq 'if type == "array" then .[] | select(.name=="Announcements") | .node_id else empty end' \
+              2>/dev/null
+          )"; then
+            CATEGORY_ID="$(printf '%s' "$CATEGORY_ID" | tr -d '\r')"
+          else
+            CATEGORY_ID=""
+          fi
 
-          if [ -z "$CATEGORY_ID" ]; then
-            echo "Discussion creation skipped (no Announcements category)"
+          if [ -z "$CATEGORY_ID" ] || [ "$CATEGORY_ID" = "null" ]; then
+            echo "Discussion creation skipped (Discussions disabled or Announcements category missing)"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- guard the Discussions category lookup so a failing REST call does not feed a 404 JSON payload into `createDiscussion`
- skip cleanly when Discussions are disabled or the `Announcements` category is missing
- keep release tag pushes green without changing SDK/runtime behavior

## Why
Issue #392 reports that `Release Content � Auto-generate announcements` fails after successful publishes when GitHub Discussions are unavailable. The existing `gh api ... || true` pattern still captures the 404 body on stdout, so the workflow mistakenly treats it as a category id.

Closes #392.

## Proof
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py`
- `python -m pytest sdk/tests/test_architecture.py -v`
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `npm --prefix mcp-server ci`
- `npm --prefix mcp-server test`
- local bash check against current repo state returned `skip`
- local positive-path simulation returned `found:ANN123`



## Operator update

### User impact
- Release announcements still skip cleanly when Discussions are disabled or the Announcements category is missing.
- Unexpected GitHub API failures now fail the workflow instead of silently dropping the announcement.

### Validation
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py`
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`
- `python -m pytest sdk/tests/test_architecture.py -v`
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `npm --prefix mcp-server ci`
- `npm --prefix mcp-server test`
- Local branch-logic simulation confirmed: success returns category id, 404 skips, 403 stays failing.
- GitHub PR CI and CodeQL reruns are green after commit `405272e`.

### Risk
- Low. Scope is limited to one workflow branch condition in `.github/workflows/release-content.yml`.

### Rollback
- Revert commit `405272e` on `codex/fix-release-content-discussion-skip`.
