### PR TITLE
Add optional Pydantic AI starter recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added a post-demo next-step block so `agentguard demo` points directly to
   `agentguard quickstart --framework raw --write`, the generated starter, and
   the follow-up local report command.
+- Added an optional local-first Pydantic AI starter recipe using Pydantic AI's
+  `TestModel`, so users can try the pattern without API keys or network calls
+  after installing the optional framework package.
 
 ### Release Security
 - Switched the PyPI publish workflow from long-lived `PYPI_TOKEN` authentication

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,17 @@ The starter files under `examples/starters/` are the executable counterparts to
 `agentguard quickstart`. They live in this repo for copy-paste onboarding and
 coding-agent setup; they are not included in the installed PyPI wheel.
 
+There is also an optional Pydantic AI starter:
+
+```bash
+pip install agentguard47 pydantic-ai
+python examples/starters/agentguard_pydantic_ai_quickstart.py
+agentguard report .agentguard/traces.jsonl
+```
+
+It uses Pydantic AI's `TestModel`, so it runs without API keys or network calls
+after the optional `pydantic-ai` package is installed.
+
 ## Framework Examples
 
 | File | Framework | What it shows |

--- a/examples/starters/README.md
+++ b/examples/starters/README.md
@@ -21,6 +21,7 @@ are not included in the installed PyPI wheel.
 | `agentguard_langchain_quickstart.py` | LangChain | Explicit callback wiring with local traces. |
 | `agentguard_langgraph_quickstart.py` | LangGraph | Fully local graph example with node guards. |
 | `agentguard_crewai_quickstart.py` | CrewAI | Explicit callback wiring with local traces. |
+| `agentguard_pydantic_ai_quickstart.py` | Pydantic AI | Local traces around a Pydantic AI agent run using `TestModel`; no API keys or network calls. |
 
 ## Suggested flow
 
@@ -33,3 +34,11 @@ agentguard report .agentguard/traces.jsonl
 ```
 
 Then move to the file that matches your real stack.
+
+For Pydantic AI:
+
+```bash
+pip install agentguard47 pydantic-ai
+python examples/starters/agentguard_pydantic_ai_quickstart.py
+agentguard report .agentguard/traces.jsonl
+```

--- a/examples/starters/agentguard_pydantic_ai_quickstart.py
+++ b/examples/starters/agentguard_pydantic_ai_quickstart.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import agentguard
+
+
+def main() -> None:
+    try:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+    except ImportError as exc:
+        raise SystemExit(
+            "Install with: pip install agentguard47 pydantic-ai"
+        ) from exc
+
+    tracer = agentguard.init(
+        profile="coding-agent",
+        service="my-pydantic-ai-agent",
+        budget_usd=5.00,
+        trace_file=".agentguard/traces.jsonl",
+        local_only=True,
+        auto_patch=False,
+    )
+
+    # TestModel lets this starter run without API keys or network calls.
+    agent = Agent(
+        TestModel(
+            custom_output_text="Add AgentGuard around the agent run and inspect the local trace."
+        ),
+        instructions="Return one practical next step for adding runtime controls.",
+    )
+
+    try:
+        with tracer.trace("pydantic_ai.agent.run") as span:
+            result = agent.run_sync("How should I guard this agent?")
+            span.event("agent.answer", data={"output": result.output})
+            print(result.output)
+    finally:
+        agentguard.shutdown()
+
+    print("Traces saved to .agentguard/traces.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/agentguard_pydantic_ai_quickstart.py
+++ b/examples/starters/agentguard_pydantic_ai_quickstart.py
@@ -14,7 +14,7 @@ def main() -> None:
 
     tracer = agentguard.init(
         profile="coding-agent",
-        service="my-pydantic-ai-agent",
+        service="my-agent",
         budget_usd=5.00,
         trace_file=".agentguard/traces.jsonl",
         local_only=True,

--- a/proof/pydantic-ai-starter-2026-05-02/VALIDATION.md
+++ b/proof/pydantic-ai-starter-2026-05-02/VALIDATION.md
@@ -1,0 +1,76 @@
+# Pydantic AI Starter Validation
+
+## Scope
+
+Docs/example growth item only. No SDK runtime behavior, public API, package
+metadata, dashboard behavior, telemetry, or hard dependency changed.
+
+Changed:
+
+- `examples/starters/agentguard_pydantic_ai_quickstart.py`
+- `examples/starters/README.md`
+- `examples/README.md`
+- `sdk/tests/test_example_starters.py`
+- `CHANGELOG.md`
+
+## External Docs Checked
+
+Pydantic AI official docs were checked for current API shape:
+
+- `Agent.run_sync(...)` is the synchronous run path.
+- `pydantic_ai.models.test.TestModel` is the local testing/development model
+  for avoiding real model requests.
+
+## Runtime Proof
+
+Absent optional dependency:
+
+```text
+$env:PYTHONPATH='sdk'; python examples\starters\agentguard_pydantic_ai_quickstart.py
+Install with: pip install agentguard47 pydantic-ai
+```
+
+Isolated optional-dependency venv:
+
+```text
+python -m venv <temp-venv>
+<temp-venv>\Scripts\python.exe -m pip install -e .\sdk pydantic-ai
+<temp-venv>\Scripts\python.exe examples\starters\agentguard_pydantic_ai_quickstart.py
+
+Add AgentGuard around the agent run and inspect the local trace.
+Traces saved to .agentguard/traces.jsonl
+TRACE_EXISTS=True
+```
+
+## Checks
+
+```text
+python -m ruff check examples\starters\agentguard_pydantic_ai_quickstart.py sdk\tests\test_example_starters.py
+All checks passed.
+
+python -m pytest sdk\tests\test_example_starters.py -v
+8 passed.
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python scripts\sdk_preflight.py
+All checks passed.
+
+make check
+not run: `make` is not installed in this PowerShell environment.
+
+Equivalent direct gate:
+
+python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py
+All checks passed.
+
+python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+702 passed, total coverage 92.98%.
+
+npm --prefix mcp-server test
+5 passed.
+
+git diff --check
+passed.
+```

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 import os
 import subprocess
@@ -71,14 +72,40 @@ def test_raw_starter_runs_and_writes_trace() -> None:
 
 def test_pydantic_ai_starter_is_optional_and_local_first() -> None:
     starter_path = STARTERS_ROOT / "agentguard_pydantic_ai_quickstart.py"
+    assert starter_path.exists(), f"Missing Pydantic AI starter: {starter_path}"
     source = starter_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
 
     compile(source, str(starter_path), "exec", flags=0, dont_inherit=True)
-    assert "pip install agentguard47 pydantic-ai" in source
-    assert "from pydantic_ai import Agent" in source
-    assert "from pydantic_ai.models.test import TestModel" in source
-    assert "local_only=True" in source
-    assert "auto_patch=False" in source
+    imports = {
+        (node.module, alias.name)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert ("pydantic_ai", "Agent") in imports
+    assert ("pydantic_ai.models.test", "TestModel") in imports
+    assert "pydantic-ai" in source
+
+    init_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "agentguard"
+        and node.func.attr == "init"
+    ]
+    assert init_calls, "Pydantic AI starter should initialize AgentGuard"
+    init_keywords = {
+        keyword.arg: keyword.value
+        for keyword in init_calls[0].keywords
+        if keyword.arg is not None
+    }
+    assert isinstance(init_keywords.get("local_only"), ast.Constant)
+    assert init_keywords["local_only"].value is True
+    assert isinstance(init_keywords.get("auto_patch"), ast.Constant)
+    assert init_keywords["auto_patch"].value is False
 
 
 def test_disposable_harness_example_links_session_id() -> None:

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -69,6 +69,18 @@ def test_raw_starter_runs_and_writes_trace() -> None:
         assert Path(tmpdir, ".agentguard", "traces.jsonl").exists()
 
 
+def test_pydantic_ai_starter_is_optional_and_local_first() -> None:
+    starter_path = STARTERS_ROOT / "agentguard_pydantic_ai_quickstart.py"
+    source = starter_path.read_text(encoding="utf-8")
+
+    compile(source, str(starter_path), "exec", flags=0, dont_inherit=True)
+    assert "pip install agentguard47 pydantic-ai" in source
+    assert "from pydantic_ai import Agent" in source
+    assert "from pydantic_ai.models.test import TestModel" in source
+    assert "local_only=True" in source
+    assert "auto_patch=False" in source
+
+
 def test_disposable_harness_example_links_session_id() -> None:
     example_path = REPO_ROOT / "examples" / "disposable_harness_session.py"
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- add an optional Pydantic AI starter recipe under `examples/starters/`
- keep it local-first by using Pydantic AI `TestModel`, so it runs without API keys or network calls after installing the optional framework package
- document the starter in examples docs and add focused coverage that it remains optional/local-first

## Scope
Examples/docs/tests only. No SDK runtime behavior, public API, package metadata, dashboard behavior, telemetry, or hard dependency changed.

## Validation
```text
$env:PYTHONPATH='sdk'; python examples\starters\agentguard_pydantic_ai_quickstart.py
Install with: pip install agentguard47 pydantic-ai

python -m venv <temp-venv>
<temp-venv>\Scripts\python.exe -m pip install -e .\sdk pydantic-ai
<temp-venv>\Scripts\python.exe examples\starters\agentguard_pydantic_ai_quickstart.py
Add AgentGuard around the agent run and inspect the local trace.
Traces saved to .agentguard/traces.jsonl
TRACE_EXISTS=True

python -m ruff check examples\starters\agentguard_pydantic_ai_quickstart.py sdk\tests\test_example_starters.py
All checks passed.

python -m pytest sdk\tests\test_example_starters.py -v
8 passed

python scripts\sdk_release_guard.py
Release guard passed.

python scripts\sdk_preflight.py
All checks passed.

make check
not run: make is unavailable in this PowerShell environment

Equivalent direct gate:
python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py
All checks passed.

python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
702 passed, total coverage 92.98%

npm --prefix mcp-server test
5 passed

git diff --check
passed
```

Proof artifact: `proof/pydantic-ai-starter-2026-05-02/VALIDATION.md`.

## Risk and rollback
Low risk: this is an optional example/docs addition and does not add `pydantic-ai` to SDK dependencies. Rollback is reverting the example, docs, test, changelog note, and proof artifact.

Closes #421
