### PR TITLE
feat: add sticky agent proof fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Release Proof
+- Added a deterministic sticky agent proof example that simulates a
+  CrewAI-style retry storm, repeated tool loop, budget burn, local incident
+  output, and dashboard-compatible hosted NDJSON without adding dependencies.
+- Added contract tests that post the sticky proof NDJSON to the local hosted
+  ingest harness so SDK proof events stay aligned with dashboard expectations.
+
 ### Activation
 - Added a post-demo next-step block so `agentguard demo` points directly to
   `agentguard quickstart --framework raw --write`, the generated starter, and

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
-Sales-ready proof with local incident output and hosted-compatible NDJSON:
+Installed-package proof:
 
 ```bash
+agentguard demo
+```
+
+Source-checkout proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+git clone https://github.com/bmdhodl/agent47.git
+cd agent47
 PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
 agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
+Sales-ready proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+```
+
 Expected first value moment:
 
 ```text
@@ -161,6 +168,7 @@ All examples are local-first. No API key is required unless the example says so.
 | Example | What it proves |
 |---|---|
 | [`examples/try_it_now.py`](examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/sticky_agent_proof.py`](examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
 | [`examples/coding_agent_review_loop.py`](examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
 | [`examples/per_token_budget_spike.py`](examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
 | [`examples/budget_aware_escalation.py`](examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |

--- a/docs/examples/proof-gallery.md
+++ b/docs/examples/proof-gallery.md
@@ -41,7 +41,28 @@ Proves:
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](coding-agent-review-loop-incident.md)
 
-## 3. Token-Budget Spike
+## 3. Sticky Agent Proof
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+```
+
+Proves:
+
+- one CrewAI-style workflow can show retry storm, loop detection, and budget burn
+- the SDK can write a local incident report and hosted-compatible NDJSON
+- dashboard proof can be validated without adding framework dependencies
+
+Expected artifacts:
+
+```text
+sticky_agent_proof_traces.jsonl
+sticky_agent_proof_hosted.ndjson
+sticky_agent_proof_incident.md
+```
+
+## 4. Token-Budget Spike
 
 ```bash
 python examples/per_token_budget_spike.py
@@ -60,7 +81,7 @@ Expected stop condition:
 Cost budget exceeded:
 ```
 
-## 4. Decision Trace Workflow
+## 5. Decision Trace Workflow
 
 ```bash
 python examples/decision_trace_workflow.py
@@ -82,7 +103,7 @@ decision.approved
 decision.bound
 ```
 
-## 5. Budget-Aware Escalation
+## 6. Budget-Aware Escalation
 
 ```bash
 python examples/budget_aware_escalation.py
@@ -100,7 +121,7 @@ Expected stop condition:
 Escalation reason: token_count 2430 exceeded 2000
 ```
 
-## 6. Starter File Smoke Test
+## 7. Starter File Smoke Test
 
 ```bash
 agentguard quickstart --framework raw --write
@@ -116,12 +137,13 @@ Proves:
 
 ## What To Share
 
-The most shareable public demo is the coding-agent review loop:
+The most shareable public demo for the release train is the sticky agent proof:
 
 ```bash
-python examples/coding_agent_review_loop.py
-agentguard incident coding_agent_review_loop_traces.jsonl
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
 ```
 
-It maps directly to the product wedge: a coding agent gets stuck reviewing and
-retrying, then AgentGuard stops the run before it keeps burning tokens.
+It maps directly to the product wedge: a production-style agent workflow retries,
+loops, burns budget, then AgentGuard produces a local incident and a
+dashboard-ready event stream.

--- a/docs/guides/dashboard-contract.md
+++ b/docs/guides/dashboard-contract.md
@@ -57,6 +57,25 @@ with:
 - network failures are logged instead of crashing the calling agent
 - retries are bounded by `max_retries`
 
+## Contract proof fixture
+
+Use the sticky proof example when you need one local artifact that can also be
+validated by the dashboard ingest contract:
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+```
+
+It writes:
+
+- `sticky_agent_proof_traces.jsonl` for local reports and incident output
+- `sticky_agent_proof_incident.md` for local review or PR evidence
+- `sticky_agent_proof_hosted.ndjson` with dashboard-compatible `span` and
+  `event` records
+
+The hosted NDJSON drops local-only records and mirrors each event `kind` into
+`type`, matching the same normalization boundary used by `HttpSink`.
+
 ## Decision history
 
 Decision traces are ordinary AgentGuard events. The hosted dashboard recognizes

--- a/examples/sticky_agent_proof.py
+++ b/examples/sticky_agent_proof.py
@@ -1,0 +1,255 @@
+"""Sticky local proof for a runaway CrewAI-style agent workflow.
+
+Run:
+
+    PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+    agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+
+No API keys, dashboard, framework installs, or network calls are required.
+The optional hosted NDJSON output mirrors the shape posted by ``HttpSink`` so
+the dashboard can validate the same proof contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, TextIO
+
+from agentguard import (
+    BudgetExceeded,
+    BudgetGuard,
+    JsonlFileSink,
+    LoopDetected,
+    LoopGuard,
+    RetryGuard,
+    RetryLimitExceeded,
+    Tracer,
+)
+from agentguard.reporting import render_incident_report
+
+DEFAULT_OUT_DIR = Path("sticky_agent_proof_output")
+TRACE_NAME = "sticky_agent_proof_traces.jsonl"
+HOSTED_NAME = "sticky_agent_proof_hosted.ndjson"
+INCIDENT_NAME = "sticky_agent_proof_incident.md"
+SERVICE = "crewai-vendor-review-sticky-proof"
+
+
+def run_sticky_agent_proof(
+    out_dir: Path | str = DEFAULT_OUT_DIR,
+    stream: Optional[TextIO] = None,
+) -> Dict[str, Path]:
+    """Run a deterministic local proof and write trace, hosted, and incident files."""
+    output = stream or sys.stdout
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    trace_path = out_path / TRACE_NAME
+    hosted_path = out_path / HOSTED_NAME
+    incident_path = out_path / INCIDENT_NAME
+    for path in (trace_path, hosted_path, incident_path):
+        if path.exists():
+            path.unlink()
+
+    tracer = Tracer(
+        sink=JsonlFileSink(str(trace_path)),
+        service=SERVICE,
+        metadata={"framework": "crewai", "proof": "sticky-agent-proof"},
+        watermark=False,
+    )
+
+    _print(output, "AgentGuard sticky agent proof")
+    _print(output, "Synthetic CrewAI-style vendor review. No API keys. No network.")
+    _run_retry_storm(tracer, output)
+    _run_loop_detection(tracer, output)
+    _run_budget_burn(tracer, output)
+    _write_hosted_ndjson(trace_path, hosted_path)
+    incident_path.write_text(
+        render_incident_report(str(trace_path), output_format="markdown"),
+        encoding="utf-8",
+    )
+
+    _print(output, "")
+    _print(output, "Proof complete.")
+    _print(output, f"Trace: {trace_path}")
+    _print(output, f"Hosted NDJSON: {hosted_path}")
+    _print(output, f"Incident: {incident_path}")
+    return {
+        "trace": trace_path,
+        "hosted": hosted_path,
+        "incident": incident_path,
+    }
+
+
+def _run_retry_storm(tracer: Tracer, out: TextIO) -> None:
+    retry_guard = RetryGuard(max_retries=3)
+    _print(out, "")
+    _print(out, "1. RetryGuard: catching a clause lookup retry storm")
+    with tracer.trace(
+        "crewai.vendor_review.retry_storm",
+        data={"crew": "vendor-review", "agent": "risk-reviewer"},
+    ) as span:
+        for attempt in range(1, 6):
+            span.event(
+                "tool.retry",
+                data={
+                    "framework": "crewai",
+                    "agent": "risk-reviewer",
+                    "task": "vendor-contract-review",
+                    "tool_name": "clause_lookup",
+                    "attempt": attempt,
+                    "reason": "same upstream timeout",
+                },
+            )
+            try:
+                retry_guard.check("clause_lookup")
+                _print(out, f"  clause_lookup retry {attempt} allowed")
+            except RetryLimitExceeded as exc:
+                span.event(
+                    "guard.retry_limit_exceeded",
+                    data={
+                        "framework": "crewai",
+                        "tool_name": "clause_lookup",
+                        "attempt": attempt,
+                        "message": str(exc),
+                    },
+                )
+                _print(out, f"  stopped retry storm on attempt {attempt}: {exc}")
+                return
+
+
+def _run_loop_detection(tracer: Tracer, out: TextIO) -> None:
+    loop_guard = LoopGuard(max_repeats=3, window=5)
+    args = {"vendor": "acme-medical", "clause": "termination-for-convenience"}
+    _print(out, "")
+    _print(out, "2. LoopGuard: catching the same tool call repeating")
+    with tracer.trace(
+        "crewai.vendor_review.loop_detection",
+        data={"crew": "vendor-review", "agent": "risk-reviewer"},
+    ) as span:
+        for attempt in range(1, 5):
+            span.event(
+                "tool.clause_lookup",
+                data={
+                    "framework": "crewai",
+                    "agent": "risk-reviewer",
+                    "task": "vendor-contract-review",
+                    "tool_name": "clause_lookup",
+                    "attempt": attempt,
+                    "args": args,
+                },
+            )
+            try:
+                loop_guard.check("clause_lookup", args)
+                _print(out, f"  repeated lookup {attempt} allowed")
+            except LoopDetected as exc:
+                span.event(
+                    "guard.loop_detected",
+                    data={
+                        "framework": "crewai",
+                        "tool_name": "clause_lookup",
+                        "attempt": attempt,
+                        "message": str(exc),
+                    },
+                )
+                _print(out, f"  stopped repeated tool loop: {exc}")
+                return
+
+
+def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
+    budget = BudgetGuard(max_cost_usd=0.05, warn_at_pct=0.8)
+    costs = (0.013, 0.014, 0.014, 0.016)
+    _print(out, "")
+    _print(out, "3. BudgetGuard: stopping cost before it compounds")
+    with tracer.trace(
+        "crewai.vendor_review.budget_burn",
+        data={"crew": "vendor-review", "agent": "risk-reviewer"},
+    ) as span:
+        for attempt, cost in enumerate(costs, 1):
+            span.event(
+                "llm.result",
+                data={
+                    "framework": "crewai",
+                    "agent": "risk-reviewer",
+                    "task": "vendor-contract-review",
+                    "model": "gpt-4o",
+                    "usage": {
+                        "prompt_tokens": 1800 + attempt * 250,
+                        "completion_tokens": 420,
+                        "total_tokens": 2220 + attempt * 250,
+                    },
+                    "cost_usd": cost,
+                },
+                cost_usd=cost,
+            )
+            warned_before = budget._warned
+            try:
+                budget.consume(tokens=2220 + attempt * 250, calls=1, cost_usd=cost)
+                _print(out, f"  model call {attempt}: ${budget.state.cost_used:.3f} used")
+            except BudgetExceeded as exc:
+                span.event(
+                    "guard.budget_exceeded",
+                    data={
+                        "framework": "crewai",
+                        "attempt": attempt,
+                        "message": str(exc),
+                        "cost_used": round(budget.state.cost_used, 6),
+                        "limit_usd": budget.max_cost_usd,
+                    },
+                )
+                _print(out, f"  stopped budget burn: {exc}")
+                return
+            if not warned_before and budget._warned:
+                span.event(
+                    "guard.budget_warning",
+                    data={
+                        "framework": "crewai",
+                        "cost_used": round(budget.state.cost_used, 6),
+                        "limit_usd": budget.max_cost_usd,
+                    },
+                )
+                _print(out, f"  budget warning at ${budget.state.cost_used:.3f}")
+
+
+def _write_hosted_ndjson(trace_path: Path, hosted_path: Path) -> None:
+    with trace_path.open(encoding="utf-8") as source, hosted_path.open(
+        "w",
+        encoding="utf-8",
+    ) as target:
+        for event in _hosted_events(source):
+            target.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _hosted_events(lines: Iterable[str]) -> Iterable[Dict[str, Any]]:
+    for line in lines:
+        if not line.strip():
+            continue
+        event = json.loads(line)
+        kind = event.get("kind")
+        if kind not in {"span", "event"}:
+            continue
+        hosted_event = dict(event)
+        hosted_event.setdefault("type", kind)
+        yield hosted_event
+
+
+def _print(stream: TextIO, line: str) -> None:
+    stream.write(line + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        default=str(DEFAULT_OUT_DIR),
+        help="Directory for trace, hosted NDJSON, and incident artifacts.",
+    )
+    args = parser.parse_args(argv)
+    run_sticky_agent_proof(Path(args.out_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/sticky_agent_proof.py
+++ b/examples/sticky_agent_proof.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, TextIO
@@ -159,7 +158,12 @@ def _run_loop_detection(tracer: Tracer, out: TextIO) -> None:
 
 
 def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
-    budget = BudgetGuard(max_cost_usd=0.05, warn_at_pct=0.8)
+    warnings: list[str] = []
+    budget = BudgetGuard(
+        max_cost_usd=0.05,
+        warn_at_pct=0.8,
+        on_warning=warnings.append,
+    )
     costs = (0.013, 0.014, 0.014, 0.016)
     _print(out, "")
     _print(out, "3. BudgetGuard: stopping cost before it compounds")
@@ -184,7 +188,7 @@ def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
                 },
                 cost_usd=cost,
             )
-            warned_before = budget._warned
+            warning_count = len(warnings)
             try:
                 budget.consume(tokens=2220 + attempt * 250, calls=1, cost_usd=cost)
                 _print(out, f"  model call {attempt}: ${budget.state.cost_used:.3f} used")
@@ -201,11 +205,12 @@ def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
                 )
                 _print(out, f"  stopped budget burn: {exc}")
                 return
-            if not warned_before and budget._warned:
+            if len(warnings) > warning_count:
                 span.event(
                     "guard.budget_warning",
                     data={
                         "framework": "crewai",
+                        "message": warnings[-1],
                         "cost_used": round(budget.state.cost_used, 6),
                         "limit_usd": budget.max_cost_usd,
                     },
@@ -227,10 +232,11 @@ def _hosted_events(lines: Iterable[str]) -> Iterable[Dict[str, Any]]:
         if not line.strip():
             continue
         event = json.loads(line)
-        kind = event.get("kind")
+        kind = event.get("kind") or event.get("type")
         if kind not in {"span", "event"}:
             continue
         hosted_event = dict(event)
+        hosted_event.setdefault("kind", kind)
         hosted_event.setdefault("type", kind)
         yield hosted_event
 

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -33,6 +33,7 @@ UNRELEASED_PATHS = {
     "docs/guides/decision-tracing.md",
     "docs/guides/managed-agent-sessions.md",
     "docs/release/trusted-publishing.md",
+    "examples/sticky_agent_proof.py",
 }
 
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -60,6 +60,13 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
+Sales-ready proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+```
+
 Expected first value moment:
 
 ```text
@@ -163,6 +170,7 @@ All examples are local-first. No API key is required unless the example says so.
 | Example | What it proves |
 |---|---|
 | [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
 | [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
 | [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
 | [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -60,9 +60,17 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
-Sales-ready proof with local incident output and hosted-compatible NDJSON:
+Installed-package proof:
 
 ```bash
+agentguard demo
+```
+
+Source-checkout proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+git clone https://github.com/bmdhodl/agent47.git
+cd agent47
 PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
 agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
 ```
@@ -170,7 +178,7 @@ All examples are local-first. No API key is required unless the example says so.
 | Example | What it proves |
 |---|---|
 | [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/try_it_now.py) | budget, loop, and retry stops |
-| [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
+| [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/main/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
 | [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
 | [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
 | [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |

--- a/sdk/tests/test_sticky_agent_proof.py
+++ b/sdk/tests/test_sticky_agent_proof.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import urllib.request
+from pathlib import Path
+
+from conftest import EXPECTED_API_KEY, IngestHandler
+
+EXAMPLE_PATH = Path(__file__).resolve().parents[2] / "examples" / "sticky_agent_proof.py"
+
+
+def _load_example_module():
+    spec = importlib.util.spec_from_file_location("sticky_agent_proof", EXAMPLE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sticky_agent_proof_writes_local_and_hosted_artifacts(tmp_path):
+    module = _load_example_module()
+    output = io.StringIO()
+
+    paths = module.run_sticky_agent_proof(tmp_path, stream=output)
+
+    assert paths["trace"].exists()
+    assert paths["hosted"].exists()
+    assert paths["incident"].exists()
+    text = output.getvalue()
+    assert "No API keys. No network." in text
+    assert "stopped retry storm" in text
+    assert "stopped repeated tool loop" in text
+    assert "stopped budget burn" in text
+
+    local_events = [
+        json.loads(line)
+        for line in paths["trace"].read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    hosted_events = [
+        json.loads(line)
+        for line in paths["hosted"].read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    names = [event["name"] for event in local_events]
+
+    assert "guard.retry_limit_exceeded" in names
+    assert "guard.loop_detected" in names
+    assert "guard.budget_warning" in names
+    assert "guard.budget_exceeded" in names
+    assert hosted_events
+    assert len(hosted_events) == len(local_events)
+    assert all(event["kind"] in {"span", "event"} for event in hosted_events)
+    assert all(event["type"] == event["kind"] for event in hosted_events)
+    assert all(event["service"] == module.SERVICE for event in hosted_events)
+
+    incident = paths["incident"].read_text(encoding="utf-8")
+    assert "# AgentGuard Incident Report" in incident
+    assert "retry_limit_exceeded" in incident
+    assert "retained history, alerts, spend trends" in incident
+
+
+def test_sticky_agent_proof_hosted_ndjson_matches_ingest_contract(tmp_path, ingest_url):
+    module = _load_example_module()
+    paths = module.run_sticky_agent_proof(tmp_path, stream=io.StringIO())
+
+    request = urllib.request.Request(
+        ingest_url,
+        data=paths["hosted"].read_bytes(),
+        headers={
+            "Authorization": f"Bearer {EXPECTED_API_KEY}",
+            "Content-Type": "application/x-ndjson",
+        },
+        method="POST",
+    )
+
+    with urllib.request.urlopen(request) as response:
+        payload = json.loads(response.read().decode())
+
+    request_log = IngestHandler.request_log()
+    assert payload["accepted"] > 0
+    assert payload["rejected"] == 0
+    assert request_log[-1]["status"] == 200


### PR DESCRIPTION
﻿## What changed
- Added `examples/sticky_agent_proof.py`, a deterministic CrewAI-style local proof for retry storm, repeated tool loop, budget burn, hosted NDJSON, and local incident output.
- Added SDK tests that verify the generated hosted NDJSON posts cleanly to the local hosted ingest harness.
- Updated README, proof gallery, dashboard contract docs, changelog, and generated PyPI README so the proof is discoverable and release-safe.

## Why it matters
This gives AgentGuard a sticky first-client demo: run one command, get local proof, get an incident report, and get dashboard-compatible events without adding dependencies or needing framework installs.

## How to verify
- `python -m pytest sdk/tests/test_sticky_agent_proof.py sdk/tests/test_hosted_ingest_contract.py -q`
- `python -m pytest sdk/tests/ -q`
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py`
- `python scripts/sdk_preflight.py`
- `python scripts/sdk_release_guard.py`
- `npm --prefix mcp-server ci`
- `npm --prefix mcp-server test`
- `PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir %TEMP%\agentguard-sticky-proof-validation`
- `PYTHONPATH=sdk python -m agentguard.cli incident %TEMP%\agentguard-sticky-proof-validation\sticky_agent_proof_traces.jsonl --format json`

## Risks
- Example uses synthetic CrewAI-style metadata, not the CrewAI package itself. This is intentional to keep core SDK proof zero-dependency.
- The generated trace IDs and timestamps are runtime-generated; the event sequence and contract shape are deterministic.

## Rollback
Revert this PR. It only adds an example/test/docs and does not change runtime SDK APIs.
