### PR TITLE
Add dashboard handoff guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Clarified incident-report dashboard handoff copy so hosted ingest is framed as
   useful when incidents need retained history, alerts, spend trends, or
   team-visible follow-up, not as a requirement for local safety.
+- Added a concise local-vs-hosted adoption table to the README and dashboard
+  contract docs so the dashboard CTA is explicit without making local SDK use
+  feel limited.
 
 ### Release Security
 - Switched the PyPI publish workflow from long-lived `PYPI_TOKEN` authentication

--- a/README.md
+++ b/README.md
@@ -270,6 +270,16 @@ The SDK is the free local proof path. The hosted dashboard is for retained
 history, alerts, team visibility, hosted decision history, and remote-control
 operations.
 
+| Use local SDK when | Use hosted dashboard when |
+| --- | --- |
+| You are proving AgentGuard in one repo | Multiple people need the same incident history |
+| You need hard stops for loops, retries, timeouts, or budget burn | Runs need retained alerts and follow-up outside the terminal |
+| You want JSONL traces and reports without an API key | You need spend trends across traces, services, or teammates |
+| You are testing an agent before production | Operators need dashboard-managed remote kill signals |
+
+Start local. Add hosted ingest when the work becomes shared, expensive, or
+risky enough that local files are no longer enough.
+
 ```python
 from agentguard import HttpSink, Tracer
 

--- a/docs/guides/dashboard-contract.md
+++ b/docs/guides/dashboard-contract.md
@@ -8,6 +8,21 @@ The product boundary is deliberate:
 - the dashboard owns retained history, alerts, team workflows, billing, and
   remote kill signal management
 
+## Local or hosted
+
+Start local. Add hosted ingest when the work becomes shared, expensive, or
+risky enough that local files are no longer enough.
+
+| Use local SDK when | Use hosted dashboard when |
+| --- | --- |
+| You are proving AgentGuard in one repo | Multiple people need the same incident history |
+| You need hard stops for loops, retries, timeouts, or budget burn | Runs need retained alerts and follow-up outside the terminal |
+| You want JSONL traces and reports without an API key | You need spend trends across traces, services, or teammates |
+| You are testing an agent before production | Operators need dashboard-managed remote kill signals |
+
+Hosted ingest should make operational follow-up easier. It should not be
+required for local safety, and it should not replace in-process guards.
+
 ## First path
 
 Keep first adoption local:

--- a/proof/dashboard-handoff-guide-2026-05-02/VALIDATION.md
+++ b/proof/dashboard-handoff-guide-2026-05-02/VALIDATION.md
@@ -1,4 +1,4 @@
-﻿# Dashboard Handoff Guide Validation
+# Dashboard Handoff Guide Validation
 
 ## Scope
 

--- a/proof/dashboard-handoff-guide-2026-05-02/VALIDATION.md
+++ b/proof/dashboard-handoff-guide-2026-05-02/VALIDATION.md
@@ -1,0 +1,43 @@
+﻿# Dashboard Handoff Guide Validation
+
+## Scope
+
+Docs and package README only. No SDK runtime behavior, public API, telemetry,
+dependencies, dashboard code, hosted ingest contract, or MCP package metadata
+changed.
+
+Changed:
+
+- `docs/guides/dashboard-contract.md`
+- `README.md`
+- `sdk/PYPI_README.md`
+- `CHANGELOG.md`
+
+## Proof Target
+
+The docs now make the local-to-hosted boundary explicit:
+
+- use local SDK for one-repo proof, hard stops, JSONL traces, local reports, and
+  pre-production testing
+- use hosted dashboard when multiple people need retained incident history,
+  alerts, spend trends, or dashboard-managed remote kill signals
+- local safety remains in-process and does not require hosted ingest
+
+## Checks
+
+```text
+python scripts\generate_pypi_readme.py --check
+passed.
+
+python -m pytest sdk\tests\test_pypi_readme_sync.py -v
+4 passed.
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python scripts\sdk_preflight.py
+4 passed through the PyPI README sync test path.
+
+git diff --check
+passed.
+```

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -272,6 +272,16 @@ The SDK is the free local proof path. The hosted dashboard is for retained
 history, alerts, team visibility, hosted decision history, and remote-control
 operations.
 
+| Use local SDK when | Use hosted dashboard when |
+| --- | --- |
+| You are proving AgentGuard in one repo | Multiple people need the same incident history |
+| You need hard stops for loops, retries, timeouts, or budget burn | Runs need retained alerts and follow-up outside the terminal |
+| You want JSONL traces and reports without an API key | You need spend trends across traces, services, or teammates |
+| You are testing an agent before production | Operators need dashboard-managed remote kill signals |
+
+Start local. Add hosted ingest when the work becomes shared, expensive, or
+risky enough that local files are no longer enough.
+
 ```python
 from agentguard import HttpSink, Tracer
 


### PR DESCRIPTION
## Summary
- Adds a concise local-vs-hosted adoption table to the dashboard contract guide.
- Mirrors the same non-pushy handoff in the README and generated PyPI README.
- Records validation proof for the docs/package-readme sync path.

## Scope / Risk
- Docs and package README only.
- No SDK runtime behavior, public API, telemetry, dependencies, dashboard code, hosted ingest contract, or MCP package metadata changed.
- Rollback: revert this PR; no migration needed.

## Validation
- `python scripts\generate_pypi_readme.py --check` -> passed
- `python -m pytest sdk\tests\test_pypi_readme_sync.py -v` -> 4 passed
- `python scripts\sdk_release_guard.py` -> passed
- `python scripts\sdk_preflight.py` -> passed through the PyPI README sync path
- `git diff --check` and staged whitespace check -> passed

Proof is saved in `proof/dashboard-handoff-guide-2026-05-02/VALIDATION.md`.