### PR TITLE
Add first-run CLI fallback guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Activation
+- Added `python -m agentguard.cli ...` fallback guidance to `doctor`, `demo`,
+  and `quickstart` so first-run users are not blocked when console scripts
+  install outside `PATH`.
 - Added a post-demo next-step block so `agentguard demo` points directly to
   `agentguard quickstart --framework raw --write`, the generated starter, and
   the follow-up local report command.

--- a/proof/first-run-activation-hardening-2026-05-03/VALIDATION.md
+++ b/proof/first-run-activation-hardening-2026-05-03/VALIDATION.md
@@ -1,0 +1,98 @@
+# First-Run Activation Hardening Validation
+
+Date: 2026-05-03
+Branch: `codex/first-run-activation-hardening`
+
+## Goal
+
+Make the local first-run path recoverable on environments where `pip install`
+places the `agentguard` console script outside `PATH`.
+
+## Reproduced Friction
+
+Editable install on this Windows host emitted:
+
+```text
+WARNING: The script agentguard.exe is installed in
+'C:\Users\patri\AppData\Roaming\Python\Python313\Scripts' which is not on PATH.
+```
+
+Without a fallback, a new user can install the SDK successfully but fail at the
+next documented `agentguard doctor` command.
+
+## Runtime Proof
+
+Clean temp directory:
+
+```text
+C:\Users\patri\AppData\Local\Temp\agentguard-first-run-proof-073756dc4c83460b9fc8f2a224d2503a
+```
+
+Commands:
+
+```powershell
+python -m pip install -e .\sdk
+python -m agentguard.cli doctor
+python -m agentguard.cli demo
+python -m agentguard.cli quickstart --framework raw --write
+python .\agentguard_raw_quickstart.py
+python -m agentguard.cli report .agentguard\traces.jsonl
+```
+
+Observed fallback guidance:
+
+```text
+If 'agentguard' is not on PATH:
+  python -m agentguard.cli demo
+  python -m agentguard.cli report agentguard_doctor_trace.jsonl
+
+If 'agentguard' is not on PATH:
+  python -m agentguard.cli report agentguard_demo_traces.jsonl
+  python -m agentguard.cli incident agentguard_demo_traces.jsonl
+  python -m agentguard.cli quickstart --framework raw --write
+
+Wrote starter: agentguard_raw_quickstart.py
+If 'agentguard' is not on PATH:
+  python -m agentguard.cli doctor
+  python -m agentguard.cli report .agentguard/traces.jsonl
+```
+
+Generated starter result:
+
+```text
+Traces saved to .agentguard/traces.jsonl
+```
+
+Report result:
+
+```text
+AgentGuard report
+  Total events: 7
+  Spans: 4  Events: 2
+  Approx run time: 1.5 ms
+  Reasoning steps: 0
+  Tool results: 1
+  LLM results: 0
+  Estimated cost: $0.00
+```
+
+## Local Checks
+
+```text
+python -m pytest sdk\tests\test_doctor.py sdk\tests\test_demo.py sdk\tests\test_quickstart.py -v
+23 passed in 0.23s
+
+python -m ruff check sdk\agentguard\doctor.py sdk\agentguard\demo.py sdk\agentguard\quickstart.py sdk\tests\test_doctor.py sdk\tests\test_demo.py sdk\tests\test_quickstart.py
+All checks passed!
+
+python scripts\sdk_preflight.py
+All checks passed!
+
+git diff --check
+passed
+```
+
+## Risk
+
+Low. The change is human-readable CLI guidance only. JSON payloads, public APIs,
+runtime guard behavior, package metadata, and dependencies are unchanged.

--- a/proof/first-run-activation-hardening-2026-05-03/VALIDATION.md
+++ b/proof/first-run-activation-hardening-2026-05-03/VALIDATION.md
@@ -14,7 +14,7 @@ Editable install on this Windows host emitted:
 
 ```text
 WARNING: The script agentguard.exe is installed in
-'C:\Users\patri\AppData\Roaming\Python\Python313\Scripts' which is not on PATH.
+'C:\Users\<USER>\AppData\Roaming\Python\Python313\Scripts' which is not on PATH.
 ```
 
 Without a fallback, a new user can install the SDK successfully but fail at the
@@ -25,7 +25,7 @@ next documented `agentguard doctor` command.
 Clean temp directory:
 
 ```text
-C:\Users\patri\AppData\Local\Temp\agentguard-first-run-proof-073756dc4c83460b9fc8f2a224d2503a
+C:\Users\<USER>\AppData\Local\Temp\agentguard-first-run-proof-<RUN_ID>
 ```
 
 Commands:

--- a/sdk/agentguard/demo.py
+++ b/sdk/agentguard/demo.py
@@ -70,6 +70,11 @@ def run_offline_demo(
     _print(out, "  agentguard quickstart --framework raw --write")
     _print(out, "  python agentguard_raw_quickstart.py")
     _print(out, "  agentguard report .agentguard/traces.jsonl")
+    _print(out, "")
+    _print(out, "If 'agentguard' is not on PATH:")
+    _print(out, f"  python -m agentguard.cli report {trace_path}")
+    _print(out, f"  python -m agentguard.cli incident {trace_path}")
+    _print(out, "  python -m agentguard.cli quickstart --framework raw --write")
     _print(out, "SDK gives you local enforcement. The dashboard adds alerts, retained history, and remote controls.")
     return 0
 

--- a/sdk/agentguard/demo.py
+++ b/sdk/agentguard/demo.py
@@ -61,20 +61,29 @@ def run_offline_demo(
     _print(out, "")
     _run_retry_demo(tracer, out)
     _print(out, "")
+    rendered_trace_path = _shell_quote_path(trace_path)
     _print(out, "Local proof complete.")
     _print(out, f"Trace written to: {trace_path}")
-    _print(out, f"View summary: agentguard report {trace_path}")
-    _print(out, f"View incident report: agentguard incident {trace_path}")
+    _print(out, f"View summary: agentguard report {rendered_trace_path}")
+    _print(out, f"View incident report: agentguard incident {rendered_trace_path}")
     _print(out, "")
     _print(out, "Next: add AgentGuard to a repo")
-    _print(out, "  agentguard quickstart --framework raw --write")
-    _print(out, "  python agentguard_raw_quickstart.py")
-    _print(out, "  agentguard report .agentguard/traces.jsonl")
+    next_commands = [
+        "agentguard quickstart --framework raw --write",
+        "python agentguard_raw_quickstart.py",
+        "agentguard report .agentguard/traces.jsonl",
+    ]
+    for command in next_commands:
+        _print(out, f"  {command}")
     _print(out, "")
-    _print(out, "If 'agentguard' is not on PATH:")
-    _print(out, f"  python -m agentguard.cli report {trace_path}")
-    _print(out, f"  python -m agentguard.cli incident {trace_path}")
-    _print(out, "  python -m agentguard.cli quickstart --framework raw --write")
+    fallback_commands = _module_command_fallbacks(
+        [
+            f"agentguard report {rendered_trace_path}",
+            f"agentguard incident {rendered_trace_path}",
+            *next_commands,
+        ]
+    )
+    _render_module_fallback(fallback_commands, out)
     _print(out, "SDK gives you local enforcement. The dashboard adds alerts, retained history, and remote controls.")
     return 0
 
@@ -164,6 +173,29 @@ def _run_retry_demo(tracer: Tracer, out: TextIO) -> None:
 
 def _print(stream: TextIO, line: str) -> None:
     stream.write(line + "\n")
+
+
+def _render_module_fallback(commands: list[str], out: TextIO) -> None:
+    if not commands:
+        return
+
+    _print(out, "If 'agentguard' is not on PATH:")
+    for command in commands:
+        _print(out, f"  {command}")
+
+
+def _module_command_fallbacks(commands: list[str]) -> list[str]:
+    fallback_commands: list[str] = []
+    for command in commands:
+        if command.startswith("agentguard "):
+            fallback_commands.append(command.replace("agentguard ", "python -m agentguard.cli ", 1))
+    return fallback_commands
+
+
+def _shell_quote_path(path: str) -> str:
+    if not any(char.isspace() or char in {'"', "'"} for char in path):
+        return path
+    return '"' + path.replace('"', '\\"') + '"'
 
 
 def main() -> None:  # pragma: no cover

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -93,7 +93,7 @@ def _run_checks(trace_path: str) -> Dict[str, Any]:
         "integration_hints": hints,
         "next_commands": [
             "agentguard demo",
-            f"agentguard report {normalized_path}",
+            f"agentguard report {_shell_quote_path(normalized_path)}",
         ],
         "recommended_repo_config": _recommended_repo_config(),
         "recommended_snippet": _recommended_snippet(repo_config_path is not None),
@@ -242,10 +242,12 @@ def _render_text(result: Dict[str, Any], out: TextIO) -> None:
     _print(out, "Helpful commands:")
     for command in result["next_commands"]:
         _print(out, f"  {command}")
-    _print(out, "")
-    _print(out, "If 'agentguard' is not on PATH:")
-    _print(out, "  python -m agentguard.cli demo")
-    _print(out, f"  python -m agentguard.cli report {result['trace_file']}")
+    fallback_commands = _module_command_fallbacks(result["next_commands"])
+    if fallback_commands:
+        _print(out, "")
+        _print(out, "If 'agentguard' is not on PATH:")
+        for command in fallback_commands:
+            _print(out, f"  {command}")
 
     if hints:
         _print(out, "")
@@ -256,3 +258,17 @@ def _render_text(result: Dict[str, Any], out: TextIO) -> None:
 
 def _print(stream: TextIO, line: str) -> None:
     stream.write(line + "\n")
+
+
+def _module_command_fallbacks(commands: List[str]) -> List[str]:
+    return [
+        command.replace("agentguard ", "python -m agentguard.cli ", 1)
+        for command in commands
+        if command.startswith("agentguard ")
+    ]
+
+
+def _shell_quote_path(path: str) -> str:
+    if not any(char.isspace() or char in {'"', "'"} for char in path):
+        return path
+    return '"' + path.replace('"', '\\"') + '"'

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -242,6 +242,10 @@ def _render_text(result: Dict[str, Any], out: TextIO) -> None:
     _print(out, "Helpful commands:")
     for command in result["next_commands"]:
         _print(out, f"  {command}")
+    _print(out, "")
+    _print(out, "If 'agentguard' is not on PATH:")
+    _print(out, "  python -m agentguard.cli demo")
+    _print(out, f"  python -m agentguard.cli report {result['trace_file']}")
 
     if hints:
         _print(out, "")

--- a/sdk/agentguard/quickstart.py
+++ b/sdk/agentguard/quickstart.py
@@ -128,6 +128,7 @@ def _render_text(payload: Dict[str, Any], out: TextIO) -> None:
     _print(out, "Next commands:")
     for command in payload["next_commands"]:
         _print(out, f"  {command}")
+    _render_module_fallback(payload["next_commands"], out)
 
 
 def _render_written_text(payload: Dict[str, Any], destination: str, out: TextIO) -> None:
@@ -151,8 +152,10 @@ def _render_written_text(payload: Dict[str, Any], destination: str, out: TextIO)
             _print(out, f"  - {note}")
     _print(out, "")
     _print(out, "Next commands:")
-    for command in _rendered_next_commands(payload["next_commands"], payload["filename"], destination):
+    rendered_commands = _rendered_next_commands(payload["next_commands"], payload["filename"], destination)
+    for command in rendered_commands:
         _print(out, f"  {command}")
+    _render_module_fallback(rendered_commands, out)
 
 
 def _base_payload(
@@ -203,6 +206,25 @@ def _rendered_next_commands(
     for command in commands:
         rendered.append(command.replace(filename, rendered_destination))
     return rendered
+
+
+def _render_module_fallback(commands: List[str], out: TextIO) -> None:
+    fallback_commands = _module_command_fallbacks(commands)
+    if not fallback_commands:
+        return
+
+    _print(out, "")
+    _print(out, "If 'agentguard' is not on PATH:")
+    for command in fallback_commands:
+        _print(out, f"  {command}")
+
+
+def _module_command_fallbacks(commands: List[str]) -> List[str]:
+    fallback_commands: List[str] = []
+    for command in commands:
+        if command.startswith("agentguard "):
+            fallback_commands.append("python -m agentguard.cli " + command[len("agentguard ") :])
+    return fallback_commands
 
 
 def _shell_quote_path(path: str) -> str:

--- a/sdk/tests/test_demo.py
+++ b/sdk/tests/test_demo.py
@@ -27,6 +27,10 @@ class TestOfflineDemo(unittest.TestCase):
             self.assertIn("agentguard quickstart --framework raw --write", output)
             self.assertIn("python agentguard_raw_quickstart.py", output)
             self.assertIn("agentguard report .agentguard/traces.jsonl", output)
+            self.assertIn("If 'agentguard' is not on PATH:", output)
+            self.assertIn(f"python -m agentguard.cli report {trace_path}", output)
+            self.assertIn(f"python -m agentguard.cli incident {trace_path}", output)
+            self.assertIn("python -m agentguard.cli quickstart --framework raw --write", output)
             self.assertIn("SDK gives you local enforcement. The dashboard adds alerts", output)
             self.assertTrue(os.path.exists(trace_path))
 

--- a/sdk/tests/test_demo.py
+++ b/sdk/tests/test_demo.py
@@ -54,6 +54,20 @@ class TestOfflineDemo(unittest.TestCase):
             self.assertTrue(os.path.exists(trace_path))
             self.assertIn("Trace written to", buf.getvalue())
 
+    def test_run_offline_demo_quotes_paths_with_spaces_in_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trace_path = os.path.join(tmpdir, "space dir", "demo's trace.jsonl")
+            buf = io.StringIO()
+
+            result = run_offline_demo(trace_path=trace_path, stream=buf)
+
+            self.assertEqual(result, 0)
+            output = buf.getvalue()
+            quoted_path = '"' + trace_path + '"'
+            self.assertIn(f"View summary: agentguard report {quoted_path}", output)
+            self.assertIn(f"python -m agentguard.cli incident {quoted_path}", output)
+            self.assertIn("python -m agentguard.cli report .agentguard/traces.jsonl", output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -132,6 +132,18 @@ class TestDoctor(unittest.TestCase):
             self.assertEqual(payload["repo_config_path"], config_path)
             self.assertIn("Invalid JSON", payload["repo_config_error"])
 
+    def test_run_doctor_quotes_paths_with_spaces_in_fallback_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trace_path = os.path.join(tmpdir, "space dir", "doctor's trace.jsonl")
+            buf = io.StringIO()
+
+            result = run_doctor(trace_path=trace_path, stream=buf)
+
+            self.assertEqual(result, 0)
+            quoted_path = '"' + trace_path + '"'
+            self.assertIn(f"agentguard report {quoted_path}", buf.getvalue())
+            self.assertIn(f"python -m agentguard.cli report {quoted_path}", buf.getvalue())
+
     def test_run_doctor_fails_without_tearing_down_existing_tracer(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             live_trace = os.path.join(tmpdir, "live.jsonl")

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -26,6 +26,9 @@ class TestDoctor(unittest.TestCase):
             self.assertIn("Suggested next step:", output)
             self.assertIn("local_only=True", output)
             self.assertIn("agentguard demo", output)
+            self.assertIn("If 'agentguard' is not on PATH:", output)
+            self.assertIn("python -m agentguard.cli demo", output)
+            self.assertIn(f"python -m agentguard.cli report {trace_path}", output)
 
     def test_run_doctor_json_output_is_parseable(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/sdk/tests/test_quickstart.py
+++ b/sdk/tests/test_quickstart.py
@@ -22,6 +22,8 @@ class TestQuickstart(unittest.TestCase):
         self.assertIn("pip install agentguard47", output)
         self.assertIn("local_only=True", output)
         self.assertIn("agentguard doctor", output)
+        self.assertIn("If 'agentguard' is not on PATH:", output)
+        self.assertIn("python -m agentguard.cli doctor", output)
 
     def test_openai_quickstart_json_is_parseable(self) -> None:
         buf = io.StringIO()
@@ -108,6 +110,7 @@ class TestQuickstart(unittest.TestCase):
                 self.assertIn("Install:", buf.getvalue())
                 self.assertIn("pip install agentguard47", buf.getvalue())
                 self.assertIn("python agentguard_raw_quickstart.py", buf.getvalue())
+                self.assertIn("python -m agentguard.cli report .agentguard/traces.jsonl", buf.getvalue())
             finally:
                 os.chdir(cwd)
 


### PR DESCRIPTION
## Summary
- Adds `python -m agentguard.cli ...` fallback guidance to `doctor`, `demo`, and `quickstart` output.
- Keeps JSON output, public APIs, runtime behavior, package metadata, and dependencies unchanged.
- Records clean-temp Windows activation proof under `proof/first-run-activation-hardening-2026-05-03/VALIDATION.md`.

## Why
A clean editable install on Windows can succeed while pip warns that `agentguard.exe` was installed outside `PATH`. That makes the next documented `agentguard doctor` command fail even though the package is installed. The module command path works reliably and is now surfaced at each first-run step.

## Validation
- `python -m pytest sdk\tests\test_doctor.py sdk\tests\test_demo.py sdk\tests\test_quickstart.py -v` -> 23 passed
- `python -m ruff check sdk\agentguard\doctor.py sdk\agentguard\demo.py sdk\agentguard\quickstart.py sdk\tests\test_doctor.py sdk\tests\test_demo.py sdk\tests\test_quickstart.py` -> passed
- `python scripts\sdk_preflight.py` -> passed
- `git diff --check` -> passed
- Clean-temp runtime proof:
  - `python -m agentguard.cli doctor`
  - `python -m agentguard.cli demo`
  - `python -m agentguard.cli quickstart --framework raw --write`
  - `python .\agentguard_raw_quickstart.py`
  - `python -m agentguard.cli report .agentguard\traces.jsonl`

## Risk / Rollback
Low risk. This is human-readable CLI guidance and test coverage only. Rollback is reverting this PR.