### PR TITLE
Tighten activation proof path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,38 @@ agentguard quickstart --framework raw
 and retry protection offline. `quickstart` prints the smallest starter for the
 stack you actually use.
 
+First value moment: you should see `BudgetGuard`, `LoopGuard`, and
+`RetryGuard` stop simulated runaway behavior before you wire a real provider or
+share any data.
+
+## Copy-paste safe repo setup
+
+Use this when you want a coding agent or teammate to add AgentGuard to a repo
+without hidden network behavior:
+
+```bash
+pip install agentguard47
+agentguard doctor
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
+```
+
+Optional shared local defaults:
+
+```json
+{
+  "profile": "coding-agent",
+  "service": "my-agent",
+  "trace_file": ".agentguard/traces.jsonl",
+  "budget_usd": 5.0
+}
+```
+
+Keep the first PR local-only. No API keys, no dashboard settings, no hosted
+sink. Add `HttpSink` later only when retained incidents, alerts, or team
+visibility are needed.
+
 ## Wrap one agent run
 
 ```python
@@ -319,6 +351,9 @@ retry storm gets stopped:
 python examples/coding_agent_review_loop.py
 agentguard incident coding_agent_review_loop_traces.jsonl
 ```
+
+Sample output:
+[`docs/examples/coding-agent-review-loop-incident.md`](docs/examples/coding-agent-review-loop-incident.md)
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/main/examples/quickstart.ipynb)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python agentguard_raw_quickstart.py
 agentguard report .agentguard/traces.jsonl
 ```
 
-Optional shared local defaults:
+Optional shared local defaults, saved as `.agentguard.json` in the repo root:
 
 ```json
 {

--- a/docs/examples/coding-agent-review-loop-incident.md
+++ b/docs/examples/coding-agent-review-loop-incident.md
@@ -1,4 +1,4 @@
-﻿# AgentGuard Incident Report
+# AgentGuard Incident Report
 
 Status: **incident**
 Severity: **critical**
@@ -9,7 +9,7 @@ Primary cause: **retry_limit_exceeded**
 - Total events: 14
 - Spans: 4
 - Events: 9
-- Duration: 1.5 ms
+- Duration: 1.7 ms
 - Estimated cost: $0.1020
 - Guard events: 2
 - Errors: 0
@@ -34,12 +34,12 @@ Primary cause: **retry_limit_exceeded**
 
 - Add exponential backoff or a deterministic fallback before retrying the same tool.
 - Treat repeated upstream failures as a stop condition instead of widening the retry ceiling.
-- Connect HttpSink to the hosted dashboard for retained alerts and remote kill switch.
+- Connect HttpSink to the hosted dashboard for retained alerts and remote control follow-up.
 - Review the trace timeline to confirm the failure path before widening limits.
 
 ## Upgrade Path
 
-Move from one-off local reports to retained alerts, spend history, and remote kill switch:
+Move from one-off local reports to retained alerts, spend history, and team-visible follow-up:
 
 ```python
 from agentguard import Tracer, HttpSink

--- a/docs/examples/coding-agent-review-loop-incident.md
+++ b/docs/examples/coding-agent-review-loop-incident.md
@@ -1,0 +1,48 @@
+﻿# AgentGuard Incident Report
+
+Status: **incident**
+Severity: **critical**
+Primary cause: **retry_limit_exceeded**
+
+## Summary
+
+- Total events: 14
+- Spans: 4
+- Events: 9
+- Duration: 1.5 ms
+- Estimated cost: $0.1020
+- Guard events: 2
+- Errors: 0
+- Exact savings: $0.0000
+- Estimated savings: $0.0205
+
+## Savings Ledger
+
+- Exact tokens saved: 0
+- Estimated tokens saved: 0
+- Exact dollars saved: $0.0000
+- Estimated dollars saved: $0.0205
+- Savings reasons:
+  - `budget_overrun_stopped` (estimated): 0 tokens / $0.0205 across 1 occurrence(s)
+
+## Guard Events
+
+- `guard.budget_exceeded` (critical)
+- `guard.retry_limit_exceeded` (critical)
+
+## Recommended Next Steps
+
+- Add exponential backoff or a deterministic fallback before retrying the same tool.
+- Treat repeated upstream failures as a stop condition instead of widening the retry ceiling.
+- Connect HttpSink to the hosted dashboard for retained alerts and remote kill switch.
+- Review the trace timeline to confirm the failure path before widening limits.
+
+## Upgrade Path
+
+Move from one-off local reports to retained alerts, spend history, and remote kill switch:
+
+```python
+from agentguard import Tracer, HttpSink
+
+tracer = Tracer(sink=HttpSink(url="https://app.agentguard47.com/api/ingest", api_key="ag_..."))
+```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,6 +10,22 @@ pip install agentguard47
 
 Zero dependencies. Python 3.9+.
 
+## Fastest safe activation path
+
+Copy-paste this when you want the shortest local proof before touching a real
+agent or provider key:
+
+```bash
+agentguard doctor
+agentguard demo
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
+```
+
+This path proves local trace writing, budget stops, loop stops, retry stops,
+and a runnable starter file without any network calls.
+
 ## Verify the install
 
 Start with a local verification pass:
@@ -115,7 +131,8 @@ agentguard incident coding_agent_review_loop_traces.jsonl
 
 This simulates repeated review/edit attempts and a stuck patch retry storm. It
 uses `BudgetGuard` and `RetryGuard`, writes a local JSONL trace, and still makes
-no network calls.
+no network calls. A checked-in sample incident is available at
+[`../examples/coding-agent-review-loop-incident.md`](../examples/coding-agent-review-loop-incident.md).
 
 If your agent runtime uses disposable workers or managed-agent harnesses, add a
 runtime `session_id` to correlate those short-lived traces:

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,9 @@ python examples/cost_guardrail.py
 python examples/openai_agents_with_guards.py
 ```
 
+Sample incident output from a clean coding-agent review-loop run:
+[`docs/examples/coding-agent-review-loop-incident.md`](../docs/examples/coding-agent-review-loop-incident.md)
+
 Each example writes traces to a local JSONL file. To send traces to the hosted dashboard instead, replace `JsonlFileSink` with `HttpSink`:
 
 ```python

--- a/proof/activation-improvements-2026-05-02/VALIDATION.md
+++ b/proof/activation-improvements-2026-05-02/VALIDATION.md
@@ -1,0 +1,65 @@
+# Activation Improvements Validation
+
+## Scope
+
+Docs and proof assets only:
+
+- README first-run activation path
+- Getting-started copy-paste setup flow
+- Coding-agent review-loop sample incident
+- PyPI README sync for the README changes
+
+## Commands run
+
+```text
+python scripts\generate_pypi_readme.py --check
+passed
+
+python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_example_starters.py sdk\tests\test_quickstart.py -v
+22 passed
+
+python scripts\sdk_preflight.py
+All checks passed
+
+python scripts\sdk_release_guard.py
+Release guard passed
+
+python -m ruff check scripts\generate_pypi_readme.py
+All checks passed
+
+python -m pytest sdk\tests\test_sdk_release_guard.py -v
+6 passed
+
+git diff --check
+passed
+```
+
+## Manual activation proof
+
+Executed in a temporary directory with `PYTHONPATH` pointed at this checkout:
+
+```text
+python -m agentguard.cli doctor --trace-file doctor.jsonl
+python -m agentguard.cli demo --trace-file demo.jsonl
+python -m agentguard.cli quickstart --framework raw --write --output agentguard_raw_quickstart.py
+python agentguard_raw_quickstart.py
+python -m agentguard.cli report .agentguard\traces.jsonl
+```
+
+Observed:
+
+- `doctor` completed and printed safe local next steps.
+- `demo` showed BudgetGuard, LoopGuard, and RetryGuard stops without network calls.
+- `quickstart --write` created a runnable raw starter.
+- The starter wrote `.agentguard/traces.jsonl`.
+- `report` rendered a local trace summary.
+
+## Generated proof asset
+
+`docs/examples/coding-agent-review-loop-incident.md` was generated from a clean
+run of:
+
+```text
+python examples\coding_agent_review_loop.py
+python -m agentguard.cli incident coding_agent_review_loop_traces.jsonl --format markdown
+```

--- a/proof/activation-improvements-2026-05-02/VALIDATION.md
+++ b/proof/activation-improvements-2026-05-02/VALIDATION.md
@@ -36,9 +36,11 @@ passed
 
 ## Manual activation proof
 
-Executed in a temporary directory with `PYTHONPATH` pointed at this checkout:
+Executed in a temporary directory with `PYTHONPATH` pointed at this checkout.
+On Windows PowerShell:
 
 ```text
+$env:PYTHONPATH="C:\Users\patri\.codex\worktrees\3c4e\agent47\sdk"
 python -m agentguard.cli doctor --trace-file doctor.jsonl
 python -m agentguard.cli demo --trace-file demo.jsonl
 python -m agentguard.cli quickstart --framework raw --write --output agentguard_raw_quickstart.py
@@ -60,6 +62,32 @@ Observed:
 run of:
 
 ```text
+$env:PYTHONPATH="C:\Users\patri\.codex\worktrees\3c4e\agent47\sdk"
 python examples\coding_agent_review_loop.py
 python -m agentguard.cli incident coding_agent_review_loop_traces.jsonl --format markdown
+```
+
+## Review follow-up validation
+
+Copilot review comments were addressed with targeted checks for reproducibility,
+README clarity, PyPI README link handling, and checked-in sample incident drift.
+
+```text
+python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_example_starters.py sdk\tests\test_reporting.py -v
+19 passed
+
+python -m ruff check sdk/agentguard/reporting.py sdk/tests/test_pypi_readme_sync.py sdk/tests/test_example_starters.py scripts/generate_pypi_readme.py
+All checks passed
+
+python scripts\generate_pypi_readme.py --check
+passed
+
+python scripts\sdk_preflight.py
+All checks passed
+
+python scripts\sdk_release_guard.py
+Release guard passed
+
+git diff --check
+passed
 ```

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -26,6 +26,7 @@ COLAB_ABSOLUTE_LINK_RE = re.compile(
 )
 UNRELEASED_PATHS = {
     "docs/competitive/agent-security-stack.md",
+    "docs/examples/coding-agent-review-loop-incident.md",
     "docs/guards/budget-aware-escalation.md",
     "docs/guides/dashboard-contract.md",
     "docs/guides/decision-tracing.md",

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -40,6 +40,38 @@ agentguard quickstart --framework raw
 and retry protection offline. `quickstart` prints the smallest starter for the
 stack you actually use.
 
+First value moment: you should see `BudgetGuard`, `LoopGuard`, and
+`RetryGuard` stop simulated runaway behavior before you wire a real provider or
+share any data.
+
+## Copy-paste safe repo setup
+
+Use this when you want a coding agent or teammate to add AgentGuard to a repo
+without hidden network behavior:
+
+```bash
+pip install agentguard47
+agentguard doctor
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
+```
+
+Optional shared local defaults:
+
+```json
+{
+  "profile": "coding-agent",
+  "service": "my-agent",
+  "trace_file": ".agentguard/traces.jsonl",
+  "budget_usd": 5.0
+}
+```
+
+Keep the first PR local-only. No API keys, no dashboard settings, no hosted
+sink. Add `HttpSink` later only when retained incidents, alerts, or team
+visibility are needed.
+
 ## Wrap one agent run
 
 ```python
@@ -321,6 +353,9 @@ retry storm gets stopped:
 python examples/coding_agent_review_loop.py
 agentguard incident coding_agent_review_loop_traces.jsonl
 ```
+
+Sample output:
+[`docs/examples/coding-agent-review-loop-incident.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md)
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.9/examples/quickstart.ipynb)
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -57,7 +57,7 @@ python agentguard_raw_quickstart.py
 agentguard report .agentguard/traces.jsonl
 ```
 
-Optional shared local defaults:
+Optional shared local defaults, saved as `.agentguard.json` in the repo root:
 
 ```json
 {

--- a/sdk/agentguard/reporting.py
+++ b/sdk/agentguard/reporting.py
@@ -161,7 +161,7 @@ def _estimate_savings(
 
 def _recommendations(primary_cause: str, severity: str) -> List[str]:
     base = [
-        "Connect HttpSink to the hosted dashboard for retained alerts and remote kill switch.",
+        "Connect HttpSink to the hosted dashboard for retained alerts and remote control follow-up.",
         "Review the trace timeline to confirm the failure path before widening limits.",
     ]
     if primary_cause == "loop_detected":
@@ -261,7 +261,7 @@ def _render_incident_markdown(incident: Dict[str, Any]) -> str:
             "",
             "## Upgrade Path",
             "",
-            "Move from one-off local reports to retained alerts, spend history, and remote kill switch:",
+            "Move from one-off local reports to retained alerts, spend history, and team-visible follow-up:",
             "",
             "```python",
             "from agentguard import Tracer, HttpSink",
@@ -329,7 +329,7 @@ def _render_incident_html(incident: Dict[str, Any]) -> str:
     </div>
     <div class="card">
       <h2>Upgrade Path</h2>
-      <p>Move from one-off local reports to retained alerts, spend history, and remote kill switch.</p>
+      <p>Move from one-off local reports to retained alerts, spend history, and team-visible follow-up.</p>
       <pre>from agentguard import Tracer, HttpSink
 
 tracer = Tracer(sink=HttpSink(url="https://app.agentguard47.com/api/ingest", api_key="ag_..."))</pre>

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path
 
 from agentguard.quickstart import FRAMEWORK_CHOICES, _build_quickstart_payload
+from agentguard.reporting import render_incident_report
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STARTERS_ROOT = REPO_ROOT / "examples" / "starters"
@@ -186,6 +187,47 @@ def test_coding_agent_review_loop_example_runs_offline() -> None:
         assert "review.iteration" in names
         assert "guard.budget_exceeded" in names
         assert "guard.retry_limit_exceeded" in names
+
+
+def test_coding_agent_review_loop_sample_incident_is_in_sync() -> None:
+    example_path = REPO_ROOT / "examples" / "coding_agent_review_loop.py"
+    sample_path = REPO_ROOT / "docs" / "examples" / "coding-agent-review-loop-incident.md"
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    sdk_path = str(REPO_ROOT / "sdk")
+    env["PYTHONPATH"] = (
+        sdk_path
+        if not existing_pythonpath
+        else os.pathsep.join([sdk_path, existing_pythonpath])
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [sys.executable, str(example_path)],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr
+        trace_path = Path(tmpdir, "coding_agent_review_loop_traces.jsonl")
+        expected = _normalize_incident_snapshot(
+            render_incident_report(str(trace_path), output_format="markdown") + "\n"
+        )
+        actual = sample_path.read_text(encoding="utf-8")
+
+        assert _normalize_incident_snapshot(actual) == expected
+
+
+def _normalize_incident_snapshot(markdown: str) -> str:
+    lines = markdown.lstrip("\ufeff").splitlines()
+    return "\n".join(
+        "- Duration: <runtime> ms" if line.startswith("- Duration: ") else line
+        for line in lines
+    ) + "\n"
 
 
 def test_budget_aware_escalation_example_runs() -> None:

--- a/sdk/tests/test_pypi_readme_sync.py
+++ b/sdk/tests/test_pypi_readme_sync.py
@@ -45,6 +45,17 @@ def test_generated_pypi_readme_links_unreleased_guide_to_main() -> None:
     )
 
 
+def test_generated_pypi_readme_links_unreleased_sample_incident_to_main() -> None:
+    module = _load_generator_module()
+
+    content = module.build_pypi_readme(REPO_ROOT)
+
+    assert (
+        "https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md"
+        in content
+    )
+
+
 def test_committed_pypi_readme_is_in_sync() -> None:
     module = _load_generator_module()
 


### PR DESCRIPTION
## Summary
- Tightens the README and getting-started activation path around the fastest safe local proof.
- Adds a copy-paste repo setup flow for humans and coding agents: `doctor`, `quickstart --write`, run starter, inspect report.
- Adds a checked-in sample incident from the coding-agent review-loop demo and links it from README/examples.

## Why this matters
These are the top activation improvements from the growth audit that do not change SDK runtime behavior: clearer first value, easier copy-paste setup, and a shareable proof artifact for demo/content loops.

## Risk
- Low. Docs/proof/generator allowlist only; no core SDK behavior, dependencies, dashboard code, or telemetry changes.
- PyPI README link for the new sample incident is intentionally pinned to `main` until a release tag contains the file.

## Rollback
- Revert this PR to remove the activation copy, sample incident artifact, generated PyPI README sync, and generator allowlist entry.

## Validation
- `python scripts\generate_pypi_readme.py --check` -> passed
- `python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_example_starters.py sdk\tests\test_quickstart.py -v` -> 22 passed
- Temp-dir activation proof: `doctor`, `demo`, `quickstart --framework raw --write`, run starter, `report` -> passed
- `python scripts\sdk_preflight.py` -> All checks passed
- `python scripts\sdk_release_guard.py` -> Release guard passed
- `python -m ruff check scripts\generate_pypi_readme.py` -> passed
- `python -m pytest sdk\tests\test_sdk_release_guard.py -v` -> 6 passed
- `git diff --check` -> passed

Proof: `proof/activation-improvements-2026-05-02/VALIDATION.md`