### PR TITLE
Clear completed follow-up queue

### DIFF
--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -1,23 +1,13 @@
 # Follow-up
 
-## From PR #404
+No active SDK follow-up items.
 
-1. Refresh stale roadmap and architecture docs in a separate hygiene PR.
-   - Done in PR `#406`.
-   - Keep future ops-doc updates concise and SDK-only.
+Completed follow-ups from PR `#404`:
 
-2. Design opt-in activation metrics before adding any telemetry.
-   - Done in `docs/guides/activation-metrics-design.md`.
-   - No default SDK telemetry.
-   - Keep local-only usage private by default.
+- PR `#406` refreshed stale roadmap and architecture docs.
+- PR `#408` added the docs-only opt-in activation metrics design.
+- PR `#412` fixed release announcement reliability for missing GitHub
+  Discussions categories.
 
-3. Keep future demos focused on the strongest SDK wedge.
-   - Local proof first.
-   - Budget stops, loop stops, retry stops, incident reports.
-   - Avoid drifting into broad observability, static scanning, or dashboard-only claims.
-
-## Next Recommended PR
-
-Reassess the remaining open issues and pick the next smallest SDK-only unblocker.
-Prefer issue `#392` if release announcement reliability still matters, or leave
-deferred security/governance issues alone until their phase-2 blockers clear.
+Deferred GitHub issues remain tracked in GitHub, not here, so this file stays a
+short active queue instead of a duplicate backlog.

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -1,13 +1,3 @@
 # Follow-up
 
 No active SDK follow-up items.
-
-Completed follow-ups from PR `#404`:
-
-- PR `#406` refreshed stale roadmap and architecture docs.
-- PR `#408` added the docs-only opt-in activation metrics design.
-- PR `#412` fixed release announcement reliability for missing GitHub
-  Discussions categories.
-
-Deferred GitHub issues remain tracked in GitHub, not here, so this file stays a
-short active queue instead of a duplicate backlog.

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -6,6 +6,21 @@
 ## 2026-05-02 | Codex
 
 ### What shipped
+- Merged PR `#412` to make release announcement discussion creation skip safely
+  when GitHub Discussions categories are unavailable.
+- Closed issue `#392`; release-adjacent automation no longer fails on missing
+  Discussions configuration.
+
+### Decisions made
+- Keep deferred phase-2 governance/security issues tracked in GitHub instead of
+  duplicating them in `FOLLOWUP.md`.
+
+### Blockers
+- `#282` and `#279` remain intentionally deferred phase-2 work.
+
+## 2026-05-02 | Codex
+
+### What shipped
 - Merged PR `#408` to add a docs-only opt-in activation metrics design.
 - Documented allowed questions, explicit consent boundaries, forbidden fields,
   zero-dependency transport constraints, and no-default-telemetry non-goals.


### PR DESCRIPTION
## Summary
- Clears completed `FOLLOWUP.md` items now that PRs #406, #408, and #412 have shipped.
- Adds the required merged-PR inbox handoff for PR #412.
- Keeps deferred phase-2 governance/security issues in GitHub only so `FOLLOWUP.md` remains an active queue, not a duplicate backlog.

## Risk
- Low. Docs/handoff only; no SDK runtime, MCP, release workflow, or package behavior changes.

## Rollback
- Revert this PR to restore the prior follow-up wording.

## Validation
- `python scripts\sdk_preflight.py` -> no SDK-relevant changes detected
- `python scripts\sdk_release_guard.py` -> Release guard passed
- `git diff --check` -> passed