### PR TITLE
Point demo users to quickstart activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Activation
+- Added a post-demo next-step block so `agentguard demo` points directly to
+  `agentguard quickstart --framework raw --write`, the generated starter, and
+  the follow-up local report command.
+
 ### Release Security
 - Switched the PyPI publish workflow from long-lived `PYPI_TOKEN` authentication
   to OIDC Trusted Publishing for the `pypi` GitHub environment, with PyPI

--- a/proof/demo-next-activation-2026-05-02/VALIDATION.md
+++ b/proof/demo-next-activation-2026-05-02/VALIDATION.md
@@ -1,0 +1,69 @@
+# Demo Next Activation Validation
+
+## Scope
+
+Activation copy only. No SDK runtime behavior, public API, dependencies,
+network behavior, dashboard behavior, or package metadata changed.
+
+Changed:
+
+- `sdk/agentguard/demo.py`
+- `sdk/tests/test_demo.py`
+- `CHANGELOG.md`
+
+## Manual Runtime Proof
+
+Command:
+
+```text
+$env:PYTHONPATH='sdk'; python -m agentguard.cli demo --trace-file <temp>\demo.jsonl
+```
+
+Relevant output:
+
+```text
+Local proof complete.
+Trace written to: <temp>\demo.jsonl
+View summary: agentguard report <temp>\demo.jsonl
+View incident report: agentguard incident <temp>\demo.jsonl
+
+Next: add AgentGuard to a repo
+  agentguard quickstart --framework raw --write
+  python agentguard_raw_quickstart.py
+  agentguard report .agentguard/traces.jsonl
+SDK gives you local enforcement. The dashboard adds alerts, retained history, and remote controls.
+TRACE_EXISTS=True
+```
+
+## Checks
+
+```text
+python -m pytest sdk\tests\test_demo.py -v
+2 passed
+
+python -m ruff check sdk\agentguard\demo.py sdk\tests\test_demo.py
+All checks passed.
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python scripts\sdk_preflight.py
+All checks passed.
+
+make check
+not run: `make` is not installed in this PowerShell environment.
+
+Equivalent direct gate:
+
+python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py
+All checks passed.
+
+python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+701 passed, total coverage 92.98%.
+
+npm --prefix mcp-server test
+5 passed.
+
+git diff --check
+passed
+```

--- a/sdk/agentguard/demo.py
+++ b/sdk/agentguard/demo.py
@@ -65,6 +65,11 @@ def run_offline_demo(
     _print(out, f"Trace written to: {trace_path}")
     _print(out, f"View summary: agentguard report {trace_path}")
     _print(out, f"View incident report: agentguard incident {trace_path}")
+    _print(out, "")
+    _print(out, "Next: add AgentGuard to a repo")
+    _print(out, "  agentguard quickstart --framework raw --write")
+    _print(out, "  python agentguard_raw_quickstart.py")
+    _print(out, "  agentguard report .agentguard/traces.jsonl")
     _print(out, "SDK gives you local enforcement. The dashboard adds alerts, retained history, and remote controls.")
     return 0
 

--- a/sdk/tests/test_demo.py
+++ b/sdk/tests/test_demo.py
@@ -23,6 +23,10 @@ class TestOfflineDemo(unittest.TestCase):
             self.assertIn("BudgetGuard", output)
             self.assertIn("LoopGuard", output)
             self.assertIn("RetryGuard", output)
+            self.assertIn("Next: add AgentGuard to a repo", output)
+            self.assertIn("agentguard quickstart --framework raw --write", output)
+            self.assertIn("python agentguard_raw_quickstart.py", output)
+            self.assertIn("agentguard report .agentguard/traces.jsonl", output)
             self.assertIn("SDK gives you local enforcement. The dashboard adds alerts", output)
             self.assertTrue(os.path.exists(trace_path))
 


### PR DESCRIPTION
## Summary
- add a clear post-demo activation block to `agentguard demo`
- point users directly to `agentguard quickstart --framework raw --write`, the generated starter, and the follow-up local report command
- cover the new activation copy in the offline demo test

## Scope
SDK CLI activation only. No SDK runtime behavior, public API, dependencies, telemetry, network behavior, or dashboard behavior changed.

## Validation
```text
python -m pytest sdk\tests\test_demo.py -v
2 passed

python -m ruff check sdk\agentguard\demo.py sdk\tests\test_demo.py
All checks passed.

python scripts\sdk_release_guard.py
Release guard passed.

python scripts\sdk_preflight.py
All checks passed.

$env:PYTHONPATH='sdk'; python -m agentguard.cli demo --trace-file <temp>\demo.jsonl
TRACE_EXISTS=True and output includes the new quickstart next-step block

make check
not run: make is unavailable in this PowerShell environment

Equivalent direct gate:
python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py
All checks passed.

python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
701 passed, total coverage 92.98%

npm --prefix mcp-server test
5 passed

git diff --check
passed
```

Proof artifact: `proof/demo-next-activation-2026-05-02/VALIDATION.md`.

## Risk and rollback
Low risk: this is CLI copy only after the existing offline demo completes. Rollback is reverting the output block plus the corresponding test/changelog note.

Closes #417
