### PR TITLE
Fix MCP package release consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   attestations enabled for release artifacts.
 - Added release documentation for the required PyPI trusted-publisher tuple and
   post-release verification steps.
+- Added an MCP package publishing checklist and normalized npm package metadata
+  so the `@agentguard47/mcp-server` release path does not rely on npm publish
+  autocorrections.
 
 ## 1.2.10
 

--- a/docs/release/mcp-publishing.md
+++ b/docs/release/mcp-publishing.md
@@ -45,8 +45,9 @@ Do not store the OTP in shell history, docs, `.npmrc`, or repo files.
 ## Post-publish verification
 
 ```bash
+MCP_VERSION="$(node -p "require('./mcp-server/package.json').version")"
 npm view @agentguard47/mcp-server version
-npm view @agentguard47/mcp-server@0.2.2 version
+npm view "@agentguard47/mcp-server@$MCP_VERSION" version
 npx -y @agentguard47/mcp-server --help
 ```
 

--- a/docs/release/mcp-publishing.md
+++ b/docs/release/mcp-publishing.md
@@ -1,0 +1,55 @@
+# MCP Package Publishing
+
+Use this checklist when `mcp-server/package.json` is ahead of the public npm
+package.
+
+The MCP package is separate from the Python SDK release:
+
+- Python SDK: `agentguard47` on PyPI
+- MCP server: `@agentguard47/mcp-server` on npm
+
+## Pre-publish checks
+
+Run from the repo root:
+
+```bash
+npm view @agentguard47/mcp-server version
+node -p "require('./mcp-server/package.json').version"
+npm --prefix mcp-server test
+python -m pytest sdk/tests/test_mcp_registry_metadata.py -v
+python scripts/sdk_release_guard.py
+```
+
+Then verify the package tarball from `mcp-server/`:
+
+```bash
+cd mcp-server
+npm pack --dry-run
+npm publish --dry-run --access public
+```
+
+The dry run should show the expected version and only the `dist/`, `README.md`,
+`LICENSE`, and `package.json` package files.
+
+## Publish
+
+The npm account must have publish rights and may require a one-time password:
+
+```bash
+cd mcp-server
+npm publish --access public --otp <one-time-code>
+```
+
+Do not store the OTP in shell history, docs, `.npmrc`, or repo files.
+
+## Post-publish verification
+
+```bash
+npm view @agentguard47/mcp-server version
+npm view @agentguard47/mcp-server@0.2.2 version
+npx -y @agentguard47/mcp-server --help
+```
+
+If the latest npm version still does not match `mcp-server/package.json`, stop
+and record the exact npm error in a GitHub issue instead of changing SDK
+runtime code.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bmdhodl/agent47.git",
+    "url": "git+https://github.com/bmdhodl/agent47.git",
     "directory": "mcp-server"
   },
   "homepage": "https://github.com/bmdhodl/agent47/tree/main/mcp-server",
@@ -25,7 +25,7 @@
     "incident-context"
   ],
   "bin": {
-    "agentguard-mcp": "./dist/index.js"
+    "agentguard-mcp": "dist/index.js"
   },
   "files": [
     "dist"

--- a/proof/mcp-release-consistency-2026-05-02/VALIDATION.md
+++ b/proof/mcp-release-consistency-2026-05-02/VALIDATION.md
@@ -1,0 +1,79 @@
+# MCP Release Consistency Validation
+
+## Scope
+
+MCP package release-infra only. No Python SDK runtime behavior, public SDK API,
+dashboard code, hosted ingest contract, or dependencies changed.
+
+Changed:
+
+- `mcp-server/package.json`
+- `docs/release/mcp-publishing.md`
+- `scripts/sdk_preflight.py`
+- `sdk/tests/test_sdk_preflight.py`
+- `CHANGELOG.md`
+
+## Verified State
+
+```text
+node -p "require('./mcp-server/package.json').version"
+0.2.2
+
+npm view @agentguard47/mcp-server version
+0.2.1
+
+npm view @agentguard47/mcp-server@0.2.2 version
+E404: @agentguard47/mcp-server@0.2.2 is not in this registry.
+```
+
+Repo metadata, lockfile, runtime version, and MCP registry metadata all target
+`0.2.2`; npm is the stale surface.
+
+## Publish Attempt
+
+`npm publish --access public` was attempted from `mcp-server/` after successful
+test and dry-run packaging. npm blocked the publish with:
+
+```text
+npm error code EOTP
+npm error This operation requires a one-time password from your authenticator.
+```
+
+The external fix is:
+
+```bash
+cd mcp-server
+npm publish --access public --otp <one-time-code>
+```
+
+Follow-up issue: https://github.com/bmdhodl/agent47/issues/428
+
+## Checks
+
+```text
+npm --prefix mcp-server test
+5 passed.
+
+python -m pytest sdk\tests\test_mcp_registry_metadata.py -v
+4 passed.
+
+python -m pytest sdk\tests\test_sdk_preflight.py sdk\tests\test_mcp_registry_metadata.py -v
+13 passed.
+
+python -m ruff check scripts\sdk_preflight.py sdk\tests\test_sdk_preflight.py
+All checks passed.
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python scripts\sdk_preflight.py
+All checks passed. MCP edits now run `npm.cmd --prefix mcp-server test` on Windows.
+
+cd mcp-server
+npm pack --dry-run
+Tarball version: @agentguard47/mcp-server@0.2.2.
+
+cd mcp-server
+npm publish --dry-run --access public
+Dry run passed.
+```

--- a/scripts/sdk_preflight.py
+++ b/scripts/sdk_preflight.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Iterable, List, Sequence, Set
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+NPM_COMMAND = "npm.cmd" if sys.platform == "win32" else "npm"
 README_SYNC_INPUTS = {
     "README.md",
     "CHANGELOG.md",
@@ -267,7 +268,7 @@ def build_plan(changed_files: Sequence[str]) -> List[Step]:
             Step(
                 label="mcp-test",
                 reason="mcp-server edits should still build and pass the lightweight Node test suite",
-                command=["npm", "--prefix", "mcp-server", "test"],
+                command=[NPM_COMMAND, "--prefix", "mcp-server", "test"],
             )
         )
 

--- a/sdk/tests/test_sdk_preflight.py
+++ b/sdk/tests/test_sdk_preflight.py
@@ -118,7 +118,7 @@ class TestBuildPlan(unittest.TestCase):
         self.assertEqual(labels, ["mcp-test"])
         self.assertEqual(
             steps[0].command,
-            ["npm", "--prefix", "mcp-server", "test"],
+            [sdk_preflight.NPM_COMMAND, "--prefix", "mcp-server", "test"],
         )
 
 


### PR DESCRIPTION
## Summary
- Verifies the MCP drift: repo metadata is `@agentguard47/mcp-server@0.2.2`, npm latest is still `0.2.1`, and `0.2.2` is unpublished.
- Normalizes npm package metadata so publish no longer relies on npm autocorrections.
- Adds an MCP publishing checklist and proof artifact with the exact npm 2FA blocker.
- Fixes Windows `sdk_preflight.py` MCP checks by using `npm.cmd` on Windows.

## Current verified package state
- Repo package version: `0.2.2`
- MCP registry metadata version: `0.2.2`
- Runtime server version: `0.2.2`
- npm latest: `0.2.1`
- `npm view @agentguard47/mcp-server@0.2.2 version`: E404, not published

## Publish blocker
`npm publish --access public` was attempted after tests and dry-run packaging passed. npm blocked the publish with `EOTP`, requiring an authenticator one-time password.

Follow-up issue: #428

Completion command once OTP is available:

```bash
cd mcp-server
npm publish --access public --otp <one-time-code>
npm view @agentguard47/mcp-server version
```

## Validation
- `npm --prefix mcp-server test` -> 5 passed
- `python -m pytest sdk\tests\test_mcp_registry_metadata.py -v` -> 4 passed
- `python -m pytest sdk\tests\test_sdk_preflight.py sdk\tests\test_mcp_registry_metadata.py -v` -> 13 passed
- `python -m ruff check scripts\sdk_preflight.py sdk\tests\test_sdk_preflight.py` -> passed
- `python scripts\sdk_release_guard.py` -> passed
- `python scripts\sdk_preflight.py` -> passed
- `npm pack --dry-run` from `mcp-server/` -> tarball version `0.2.2`
- `npm publish --dry-run --access public` from `mcp-server/` -> passed
- `git diff --check` and staged whitespace check -> passed

Proof is saved in `proof/mcp-release-consistency-2026-05-02/VALIDATION.md`.