### PR TITLE
Switch PyPI releases to Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,16 +58,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: sdk/dist/
-          password: ${{ secrets.PYPI_TOKEN }}
-          # Current release path still uses PYPI_TOKEN because PyPI Trusted Publishing
-          # is not configured yet for this workflow. GitHub-side publisher tuple:
-          # - owner: bmdhodl
-          # - repo: agent47
-          # - workflow: .github/workflows/publish.yml
-          # - environment: pypi
-          #
-          # Once the Trusted Publisher is added on PyPI for `agentguard47`:
-          # 1. Remove the `password` line above.
-          # 2. Add `attestations: true`.
-          # 3. Publish the next tag and confirm PyPI file metadata says
-          #    "Uploaded using Trusted Publishing? Yes".
+          attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Release Security
+- Switched the PyPI publish workflow from long-lived `PYPI_TOKEN` authentication
+  to OIDC Trusted Publishing for the `pypi` GitHub environment, with PyPI
+  attestations enabled for release artifacts.
+- Added release documentation for the required PyPI trusted-publisher tuple and
+  post-release verification steps.
+
 ## 1.2.10
 
 ### Activation Proof Path

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ assert result.passed
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](docs/guides/managed-agent-sessions.md) |
 | Activation metrics design | [`docs/guides/activation-metrics-design.md`](docs/guides/activation-metrics-design.md) |
 | Proof gallery | [`docs/examples/proof-gallery.md`](docs/examples/proof-gallery.md) |
+| PyPI Trusted Publishing | [`docs/release/trusted-publishing.md`](docs/release/trusted-publishing.md) |
 
 ## Architecture
 

--- a/docs/release/trusted-publishing.md
+++ b/docs/release/trusted-publishing.md
@@ -1,0 +1,75 @@
+# PyPI Trusted Publishing
+
+AgentGuard publishes `agentguard47` to PyPI from
+`.github/workflows/publish.yml` when a `v*` tag is pushed.
+
+The release job uses PyPI Trusted Publishing instead of a long-lived
+`PYPI_TOKEN`. GitHub mints a short-lived OIDC token for the `pypi` environment,
+and PyPI exchanges that identity for a temporary upload credential.
+
+## PyPI Project Configuration
+
+The PyPI project owner must configure this trusted publisher for
+`agentguard47`:
+
+```text
+Owner: bmdhodl
+Repository name: agent47
+Workflow filename: publish.yml
+Environment name: pypi
+```
+
+PyPI asks for the workflow filename, not the full path. The matching workflow
+path in this repo is `.github/workflows/publish.yml`.
+
+## GitHub Workflow Requirements
+
+The publish job must keep:
+
+```yaml
+environment: pypi
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+```
+
+The `pypa/gh-action-pypi-publish` step must not include `username`,
+`password`, or `api-token` inputs. Tokenless publishing is what causes the
+action to use Trusted Publishing.
+
+Current publish step:
+
+```yaml
+- name: Publish to PyPI
+  uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+  with:
+    packages-dir: sdk/dist/
+    attestations: true
+```
+
+## Release Verification
+
+After the next release tag publishes:
+
+1. Open the GitHub Actions run for `.github/workflows/publish.yml`.
+2. Confirm the publish step did not warn that Trusted Publishing is disabled.
+3. Open the new version on PyPI.
+4. Confirm each release file shows Trusted Publishing provenance and
+   attestations in PyPI file metadata.
+5. Remove the old `PYPI_TOKEN` repository secret after a successful trusted
+   publishing release.
+
+## Rollback
+
+If publishing fails because the PyPI trusted publisher is not configured yet,
+configure the PyPI publisher tuple above and rerun the failed release workflow.
+Do not restore `PYPI_TOKEN` unless a release is blocked and the owner explicitly
+chooses a temporary token-based rollback.
+
+## References
+
+- [PyPI: Publishing with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/)
+- [PyPI: Adding a Trusted Publisher to an Existing Project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+- [PyPI: Producing Attestations](https://docs.pypi.org/attestations/producing-attestations/)
+- [pypa/gh-action-pypi-publish Trusted Publishing](https://github.com/pypa/gh-action-pypi-publish)

--- a/ops/04-DEFINITION_OF_DONE.md
+++ b/ops/04-DEFINITION_OF_DONE.md
@@ -21,6 +21,8 @@
 - [ ] `sdk/PYPI_README.md` is regenerated from `README.md` + `CHANGELOG.md` and matches the release tag.
 - [ ] GitHub Releases has an entry for the tag, not just a git tag.
 - [ ] PyPI version matches the Git tag after publish.
+- [ ] PyPI file metadata confirms Trusted Publishing and attestations for the
+      release artifacts.
 - [ ] Release notes link to the correct docs, repo, and package name.
 
 ## Adding a new guard

--- a/proof/pypi-trusted-publishing-2026-05-02/VALIDATION.md
+++ b/proof/pypi-trusted-publishing-2026-05-02/VALIDATION.md
@@ -1,0 +1,83 @@
+# PyPI Trusted Publishing Validation
+
+## Scope
+
+Release-infrastructure and release-docs only.
+
+Changed:
+
+- `.github/workflows/publish.yml`
+- `docs/release/trusted-publishing.md`
+- `ops/04-DEFINITION_OF_DONE.md`
+- `CHANGELOG.md`
+- `README.md`
+- generated `sdk/PYPI_README.md`
+- `scripts/generate_pypi_readme.py`
+
+No SDK runtime behavior, public Python API, package version, or dependency
+metadata changed.
+
+## External References Checked
+
+- PyPI Trusted Publishing docs require `id-token: write`, no explicit username
+  or password, and a matching publisher config for owner, repo, workflow, and
+  environment.
+- PyPI attestation docs state `pypa/gh-action-pypi-publish` can upload
+  attestations when publishing with a trusted publisher.
+
+## Commands
+
+```text
+python scripts\generate_pypi_readme.py --write
+
+python scripts\generate_pypi_readme.py --check
+passed
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_sdk_release_guard.py -v
+10 passed
+
+python -m ruff check scripts/generate_pypi_readme.py scripts/sdk_release_guard.py
+All checks passed.
+
+python scripts\sdk_preflight.py
+passed
+
+git diff --check
+passed
+
+$env:SOURCE_DATE_EPOCH="315532800"; python -m build .\sdk
+Successfully built agentguard47-1.2.10.tar.gz and agentguard47-1.2.10-py3-none-any.whl
+```
+
+## Workflow Contract Check
+
+```text
+publish.yml has:
+- environment: pypi
+- permissions.id-token: write
+- permissions.attestations: write
+- pypa/gh-action-pypi-publish with packages-dir: sdk/dist/
+- attestations: true
+
+publish.yml no longer has:
+- password: ${{ secrets.PYPI_TOKEN }}
+```
+
+## Remaining External Prerequisite
+
+The PyPI project owner must configure the trusted publisher for `agentguard47`
+before the next release tag:
+
+```text
+Owner: bmdhodl
+Repository name: agent47
+Workflow filename: publish.yml
+Environment name: pypi
+```
+
+After the next release publishes, verify PyPI file metadata shows Trusted
+Publishing provenance and attestations. Then remove the old `PYPI_TOKEN`
+repository secret.

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -32,6 +32,7 @@ UNRELEASED_PATHS = {
     "docs/guides/dashboard-contract.md",
     "docs/guides/decision-tracing.md",
     "docs/guides/managed-agent-sessions.md",
+    "docs/release/trusted-publishing.md",
 }
 
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -336,6 +336,7 @@ assert result.passed
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/managed-agent-sessions.md) |
 | Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/activation-metrics-design.md) |
 | Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md) |
+| PyPI Trusted Publishing | [`docs/release/trusted-publishing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/trusted-publishing.md) |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- switch SDK PyPI publishing from long-lived `PYPI_TOKEN` auth to PyPI Trusted Publishing via GitHub OIDC
- enable PyPI upload attestations in `.github/workflows/publish.yml`
- document the required PyPI trusted publisher tuple, release verification steps, and rollback path

## Scope
SDK/release-infra only. No SDK runtime behavior, public Python API, package version, dependency metadata, dashboard code, auth, billing, database, or deployment config changes.

## Remaining owner action
Before the next `v*` release tag publishes, configure the PyPI trusted publisher for `agentguard47`:

```text
Owner: bmdhodl
Repository name: agent47
Workflow filename: publish.yml
Environment name: pypi
```

GitHub `pypi` environment already exists. GitHub license detection was also verified as MIT before this branch.

## Validation
```text
python scripts\generate_pypi_readme.py --check
passed

python scripts\sdk_release_guard.py
Release guard passed.

python -m pytest sdk\tests\test_pypi_readme_sync.py sdk\tests\test_sdk_release_guard.py -v
10 passed

python -m ruff check scripts/generate_pypi_readme.py scripts/sdk_release_guard.py
All checks passed.

python scripts\sdk_preflight.py
passed

git diff --check
passed

$env:SOURCE_DATE_EPOCH="315532800"; python -m build .\sdk
Successfully built agentguard47-1.2.10.tar.gz and agentguard47-1.2.10-py3-none-any.whl
```

Additional proof is recorded in `proof/pypi-trusted-publishing-2026-05-02/VALIDATION.md`.

## Risk and rollback
Risk: the next release publish will fail if the PyPI trusted publisher is not configured before the release tag. Preferred fix is to add the PyPI publisher tuple and rerun the failed workflow. Only restore token-based publishing if a release is blocked and the owner explicitly chooses a temporary rollback.

Closes #416
