### PR TITLE
Clarify incident dashboard handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added an optional local-first Pydantic AI starter recipe using Pydantic AI's
   `TestModel`, so users can try the pattern without API keys or network calls
   after installing the optional framework package.
+- Clarified incident-report dashboard handoff copy so hosted ingest is framed as
+  useful when incidents need retained history, alerts, spend trends, or
+  team-visible follow-up, not as a requirement for local safety.
 
 ### Release Security
 - Switched the PyPI publish workflow from long-lived `PYPI_TOKEN` authentication

--- a/docs/examples/coding-agent-review-loop-incident.md
+++ b/docs/examples/coding-agent-review-loop-incident.md
@@ -34,12 +34,12 @@ Primary cause: **retry_limit_exceeded**
 
 - Add exponential backoff or a deterministic fallback before retrying the same tool.
 - Treat repeated upstream failures as a stop condition instead of widening the retry ceiling.
-- Connect HttpSink to the hosted dashboard for retained alerts and remote control follow-up.
 - Review the trace timeline to confirm the failure path before widening limits.
+- Keep one-off investigations local; add HttpSink only when future incidents need retained history, alerts, or team-visible follow-up.
 
 ## Upgrade Path
 
-Move from one-off local reports to retained alerts, spend history, and team-visible follow-up:
+Keep this report local if it is a one-off investigation. Add hosted ingest only when future incidents need retained history, alerts, spend trends, or team-visible follow-up:
 
 ```python
 from agentguard import Tracer, HttpSink

--- a/proof/incident-dashboard-handoff-2026-05-02/VALIDATION.md
+++ b/proof/incident-dashboard-handoff-2026-05-02/VALIDATION.md
@@ -1,0 +1,70 @@
+# Incident Dashboard Handoff Validation
+
+## Scope
+
+Copy and report-rendering only. No SDK runtime enforcement behavior, public API,
+dependencies, hosted ingest contract, telemetry, dashboard code, or package
+metadata changed.
+
+Changed:
+
+- `sdk/agentguard/reporting.py`
+- `sdk/tests/test_reporting.py`
+- `docs/examples/coding-agent-review-loop-incident.md`
+- `CHANGELOG.md`
+
+## Runtime Proof
+
+Command:
+
+```text
+$env:PYTHONPATH='sdk'
+python examples\coding_agent_review_loop.py
+python -m agentguard.cli incident coding_agent_review_loop_traces.jsonl
+```
+
+Relevant incident output:
+
+```text
+- Keep one-off investigations local; add HttpSink only when future incidents need retained history, alerts, or team-visible follow-up.
+
+Keep this report local if it is a one-off investigation. Add hosted ingest only when future incidents need retained history, alerts, spend trends, or team-visible follow-up:
+
+from agentguard import Tracer, HttpSink
+tracer = Tracer(sink=HttpSink(url="https://app.agentguard47.com/api/ingest", api_key="ag_..."))
+
+TRACE_EXISTS=True
+```
+
+## Checks
+
+```text
+python -m pytest sdk\tests\test_reporting.py sdk\tests\test_example_starters.py::test_coding_agent_review_loop_sample_incident_is_in_sync -v
+9 passed.
+
+python -m ruff check sdk\agentguard\reporting.py sdk\tests\test_reporting.py
+All checks passed.
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python scripts\sdk_preflight.py
+All checks passed.
+
+git diff --check
+passed.
+
+make check
+not run: `make` is not installed in this PowerShell environment.
+
+Equivalent direct gate:
+
+python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py
+All checks passed.
+
+python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+702 passed, total coverage 92.98%.
+
+npm --prefix mcp-server test
+5 passed.
+```

--- a/sdk/agentguard/reporting.py
+++ b/sdk/agentguard/reporting.py
@@ -161,8 +161,11 @@ def _estimate_savings(
 
 def _recommendations(primary_cause: str, severity: str) -> List[str]:
     base = [
-        "Connect HttpSink to the hosted dashboard for retained alerts and remote control follow-up.",
         "Review the trace timeline to confirm the failure path before widening limits.",
+        (
+            "Keep one-off investigations local; add HttpSink only when future incidents "
+            "need retained history, alerts, or team-visible follow-up."
+        ),
     ]
     if primary_cause == "loop_detected":
         return [
@@ -261,7 +264,11 @@ def _render_incident_markdown(incident: Dict[str, Any]) -> str:
             "",
             "## Upgrade Path",
             "",
-            "Move from one-off local reports to retained alerts, spend history, and team-visible follow-up:",
+            (
+                "Keep this report local if it is a one-off investigation. Add hosted ingest "
+                "only when future incidents need retained history, alerts, spend trends, or "
+                "team-visible follow-up:"
+            ),
             "",
             "```python",
             "from agentguard import Tracer, HttpSink",
@@ -329,7 +336,7 @@ def _render_incident_html(incident: Dict[str, Any]) -> str:
     </div>
     <div class="card">
       <h2>Upgrade Path</h2>
-      <p>Move from one-off local reports to retained alerts, spend history, and team-visible follow-up.</p>
+      <p>Keep this report local if it is a one-off investigation. Add hosted ingest only when future incidents need retained history, alerts, spend trends, or team-visible follow-up.</p>
       <pre>from agentguard import Tracer, HttpSink
 
 tracer = Tracer(sink=HttpSink(url="https://app.agentguard47.com/api/ingest", api_key="ag_..."))</pre>

--- a/sdk/tests/test_reporting.py
+++ b/sdk/tests/test_reporting.py
@@ -116,9 +116,11 @@ class TestIncidentSummary(unittest.TestCase):
         self.assertEqual(incident["severity"], "critical")
         self.assertEqual(incident["primary_cause"], "retry_limit_exceeded")
         self.assertIn("exponential backoff", incident["recommendations"][0])
-        self.assertIn(
-            "Keep one-off investigations local",
-            incident["recommendations"][-1],
+        self.assertTrue(
+            any(
+                "Keep one-off investigations local" in recommendation
+                for recommendation in incident["recommendations"]
+            )
         )
 
 

--- a/sdk/tests/test_reporting.py
+++ b/sdk/tests/test_reporting.py
@@ -116,6 +116,10 @@ class TestIncidentSummary(unittest.TestCase):
         self.assertEqual(incident["severity"], "critical")
         self.assertEqual(incident["primary_cause"], "retry_limit_exceeded")
         self.assertIn("exponential backoff", incident["recommendations"][0])
+        self.assertIn(
+            "Keep one-off investigations local",
+            incident["recommendations"][-1],
+        )
 
 
 class TestIncidentRendering(unittest.TestCase):
@@ -153,6 +157,8 @@ class TestIncidentRendering(unittest.TestCase):
         self.assertIn("## Savings Ledger", report)
         self.assertIn("Estimated savings: $0.0075", report)
         self.assertIn("`loop_prevented` (estimated): 1500 tokens / $0.0075", report)
+        self.assertIn("Keep this report local if it is a one-off investigation.", report)
+        self.assertIn("retained history, alerts, spend trends", report)
         self.assertIn("HttpSink", report)
 
     def test_html_report_contains_title(self):
@@ -161,6 +167,7 @@ class TestIncidentRendering(unittest.TestCase):
             output_format="html",
         )
         self.assertIn("<title>AgentGuard Incident Report</title>", report)
+        self.assertIn("Keep this report local if it is a one-off investigation.", report)
 
     def test_json_report_is_parseable(self):
         report = render_incident_report(


### PR DESCRIPTION
## Summary
- Clarifies local incident report dashboard handoff so hosted ingest is positioned as useful when future incidents need retained history, alerts, spend trends, or team-visible follow-up.
- Keeps local reports explicitly valid for one-off investigations.
- Updates reporting tests, the coding-agent review-loop sample incident, changelog, and proof artifact.

## Scope / Risk
- SDK/reporting copy only.
- No runtime guard behavior, public API, telemetry, dependencies, hosted ingest contract, dashboard code, or package metadata changed.
- Rollback: revert this PR; no migration needed.

## Validation
- `python -m pytest sdk\tests\test_reporting.py sdk\tests\test_example_starters.py::test_coding_agent_review_loop_sample_incident_is_in_sync -v` -> 9 passed
- `python -m ruff check sdk\agentguard\reporting.py sdk\tests\test_reporting.py` -> passed
- `python scripts\sdk_release_guard.py` -> passed
- `python scripts\sdk_preflight.py` -> passed
- `git diff --check` -> passed
- `make check` -> not available in this PowerShell environment
- Equivalent full gate already run: `python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 702 passed, 92.98% coverage
- `npm --prefix mcp-server test` -> 5 passed

Runtime proof is saved in `proof/incident-dashboard-handoff-2026-05-02/VALIDATION.md`.