### PR TITLE
Improve repo trust and OSS onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: sdk-version
     attributes:
       label: AgentGuard version
-      placeholder: "1.2.7"
+      placeholder: "1.2.10"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: PyPI Package
     url: https://pypi.org/project/agentguard47/
     about: Install the latest version from PyPI.
+  - name: GitHub Discussions
+    url: https://github.com/bmdhodl/agent47/discussions
+    about: Ask broader usage questions or share what you are building.

--- a/.github/ISSUE_TEMPLATE/demo_request.yml
+++ b/.github/ISSUE_TEMPLATE/demo_request.yml
@@ -1,0 +1,55 @@
+name: Demo Request
+description: Request a runnable local proof, example, or recipe
+labels: ["type:docs", "component:sdk", "growth"]
+body:
+  - type: input
+    id: scenario
+    attributes:
+      label: Scenario
+      description: What should the demo prove?
+      placeholder: "Stop a coding-agent review loop before it burns tokens"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: demo-type
+    attributes:
+      label: Demo type
+      options:
+        - Local-only example
+        - Framework starter
+        - Notebook
+        - Incident/report sample
+        - MCP read-only workflow
+    validations:
+      required: true
+
+  - type: textarea
+    id: user
+    attributes:
+      label: Target user
+      description: Who would run this demo and why?
+      placeholder: "A developer adding guardrails to a LangGraph coding agent."
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Ideal command
+      description: If you know it, what command should a user be able to run?
+      placeholder: "python examples/my_demo.py"
+    validations:
+      required: false
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Expected proof
+      description: What should the user see when the demo works?
+      placeholder: |
+        - guard exception raised
+        - trace file written
+        - incident report generated
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,13 +1,13 @@
 name: Feature Request
-description: Suggest a new capability for AgentGuard
+description: Suggest a new SDK, MCP, CLI, docs, or example capability
 labels: ["type:feature"]
 body:
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: What problem does this solve? What's frustrating today?
-      placeholder: "When I try to ..., I can't because ..."
+      description: What problem does this solve? What is frustrating today?
+      placeholder: "When I try to ..., I cannot because ..."
     validations:
       required: true
 
@@ -30,8 +30,9 @@ body:
       options:
         - SDK core (guards, tracing)
         - Integration (LangChain, LangGraph, CrewAI)
+        - MCP server
         - CLI
-        - Dashboard
+        - Docs or examples
         - Other
     validations:
       required: true
@@ -50,9 +51,9 @@ body:
       label: Acceptance criteria
       description: How will we know this is done? Be specific.
       placeholder: |
-        - [ ] Guard raises exception when budget exceeds $5
-        - [ ] Works with LangChain AgentGuardCallbackHandler
-        - [ ] Test coverage for new code
+        - [ ] Guard raises an exception when the limit is exceeded
+        - [ ] Works in local-only mode
+        - [ ] Test coverage or proof artifact exists
     validations:
       required: true
 
@@ -62,8 +63,8 @@ body:
       label: Roadmap alignment
       description: Does this relate to an existing ops/03-ROADMAP item?
       options:
-        - "Yes — existing Now/Next item"
-        - "Yes — existing Later item"
-        - "No — new idea"
+        - "Yes - existing Now/Next item"
+        - "Yes - existing Later item"
+        - "No - new idea"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -1,0 +1,55 @@
+name: Integration Request
+description: Request or improve support for a Python agent framework, provider, or runtime
+labels: ["type:feature", "component:sdk", "growth"]
+body:
+  - type: input
+    id: integration
+    attributes:
+      label: Integration
+      description: Which framework, provider, runtime, or tool should AgentGuard work with?
+      placeholder: "Pydantic AI, LlamaIndex, OpenAI Agents SDK, smolagents, ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow
+      description: What agent workflow should be guarded?
+      placeholder: "A coding agent calls tools, retries failed patches, and should stop at $5."
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-code
+    attributes:
+      label: Current code
+      description: Paste the smallest representative code shape if you can.
+      render: python
+    validations:
+      required: false
+
+  - type: dropdown
+    id: value
+    attributes:
+      label: Why this matters
+      options:
+        - Popular framework or provider
+        - Blocks my real project
+        - Improves coding-agent safety
+        - Improves MCP or agent-client discovery
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Done looks like
+      description: What would make this integration useful enough?
+      placeholder: |
+        - [ ] local example runs without dashboard access
+        - [ ] docs show the minimal setup
+        - [ ] no hard dependency is added to the core SDK
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,19 @@
 
 <!-- Link to GitHub issues: Closes #XX -->
 
+## Proof
+
+<!-- Paste validation commands and results. Link proof artifacts when useful. -->
+
+## Risk And Rollback
+
+<!-- What could break? How would we revert or disable it? -->
+
 ## Scope
 
-- **Related ops/ doc(s):** <!-- NORTHSTAR | SDK_SCOPE | ARCHITECTURE | ROADMAP | DEFINITION_OF_DONE | N/A -->
-- **Does this change the public API?** <!-- Yes / No — if Yes, update ops/02-ARCHITECTURE.md -->
-- **Does this shift roadmap priority?** <!-- Yes / No — if Yes, update ops/03-ROADMAP_NOW_NEXT_LATER.md -->
+- **Related ops/doc(s):** <!-- NORTHSTAR | SDK_SCOPE | ARCHITECTURE | ROADMAP | DEFINITION_OF_DONE | N/A -->
+- **Does this change the public API?** <!-- Yes / No. If yes, update ops/02-ARCHITECTURE.md. -->
+- **Does this shift roadmap priority?** <!-- Yes / No. If yes, update ops/03-ROADMAP_NOW_NEXT_LATER.md. -->
 
 ## Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,210 +1,164 @@
 # Contributing to AgentGuard
 
-Thanks for your interest in AgentGuard. This guide covers everything you need to set up, test, and submit a PR.
+AgentGuard is a zero-dependency runtime-control SDK for Python agents. Good
+contributions make the SDK easier to trust, install, test, or use in a real
+agent repo.
 
-## Repo Structure
+## Best First Contributions
 
+Start with issues labeled
+[`good first issue`](https://github.com/bmdhodl/agent47/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+or one of these small scopes:
+
+- improve an example without adding dependencies
+- add a focused test for an existing guard, CLI command, or helper
+- clarify docs around local-first setup, MCP, or framework integration
+- add a minimal recipe for a real Python agent workflow
+- fix package metadata, release notes, or README link drift
+
+Avoid speculative new guards, broad observability features, dashboard-only
+features, or changes that add hard runtime dependencies.
+
+## Repo Map
+
+```text
+sdk/          Python SDK source and tests
+mcp-server/   Read-only MCP server package
+docs/         Guides, examples, launch notes, and competitive notes
+examples/     Runnable local examples and starter files
+ops/          Product direction, architecture, roadmap, and definition of done
+memory/       SDK-specific state and decisions for agent contributors
+.github/      CI, issue templates, PR template, and repo automation
 ```
-agent47/
-├── sdk/           # Python SDK (agentguard47) — MIT licensed
-│   ├── agentguard/    # Source code
-│   └── tests/         # Test suite (unittest)
-├── mcp-server/    # MCP server for AI agent access
-├── site/          # Landing page
-├── scripts/       # Automation and deploy scripts
-├── docs/          # Examples and guides
-└── .github/       # CI/CD workflows
-```
 
-## Dev Setup
+The hosted dashboard is not developed in this public repository.
 
-### Prerequisites
+## Local Setup
 
-- Python 3.9+ (we test 3.9, 3.10, 3.11, 3.12)
+Prerequisites:
+
+- Python 3.9 through 3.12 for supported runtime testing
 - Git
-
-### Clone and install
+- Node.js only if you are working on `mcp-server/`
 
 ```bash
 git clone https://github.com/bmdhodl/agent47.git
 cd agent47
-
-# Create a virtualenv (recommended)
-python3 -m venv .venv
+python -m venv .venv
 source .venv/bin/activate
-
-# Install the SDK in editable mode
 pip install -e ./sdk
-
-# Install dev tools
 pip install pytest pytest-cov ruff
 ```
 
-Verify the install:
+On Windows PowerShell:
 
-```bash
-python -c "import agentguard; print(agentguard.__version__)"
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -e .\sdk
+pip install pytest pytest-cov ruff
 ```
 
-### Optional extras
-
-If you're working on an integration, install its dependencies:
+Verify the local path:
 
 ```bash
-pip install -e "./sdk[langchain]"    # LangChain
-pip install -e "./sdk[langgraph]"    # LangGraph
-pip install -e "./sdk[crewai]"       # CrewAI
-pip install -e "./sdk[otel]"         # OpenTelemetry
+agentguard doctor
+agentguard demo
 ```
 
-## Running Tests
+## Common Checks
+
+Prefer the Makefile when available:
 
 ```bash
-# Full test suite with coverage
-python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing
+make preflight
+make check
+make release-guard
+```
 
-# Single test file
+Direct equivalents:
+
+```bash
+python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+python -m ruff check sdk/agentguard/
+python scripts/sdk_release_guard.py
+```
+
+Focused examples:
+
+```bash
 python -m pytest sdk/tests/test_guards.py -v
-
-# Single test case
-python -m pytest sdk/tests/test_guards.py::TestLoopGuard::test_loop_detected -v
-
-# Coverage with fail-under (matches CI)
-python -m pytest sdk/tests/ -v \
-  --cov=agentguard \
-  --cov-report=term-missing \
-  --cov-fail-under=80
+python -m pytest sdk/tests/test_quickstart.py -v
+python examples/coding_agent_review_loop.py
 ```
 
-CI runs tests across Python 3.9–3.12 and enforces 80% minimum coverage.
-
-## Linting
-
-We use [ruff](https://docs.astral.sh/ruff/) for linting.
+If you touch `mcp-server/`:
 
 ```bash
-# Lint the SDK source (not tests or examples)
-ruff check sdk/agentguard/
-
-# Auto-fix what ruff can
-ruff check sdk/agentguard/ --fix
+cd mcp-server
+npm ci
+npm run build
 ```
 
-CI runs `ruff check sdk/agentguard/` — your PR must pass this.
+## Zero-Dependency Rule
 
-## Code Style
+The core SDK under `sdk/agentguard/` must stay stdlib-only. Optional integration
+dependencies are allowed only in integration modules or optional sinks, and they
+must be guarded with `try/except ImportError`.
 
-### Zero dependencies
-
-The core SDK uses **Python stdlib only**. No third-party imports in `sdk/agentguard/` outside of optional integration modules. Optional extras (like `langchain-core`, `opentelemetry-api`) are fine in `integrations/` and `sinks/otel.py`, guarded by try/except ImportError.
-
-### Import patterns
+Allowed pattern:
 
 ```python
-# Optional dependency — guard at module level
 try:
     from opentelemetry.trace import StatusCode
-    _HAS_OTEL = True
 except ImportError:
-    _HAS_OTEL = False
-
-# Lazy import inside methods when needed
-def _start_span(self, ...):
-    from opentelemetry.trace import set_span_in_context
-    ...
+    StatusCode = None
 ```
 
-### Python version
+Do not add a hard dependency to the core SDK unless maintainers explicitly
+approve the tradeoff first.
 
-Target Python 3.9+. Use `from __future__ import annotations` for type hint forward references. Avoid 3.10+ syntax like `X | Y` unions.
+## Public API Rule
 
-### Public API
+Public imports are exported from `sdk/agentguard/__init__.py`. If a PR changes
+that surface, call it out in the PR and update architecture docs when needed.
 
-All public exports go through `sdk/agentguard/__init__.py`. If you add a new class or function that users should import, add it there.
+Guards should raise specific exceptions such as `BudgetExceeded`,
+`LoopDetected`, `TimeoutExceeded`, or `RetryLimitExceeded`. They should not
+return booleans as the main enforcement path.
 
-### Guards
+## Pull Request Checklist
 
-Guards raise specific exceptions: `LoopDetected`, `BudgetExceeded`, `TimeoutExceeded`, `RateLimitExceeded`. Guard checks should happen **inside** trace spans so rejections appear in traces.
+Open focused PRs. A good PR usually does one thing.
 
-### Thread safety
+Include:
 
-Use `threading.Lock` for shared mutable state in sinks and guards. The `HttpSink` and `OtelTraceSink` are examples.
+- what changed
+- why it matters
+- which files are in scope
+- validation commands and results
+- risk and rollback notes
+- linked issue when applicable
 
-## Branch Naming
+Before requesting review, run the smallest relevant checks plus `make preflight`
+or the direct equivalent. New behavior needs tests. Docs-only PRs should still
+run release/readme sync checks when they touch release-facing files.
 
-```
-feature/<short-description>    # New feature
-fix/<short-description>        # Bug fix
-docs/<short-description>       # Documentation
-refactor/<short-description>   # Refactoring
-```
+## AI-Assisted Contributions
 
-Examples: `feature/redis-sink`, `fix/loop-guard-window`, `docs/readme-rewrite`
+AI-assisted contributions are welcome. The quality bar is unchanged.
 
-## PR Guidelines
+If an autonomous agent opened the PR end-to-end with minimal human steering,
+prefix the PR title with `agent:` and apply the `agent-generated` label. If a
+human used Copilot, Claude, Cursor, Codex, or another tool while reviewing and
+owning the result, no special label is required.
 
-1. **One feature or fix per PR.** Keep changes focused.
-2. **Branch from `main`**, push your branch, open a PR.
-3. **Include tests** for any new SDK functionality.
-4. **Run lint and tests locally** before pushing:
-   ```bash
-   ruff check sdk/agentguard/
-   python -m pytest sdk/tests/ -v --cov=agentguard --cov-fail-under=80
-   ```
-5. **Reference the GitHub issue** in your PR description (e.g., "Closes #42").
-6. **CI must pass** — tests on Python 3.9–3.12 + lint.
+## Communication
 
-## AI Contributions
-
-AgentGuard is an AI cost-control SDK. AI-assisted contributions are dogfood, not a smell. We encourage them, with one disclosure rule.
-
-**Posture:** Encouraged-with-disclosure.
-
-**Disclosure rules:**
-
-- **Autonomous-agent PRs** (an AI agent opened the PR end-to-end with minimal human steering): prefix the PR title with `agent:` and apply the `agent-generated` label. Example: `agent: add Redis sink retry backoff`.
-- **Human-AI-assisted PRs** (you used Copilot, Claude, Cursor, etc. to help write code you reviewed and own): no special tag required. Treat it like any other PR.
-
-**Quality bar is the same.** Same tests, same lint, same review. Disclosure is about transparency, not gating — we are not lowering or raising the bar based on how the code was written.
-
-**What we don't require:**
-
-- Copyright-style human attestations.
-- Banning LLM-drafted commit messages or PR descriptions.
-- Rejecting PRs for "AI smell" alone — if the code is correct, tested, and clear, it ships.
-
-If you're unsure which bucket a PR falls into, default to disclosing.
-
-## Commit Messages
-
-Use clear, imperative messages:
-
-```
-Add FuzzyLoopGuard for alternation detection
-Fix BudgetGuard warning callback not firing at threshold
-Update README with LangGraph integration example
-```
-
-## CI
-
-CI runs on every push and PR via GitHub Actions (`.github/workflows/ci.yml`):
-
-- **Tests**: `pytest` across Python 3.9, 3.10, 3.11, 3.12 with `--cov-fail-under=80`
-- **Lint**: `ruff check sdk/agentguard/`
-- **Coverage**: uploaded as artifact on Python 3.12 runs
-
-## Issue Labels
-
-| Prefix | Values |
-|--------|--------|
-| `component:` | sdk, dashboard, api, infra |
-| `type:` | feature, bug, refactor, docs, test, ci, security, perf |
-| `priority:` | critical, high, medium, low |
-
-## Project Board
-
-Track issues and progress: https://github.com/users/bmdhodl/projects/4
+Use GitHub issues for bugs, integration requests, demo requests, and feature
+proposals. Use GitHub Discussions for broader usage questions when available.
 
 ## License
 
-SDK is MIT licensed (BMD PAT LLC). By contributing, you agree your contributions are licensed under MIT.
+AgentGuard is MIT licensed. By contributing, you agree that your contribution
+is licensed under MIT.

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,21 @@
-This repository uses a split license:
+MIT License
 
-- sdk/          — MIT License (see sdk/LICENSE)
-- mcp-server/   — MIT License (see mcp-server/LICENSE)
-- dashboard/    — Business Source License 1.1 (see dashboard/LICENSE)
-- All other files — MIT License
+Copyright (c) 2026 BMD PAT LLC
 
-The SDK and MCP server are free and open source. The dashboard is
-source-available under the Business Source License 1.1, which permits
-viewing, modifying, and non-production use, but prohibits offering
-the dashboard as a competing hosted service. The dashboard code
-converts to Apache License 2.0 on February 7, 2030.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-See individual LICENSE files in each directory for full terms.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ All examples are local-first. No API key is required unless the example says so.
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](docs/examples/coding-agent-review-loop-incident.md)
 
+Proof gallery:
+[`docs/examples/proof-gallery.md`](docs/examples/proof-gallery.md)
+
 Starter files:
 [`examples/starters/`](examples/starters/)
 
@@ -330,6 +333,7 @@ assert result.passed
 | Decision traces | [`docs/guides/decision-tracing.md`](docs/guides/decision-tracing.md) |
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](docs/guides/managed-agent-sessions.md) |
 | Activation metrics design | [`docs/guides/activation-metrics-design.md`](docs/guides/activation-metrics-design.md) |
+| Proof gallery | [`docs/examples/proof-gallery.md`](docs/examples/proof-gallery.md) |
 
 ## Architecture
 

--- a/docs/assets/agentguard-social-preview.svg
+++ b/docs/assets/agentguard-social-preview.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" role="img" aria-labelledby="title desc">
+  <title id="title">AgentGuard47 social preview</title>
+  <desc id="desc">AgentGuard47 stops runaway Python agents with local runtime guards.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#08111f"/>
+      <stop offset="52%" stop-color="#102d3f"/>
+      <stop offset="100%" stop-color="#132018"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="42%" r="70%">
+      <stop offset="0%" stop-color="#5eead4" stop-opacity="0.35"/>
+      <stop offset="65%" stop-color="#5eead4" stop-opacity="0.04"/>
+      <stop offset="100%" stop-color="#5eead4" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1280" height="640" fill="url(#bg)"/>
+  <rect width="1280" height="640" fill="url(#glow)"/>
+  <g opacity="0.16" stroke="#d1fae5" stroke-width="1">
+    <path d="M96 118H1184"/>
+    <path d="M96 522H1184"/>
+    <path d="M170 70V570"/>
+    <path d="M1110 70V570"/>
+  </g>
+  <g transform="translate(90 92)">
+    <rect x="0" y="0" width="1100" height="456" rx="34" fill="#06131f" opacity="0.82" stroke="#5eead4" stroke-opacity="0.42"/>
+    <text x="62" y="105" fill="#a7f3d0" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="30" letter-spacing="3">AGENTGUARD47</text>
+    <text x="62" y="190" fill="#f8fafc" font-family="Inter, Avenir, Helvetica, Arial, sans-serif" font-size="64" font-weight="800">Stop runaway</text>
+    <text x="62" y="266" fill="#f8fafc" font-family="Inter, Avenir, Helvetica, Arial, sans-serif" font-size="64" font-weight="800">Python agents.</text>
+    <text x="66" y="330" fill="#cbd5e1" font-family="Inter, Avenir, Helvetica, Arial, sans-serif" font-size="30">Budget caps. Loop detection. Retry limits.</text>
+    <text x="66" y="382" fill="#86efac" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="28">pip install agentguard47</text>
+    <g transform="translate(762 102)">
+      <rect x="0" y="0" width="250" height="250" rx="38" fill="#0f172a" stroke="#86efac" stroke-opacity="0.55"/>
+      <path d="M73 126l38 38 78-91" fill="none" stroke="#86efac" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="125" y="318" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="24">ZERO DEPS</text>
+    </g>
+  </g>
+</svg>

--- a/docs/examples/proof-gallery.md
+++ b/docs/examples/proof-gallery.md
@@ -1,0 +1,127 @@
+# AgentGuard Proof Gallery
+
+These are local, runnable proof paths for the public SDK. Use them in demos,
+issues, discussions, launch posts, and first-run validation.
+
+No hosted dashboard or API key is required unless a command explicitly says so.
+
+## 1. Offline Guard Demo
+
+```bash
+pip install agentguard47
+agentguard demo
+```
+
+Proves:
+
+- `BudgetGuard` stops simulated spend
+- `LoopGuard` stops repeated tool calls
+- `RetryGuard` stops retry storms
+- no network calls are required
+
+Expected stop condition:
+
+```text
+Local proof complete.
+```
+
+## 2. Coding-Agent Review Loop
+
+```bash
+python examples/coding_agent_review_loop.py
+agentguard incident coding_agent_review_loop_traces.jsonl
+```
+
+Proves:
+
+- repeated review/edit attempts can burn budget
+- stuck patch retries are stopped locally
+- the same trace can become an incident report
+
+Sample incident:
+[`docs/examples/coding-agent-review-loop-incident.md`](coding-agent-review-loop-incident.md)
+
+## 3. Token-Budget Spike
+
+```bash
+python examples/per_token_budget_spike.py
+agentguard report per_token_budget_spike_traces.jsonl
+```
+
+Proves:
+
+- one oversized context or completion can exceed a run budget
+- the SDK can price a local synthetic turn without provider credentials
+- spend control is not only about loop count
+
+Expected stop condition:
+
+```text
+BudgetExceeded
+```
+
+## 4. Decision Trace Workflow
+
+```bash
+python examples/decision_trace_workflow.py
+agentguard decisions decision_trace_workflow.jsonl
+```
+
+Proves:
+
+- agent proposals can be captured as `decision.proposed`
+- human edits and overrides can carry reason/comment fields
+- approval and binding outcomes use the normal trace pipeline
+
+Expected event types:
+
+```text
+decision.proposed
+decision.edited
+decision.approved
+decision.bound
+```
+
+## 5. Budget-Aware Escalation
+
+```bash
+python examples/budget_aware_escalation.py
+```
+
+Proves:
+
+- apps can keep a cheaper default model
+- hard turns can be marked for escalation by deterministic rules
+- the SDK advises without hiding provider routing inside AgentGuard
+
+Expected stop condition:
+
+```text
+Escalation reason: token_count 2430 exceeded 2000
+```
+
+## 6. Starter File Smoke Test
+
+```bash
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
+```
+
+Proves:
+
+- a new repo can get a runnable local integration in one command
+- generated starters write traces to `.agentguard/traces.jsonl`
+- first value does not require a dashboard account
+
+## What To Share
+
+The most shareable public demo is the coding-agent review loop:
+
+```bash
+python examples/coding_agent_review_loop.py
+agentguard incident coding_agent_review_loop_traces.jsonl
+```
+
+It maps directly to the product wedge: a coding agent gets stuck reviewing and
+retrying, then AgentGuard stops the run before it keeps burning tokens.

--- a/docs/examples/proof-gallery.md
+++ b/docs/examples/proof-gallery.md
@@ -57,7 +57,7 @@ Proves:
 Expected stop condition:
 
 ```text
-BudgetExceeded
+Cost budget exceeded:
 ```
 
 ## 4. Decision Trace Workflow

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,6 +75,10 @@ python examples/openai_agents_with_guards.py
 Sample incident output from a clean coding-agent review-loop run:
 [`docs/examples/coding-agent-review-loop-incident.md`](../docs/examples/coding-agent-review-loop-incident.md)
 
+For a shareable command-by-command tour of the strongest local demos, see the
+proof gallery:
+[`docs/examples/proof-gallery.md`](../docs/examples/proof-gallery.md)
+
 Each example writes traces to a local JSONL file. To send traces to the hosted dashboard instead, replace `JsonlFileSink` with `HttpSink`:
 
 ```python

--- a/proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md
+++ b/proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md
@@ -113,7 +113,7 @@ decision.approved: 1
 decision.bound: 1
 
 python examples\budget_aware_escalation.py
-Escalation reason: token_count 2430 exceeded 2000.
+Escalation reason: token_count 2430 exceeded 2000
 ```
 
 ## Notes

--- a/proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md
+++ b/proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md
@@ -1,0 +1,125 @@
+# Repo Trust And Star Conversion Validation
+
+## Scope
+
+Docs and repository-health surfaces only.
+
+Changed:
+
+- root `LICENSE`
+- `CONTRIBUTING.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/ISSUE_TEMPLATE/*.yml`
+- `docs/examples/proof-gallery.md`
+- `docs/assets/agentguard-social-preview.svg`
+- `README.md`
+- `examples/README.md`
+- generated `sdk/PYPI_README.md`
+
+No SDK runtime code, dashboard code, dependency metadata, or public Python API
+changed.
+
+## External Patterns Reviewed
+
+- GitHub contributor guidance: contributing docs and issue/PR templates should
+  be surfaced directly in repository workflows.
+- pyOpenSci Python package guidance: root README should include install,
+  badges, and a short useful code demo.
+- 10up open-source best practices: README, code of conduct, contributing,
+  license, security policy, issue templates, and PR template are baseline trust
+  files.
+- AgentOps and LangChain quickstarts: successful AI SDK repos make the first
+  runnable proof and GitHub path obvious.
+
+## Commands
+
+```text
+python scripts\generate_pypi_readme.py --write
+
+python scripts\generate_pypi_readme.py --check
+passed
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_demo.py sdk\tests\test_quickstart.py -v
+19 passed
+
+python scripts\sdk_preflight.py
+passed
+
+make check
+failed: make is not installed in this PowerShell environment.
+
+make structural
+failed: make is not installed in this PowerShell environment.
+
+make security
+failed: make is not installed in this PowerShell environment.
+
+python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py
+All checks passed.
+
+python -m pytest sdk/tests/test_architecture.py -v
+9 passed
+
+python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
+passed
+
+npm --prefix mcp-server test
+5 passed
+
+python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+701 passed, coverage 92.97%
+
+git diff --check
+passed
+```
+
+## Local Proof Commands
+
+Executed from a temporary directory so generated trace files did not dirty the
+repo checkout:
+
+```text
+python -m agentguard.cli demo
+Local proof complete.
+
+python examples\coding_agent_review_loop.py
+BudgetGuard stopped review loop on attempt 3.
+RetryGuard stopped retry storm on attempt 4.
+
+python -m agentguard.cli incident coding_agent_review_loop_traces.jsonl
+Status: incident
+Primary cause: retry_limit_exceeded
+
+python examples\per_token_budget_spike.py
+Budget spike caught on turn 3.
+
+python -m agentguard.cli report per_token_budget_spike_traces.jsonl
+AgentGuard report rendered.
+
+python examples\decision_trace_workflow.py
+Wrote decision_trace_workflow.jsonl.
+
+python -m agentguard.cli decisions decision_trace_workflow.jsonl
+decision events: 4
+decision.proposed: 1
+decision.edited: 1
+decision.approved: 1
+decision.bound: 1
+
+python examples\budget_aware_escalation.py
+Escalation reason: token_count 2430 exceeded 2000.
+```
+
+## Notes
+
+- The root license is now the standard MIT text, matching `sdk/LICENSE` and
+  `mcp-server/LICENSE`, so GitHub can detect the repository license cleanly
+  after merge.
+- The social preview SVG is a source asset. GitHub still requires uploading a
+  rendered PNG/JPG in repository settings to enable a custom social preview.
+- Repository topics were updated through GitHub: removed generic
+  `observability`, `tracing`, `multi-agent`, and `llm`; added
+  `runtime-control`, `coding-agents`, and `mcp-server`.

--- a/proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md
+++ b/proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md
@@ -72,6 +72,9 @@ npm --prefix mcp-server test
 python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
 701 passed, coverage 92.97%
 
+python -m ruff check scripts/generate_pypi_readme.py
+All checks passed.
+
 git diff --check
 passed
 ```
@@ -123,3 +126,7 @@ Escalation reason: token_count 2430 exceeded 2000.
 - Repository topics were updated through GitHub: removed generic
   `observability`, `tracing`, `multi-agent`, and `llm`; added
   `runtime-control`, `coding-agents`, and `mcp-server`.
+- Automated review flagged the generated PyPI README proof-gallery link because
+  the new file does not exist in tag `v1.2.10`. `scripts/generate_pypi_readme.py`
+  now treats `docs/examples/proof-gallery.md` as unreleased and links it to
+  `main` until a future release tag includes it.

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -27,6 +27,7 @@ COLAB_ABSOLUTE_LINK_RE = re.compile(
 UNRELEASED_PATHS = {
     "docs/competitive/agent-security-stack.md",
     "docs/examples/coding-agent-review-loop-incident.md",
+    "docs/examples/proof-gallery.md",
     "docs/guards/budget-aware-escalation.md",
     "docs/guides/dashboard-contract.md",
     "docs/guides/decision-tracing.md",

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -172,7 +172,7 @@ Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md)
 
 Proof gallery:
-[`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/examples/proof-gallery.md)
+[`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md)
 
 Starter files:
 [`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.10/examples/starters)
@@ -335,7 +335,7 @@ assert result.passed
 | Decision traces | [`docs/guides/decision-tracing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/decision-tracing.md) |
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/managed-agent-sessions.md) |
 | Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/activation-metrics-design.md) |
-| Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/examples/proof-gallery.md) |
+| Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md) |
 
 ## Architecture
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -171,6 +171,9 @@ All examples are local-first. No API key is required unless the example says so.
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md)
 
+Proof gallery:
+[`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/examples/proof-gallery.md)
+
 Starter files:
 [`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.10/examples/starters)
 
@@ -332,6 +335,7 @@ assert result.passed
 | Decision traces | [`docs/guides/decision-tracing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/decision-tracing.md) |
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/managed-agent-sessions.md) |
 | Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/activation-metrics-design.md) |
+| Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/examples/proof-gallery.md) |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Tighten open-source trust surfaces: MIT root license, contributor guide, PR template, and issue forms.
- Add a local proof gallery plus a social-preview source asset for shareable repo positioning.
- Link the proof gallery from README/examples and regenerate the PyPI README.

## Related Issues

Follow-up from repo growth audit. Does not close an existing issue.

## Proof

Validation artifact: `proof/repo-trust-star-conversion-2026-05-02/VALIDATION.md`

Commands run:

```text
python scripts\generate_pypi_readme.py --check
python scripts\sdk_release_guard.py
python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_demo.py sdk\tests\test_quickstart.py -v
python scripts\sdk_preflight.py
python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py
python -m pytest sdk/tests/test_architecture.py -v
python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
npm --prefix mcp-server test
python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
git diff --check
```

Results:

```text
PyPI README sync passed.
Release guard passed.
Focused docs/activation tests: 19 passed.
Preflight passed.
Ruff passed.
Structural tests: 9 passed.
Bandit passed.
MCP tests: 5 passed.
Full SDK tests: 701 passed, coverage 92.97%.
git diff --check passed.
```

Local proof gallery commands were also run from a temporary directory: offline demo, coding-agent review loop plus incident report, token-budget spike plus report, decision trace workflow plus decisions report, and budget-aware escalation.

## Risk And Rollback

Risk is low. This is docs, GitHub forms, license text, and repo metadata only. Rollback is reverting this PR. The social preview SVG is only a source asset; GitHub still needs a rendered PNG/JPG uploaded in repository settings.

## Scope

- **Related ops/doc(s):** NORTHSTAR, ROADMAP, DEFINITION_OF_DONE
- **Does this change the public API?** No
- **Does this shift roadmap priority?** No

## Checklist

- [x] `make check` equivalent passes (pytest + ruff + MCP; `make` is unavailable in local PowerShell)
- [x] `make structural` equivalent passes
- [x] `make security` equivalent passes
- [x] New functionality has tests or proof
- [x] No new hard dependencies in core SDK
- [x] No hardcoded absolute paths
- [x] If `__init__.py` exports changed, `ops/02-ARCHITECTURE.md` updated