### PR TITLE
Add MCP proof gallery coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added a post-demo next-step block so `agentguard demo` points directly to
   `agentguard quickstart --framework raw --write`, the generated starter, and
   the follow-up local report command.
+- Added an MCP read-path proof to the proof gallery and test coverage that
+  catches stale local example and sample-doc references.
 - Added an optional local-first Pydantic AI starter recipe using Pydantic AI's
   `TestModel`, so users can try the pattern without API keys or network calls
   after installing the optional framework package.

--- a/docs/examples/proof-gallery.md
+++ b/docs/examples/proof-gallery.md
@@ -114,6 +114,26 @@ Proves:
 - generated starters write traces to `.agentguard/traces.jsonl`
 - first value does not require a dashboard account
 
+## 7. MCP Read Path
+
+```bash
+npm --prefix mcp-server test
+AGENTGUARD_API_KEY=ag_... npx -y @agentguard47/mcp-server
+```
+
+Proves:
+
+- the MCP server is a narrow read-only surface over retained AgentGuard data
+- coding agents can inspect traces, decisions, alerts, usage, costs, and budget
+  health after hosted ingest is enabled
+- local SDK enforcement remains independent of the hosted dashboard
+
+Expected boundary:
+
+```text
+Requires AGENTGUARD_API_KEY for retained hosted data. Does not add local runtime enforcement.
+```
+
 ## What To Share
 
 The most shareable public demo is the coding-agent review loop:

--- a/proof/proof-gallery-upgrade-2026-05-03/VALIDATION.md
+++ b/proof/proof-gallery-upgrade-2026-05-03/VALIDATION.md
@@ -1,0 +1,45 @@
+# Proof Gallery Upgrade Validation
+
+Date: 2026-05-03
+Branch: `codex/proof-gallery-upgrade`
+
+## Goal
+
+Make the public proof gallery more complete and harder to let drift.
+
+## What Changed
+
+- Added a dedicated MCP read-path proof section to
+  `docs/examples/proof-gallery.md`.
+- Added test coverage that verifies:
+  - local `python examples/*.py` references in the proof gallery point to files
+    that exist
+  - Markdown links in the proof gallery point to files that exist
+  - the MCP read-path section keeps the read-only boundary and API-key
+    requirement explicit
+
+## Validation
+
+```text
+python -m pytest sdk\tests\test_example_starters.py -v
+9 passed in 1.20s
+
+npm --prefix mcp-server test
+tests 5
+pass 5
+fail 0
+
+python -m ruff check sdk\tests\test_example_starters.py
+All checks passed!
+
+python scripts\sdk_preflight.py
+All checks passed!
+
+git diff --check
+passed
+```
+
+## Risk
+
+Low. This is docs plus sync coverage only. No SDK runtime behavior, MCP runtime
+behavior, package metadata, or dependency changes.

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -266,7 +266,10 @@ def test_coding_agent_review_loop_sample_incident_is_in_sync() -> None:
 def test_proof_gallery_demo_references_stay_valid() -> None:
     source = PROOF_GALLERY_PATH.read_text(encoding="utf-8")
 
-    for match in re.finditer(r"python (examples/[A-Za-z0-9_/-]+\\.py)", source):
+    example_references = list(re.finditer(r"python (examples/[A-Za-z0-9_/-]+\.py)", source))
+    assert example_references, "Proof gallery should reference at least one local example"
+
+    for match in example_references:
         example_path = REPO_ROOT / match.group(1)
         assert example_path.exists(), f"Proof gallery references missing example: {match.group(1)}"
 

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,7 @@ from agentguard.reporting import render_incident_report
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STARTERS_ROOT = REPO_ROOT / "examples" / "starters"
+PROOF_GALLERY_PATH = REPO_ROOT / "docs" / "examples" / "proof-gallery.md"
 
 
 def test_quickstart_payloads_have_matching_starter_files() -> None:
@@ -259,6 +261,26 @@ def test_coding_agent_review_loop_sample_incident_is_in_sync() -> None:
         actual = sample_path.read_text(encoding="utf-8")
 
         assert _normalize_incident_snapshot(actual) == expected
+
+
+def test_proof_gallery_demo_references_stay_valid() -> None:
+    source = PROOF_GALLERY_PATH.read_text(encoding="utf-8")
+
+    for match in re.finditer(r"python (examples/[A-Za-z0-9_/-]+\\.py)", source):
+        example_path = REPO_ROOT / match.group(1)
+        assert example_path.exists(), f"Proof gallery references missing example: {match.group(1)}"
+
+    for link in re.findall(r"\[`([^`]+)`\]\(([^)]+)\)", source):
+        label, href = link
+        if href.startswith("http"):
+            continue
+        target = (PROOF_GALLERY_PATH.parent / href).resolve()
+        assert target.exists(), f"Proof gallery link is stale: {label} -> {href}"
+
+    assert "## 7. MCP Read Path" in source
+    assert "read-only" in source
+    assert "AGENTGUARD_API_KEY" in source
+    assert "local SDK enforcement remains independent" in source
 
 
 def _normalize_incident_snapshot(markdown: str) -> str:


### PR DESCRIPTION
## Summary
- Adds a dedicated MCP read-path proof to `docs/examples/proof-gallery.md`.
- Adds sync coverage so proof-gallery local example commands and sample-doc links cannot silently drift.
- Keeps the MCP boundary explicit: read-only hosted data surface, not local runtime enforcement.

## Validation
- `python -m pytest sdk\tests\test_example_starters.py -v` -> 9 passed
- `npm --prefix mcp-server test` -> 5 passed
- `python -m ruff check sdk\tests\test_example_starters.py` -> passed
- `python scripts\sdk_preflight.py` -> passed
- `git diff --check` -> passed

## Proof
See `proof/proof-gallery-upgrade-2026-05-03/VALIDATION.md`.

## Risk / Rollback
Low risk. This is docs plus sync coverage only. No SDK runtime behavior, MCP runtime behavior, package metadata, or dependency changes.