### PR TITLE
Handle missing release discussion category

### DIFF
--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -60,9 +60,15 @@ jobs:
           } > "$BODY_FILE"
 
           REPOSITORY_ID="$(gh api repos/bmdhodl/agent47 --jq '.node_id')"
-          CATEGORY_ID="$(gh api repos/bmdhodl/agent47/discussions/categories --jq '.[] | select(.name=="Announcements") | .node_id' 2>/dev/null || true)"
+          CATEGORY_FILE="$(mktemp)"
+          trap 'rm -f "$BODY_FILE" "$CATEGORY_FILE"' EXIT
 
-          if [ -z "$CATEGORY_ID" ]; then
+          if ! gh api repos/bmdhodl/agent47/discussions/categories > "$CATEGORY_FILE" 2>/dev/null; then
+            echo "Discussion creation skipped (categories unavailable or Discussions disabled)"
+            exit 0
+          fi
+
+          if ! CATEGORY_ID="$(python scripts/resolve_discussion_category.py < "$CATEGORY_FILE")"; then
             echo "Discussion creation skipped (no Announcements category)"
             exit 0
           fi

--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -44,7 +44,8 @@ jobs:
           PREV_TAG: ${{ steps.release.outputs.prev_tag }}
         run: |
           BODY_FILE="$(mktemp)"
-          trap 'rm -f "$BODY_FILE"' EXIT
+          CATEGORY_FILE="$(mktemp)"
+          trap 'rm -f "$BODY_FILE" "$CATEGORY_FILE"' EXIT
 
           {
             printf '## AgentGuard %s Released\n\n' "$TAG"
@@ -60,8 +61,6 @@ jobs:
           } > "$BODY_FILE"
 
           REPOSITORY_ID="$(gh api repos/bmdhodl/agent47 --jq '.node_id')"
-          CATEGORY_FILE="$(mktemp)"
-          trap 'rm -f "$BODY_FILE" "$CATEGORY_FILE"' EXIT
 
           if ! gh api repos/bmdhodl/agent47/discussions/categories > "$CATEGORY_FILE" 2>/dev/null; then
             echo "Discussion creation skipped (categories unavailable or Discussions disabled)"

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -6,6 +6,20 @@
 ## 2026-05-02 | Codex
 
 ### What shipped
+- Merged PR `#408` to add a docs-only opt-in activation metrics design.
+- Documented allowed questions, explicit consent boundaries, forbidden fields,
+  zero-dependency transport constraints, and no-default-telemetry non-goals.
+
+### Decisions made
+- Keep SDK activation metrics as design-only unless explicitly approved later.
+- Prefer server-side/package metrics before any local SDK telemetry.
+
+### Blockers
+- None.
+
+## 2026-05-02 | Codex
+
+### What shipped
 - Merged PR `#406` to refresh stale SDK roadmap and architecture docs.
 - Updated current focus around `v1.2.9`, official MCP Registry listing,
   dashboard contract boundaries, decision traces, and local proof surfaces.

--- a/proof/release-discussion-skip-2026-05-02/VALIDATION.md
+++ b/proof/release-discussion-skip-2026-05-02/VALIDATION.md
@@ -1,0 +1,58 @@
+# Release Discussion Skip Validation
+
+Issue: `#392`
+
+## What changed
+
+- `.github/workflows/release-content.yml` now skips discussion creation when
+  the Discussions categories endpoint is unavailable.
+- `scripts/resolve_discussion_category.py` accepts only the expected GitHub
+  category-list JSON shape and a non-empty `node_id`.
+- `sdk/tests/test_release_discussion_category.py` covers valid category lookup,
+  GitHub `404` error payloads, blank IDs, and CLI behavior.
+
+## Commands run
+
+```text
+python -m pytest sdk\tests\test_release_discussion_category.py -v
+5 passed
+
+python scripts\sdk_preflight.py
+All checks passed!
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+git diff --check
+passed
+
+python -m pytest sdk\tests --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+699 passed, coverage 92.88%
+
+python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/resolve_discussion_category.py sdk/tests/test_release_discussion_category.py
+All checks passed!
+
+python -m pytest sdk\tests\test_architecture.py -v
+9 passed
+
+npm --prefix mcp-server test
+5 passed
+
+python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
+passed
+```
+
+## Manual probes
+
+```text
+'[{"name":"Announcements","node_id":"DIC_ok"}]' | python scripts\resolve_discussion_category.py
+DIC_ok
+
+'{"message":"Not Found","status":"404"}' | python scripts\resolve_discussion_category.py
+skip path returned nonzero as expected
+```
+
+## Known validation note
+
+`make` is not installed in this Windows shell, so the equivalent direct commands
+were run instead.

--- a/scripts/resolve_discussion_category.py
+++ b/scripts/resolve_discussion_category.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Resolve a GitHub Discussions category node_id from API JSON.
+
+The GitHub REST endpoint can return an error object when Discussions are
+disabled or unavailable. This helper accepts only the expected category list
+shape so release announcement automation can skip safely instead of sending a
+bad GraphQL mutation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Optional
+
+
+def extract_category_node_id(payload: Any, category_name: str) -> Optional[str]:
+    """Return a non-empty node_id for category_name, or None if unavailable."""
+    if not isinstance(payload, list):
+        return None
+
+    for category in payload:
+        if not isinstance(category, dict):
+            continue
+        if category.get("name") != category_name:
+            continue
+        node_id = category.get("node_id")
+        if isinstance(node_id, str) and node_id.strip():
+            return node_id
+    return None
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--category", default="Announcements")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 1
+
+    node_id = extract_category_node_id(payload, args.category)
+    if not node_id:
+        return 1
+
+    print(node_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/tests/test_release_discussion_category.py
+++ b/sdk/tests/test_release_discussion_category.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+_SCRIPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+_SCRIPT_PATH = _SCRIPTS_DIR / "resolve_discussion_category.py"
+_SPEC = importlib.util.spec_from_file_location("resolve_discussion_category", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+resolve_discussion_category = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = resolve_discussion_category
+_SPEC.loader.exec_module(resolve_discussion_category)
+
+
+class TestDiscussionCategoryResolution(unittest.TestCase):
+    def test_extracts_matching_category_node_id(self):
+        payload = [
+            {"name": "General", "node_id": "DIC_general"},
+            {"name": "Announcements", "node_id": "DIC_announcements"},
+        ]
+
+        self.assertEqual(
+            resolve_discussion_category.extract_category_node_id(payload, "Announcements"),
+            "DIC_announcements",
+        )
+
+    def test_rejects_github_error_object(self):
+        payload = {
+            "message": "Not Found",
+            "documentation_url": "https://docs.github.com/rest",
+            "status": "404",
+        }
+
+        self.assertIsNone(
+            resolve_discussion_category.extract_category_node_id(payload, "Announcements")
+        )
+
+    def test_rejects_missing_or_blank_node_id(self):
+        payload = [
+            {"name": "Announcements", "node_id": ""},
+            {"name": "Announcements"},
+        ]
+
+        self.assertIsNone(
+            resolve_discussion_category.extract_category_node_id(payload, "Announcements")
+        )
+
+    def test_cli_prints_node_id_for_valid_category(self):
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT_PATH)],
+            input=json.dumps([{"name": "Announcements", "node_id": "DIC_ok"}]),
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+
+        self.assertEqual(result.stdout.strip(), "DIC_ok")
+
+    def test_cli_exits_nonzero_for_error_payload(self):
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT_PATH)],
+            input=json.dumps({"message": "Not Found", "status": "404"}),
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")


### PR DESCRIPTION
## Summary
- Fixes #392 by making release discussion creation skip safely when Discussions categories are unavailable or the Announcements category is missing.
- Adds a stdlib-only category resolver that rejects GitHub error payloads and blank node IDs before GraphQL `createDiscussion` runs.
- Records the merged PR #408 inbox handoff.

## Risk
- Low. Release announcement generation only; no SDK runtime, package metadata, dashboard, or publish auth behavior changed.
- If the resolver cannot parse a valid category response, the workflow skips discussion creation instead of failing release-adjacent automation.

## Rollback
- Revert this PR to restore the previous inline `gh api --jq` category lookup.

## Validation
- `python -m pytest sdk\tests\test_release_discussion_category.py -v` -> 5 passed
- `python scripts\sdk_preflight.py` -> All checks passed
- `python scripts\sdk_release_guard.py` -> Release guard passed
- `git diff --check` -> passed
- `python -m pytest sdk\tests --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 699 passed, 92.88% coverage
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/resolve_discussion_category.py sdk/tests/test_release_discussion_category.py` -> passed
- `python -m pytest sdk\tests\test_architecture.py -v` -> 9 passed
- `npm --prefix mcp-server test` -> 5 passed
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q` -> passed

Proof artifact: `proof/release-discussion-skip-2026-05-02/VALIDATION.md`