### PR TITLE
Guard hosted dashboard handoff copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ costs, usage, and budget health.
 ## Hosted Dashboard Boundary
 
 The SDK is the free local proof path. The hosted dashboard is for retained
-history, alerts, team visibility, hosted decision history, and remote-control
-operations.
+history, alerts, team visibility, spend trends, hosted decision history, and
+dashboard-managed remote kill signals.
 
 | Use local SDK when | Use hosted dashboard when |
 | --- | --- |

--- a/docs/guides/dashboard-contract.md
+++ b/docs/guides/dashboard-contract.md
@@ -5,8 +5,8 @@ Use this when you move from local SDK proof to the hosted AgentGuard dashboard.
 The product boundary is deliberate:
 - the SDK owns local runtime enforcement, local traces, local reports, and
   structured event emission
-- the dashboard owns retained history, alerts, team workflows, billing, and
-  remote kill signal management
+- the dashboard owns retained history, alerts, team visibility, spend trends,
+  hosted decision history, and dashboard-managed remote kill signals
 
 ## Local or hosted
 
@@ -20,8 +20,8 @@ risky enough that local files are no longer enough.
 | You want JSONL traces and reports without an API key | You need spend trends across traces, services, or teammates |
 | You are testing an agent before production | Operators need dashboard-managed remote kill signals |
 
-Hosted ingest should make operational follow-up easier. It should not be
-required for local safety, and it should not replace in-process guards.
+Hosted ingest should make operational follow-up easier. It is not required for
+local safety, and it does not replace in-process guards.
 
 ## First path
 

--- a/proof/dashboard-handoff-sweep-2026-05-03/VALIDATION.md
+++ b/proof/dashboard-handoff-sweep-2026-05-03/VALIDATION.md
@@ -1,0 +1,49 @@
+# Dashboard Handoff Sweep Validation
+
+Date: 2026-05-03
+Branch: `codex/dashboard-handoff-sweep`
+
+## Goal
+
+Keep the SDK-to-dashboard handoff explicit, useful, and non-pushy.
+
+## What Changed
+
+- Tightened README hosted-dashboard wording around:
+  - retained history
+  - alerts
+  - team visibility
+  - spend trends
+  - hosted decision history
+  - dashboard-managed remote kill signals
+- Updated `docs/guides/dashboard-contract.md` to use the same language and to
+  state that hosted ingest is not required for local safety.
+- Regenerated `sdk/PYPI_README.md` from README.
+- Added docs guard tests so the boundary does not silently drift.
+
+## Validation
+
+```text
+python -m pytest sdk\tests\test_dashboard_handoff_docs.py sdk\tests\test_pypi_readme_sync.py -v
+6 passed in 0.08s
+
+python -m ruff check sdk\tests\test_dashboard_handoff_docs.py
+All checks passed!
+
+python scripts\generate_pypi_readme.py --check
+passed
+
+python scripts\sdk_release_guard.py
+Release guard passed.
+
+python scripts\sdk_preflight.py
+All checks passed!
+
+git diff --check
+passed
+```
+
+## Risk
+
+Low. This is documentation and docs-test coverage only. No SDK runtime behavior,
+MCP runtime behavior, package metadata, or dependency changes.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -269,8 +269,8 @@ costs, usage, and budget health.
 ## Hosted Dashboard Boundary
 
 The SDK is the free local proof path. The hosted dashboard is for retained
-history, alerts, team visibility, hosted decision history, and remote-control
-operations.
+history, alerts, team visibility, spend trends, hosted decision history, and
+dashboard-managed remote kill signals.
 
 | Use local SDK when | Use hosted dashboard when |
 | --- | --- |

--- a/sdk/tests/test_dashboard_handoff_docs.py
+++ b/sdk/tests/test_dashboard_handoff_docs.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _normalized(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+def test_dashboard_handoff_copy_stays_local_first() -> None:
+    readme = _read("README.md")
+    dashboard_contract = _read("docs/guides/dashboard-contract.md")
+    mcp_readme = _read("mcp-server/README.md")
+
+    combined = "\n".join([readme, dashboard_contract, mcp_readme])
+    normalized_readme = _normalized(readme)
+    normalized_contract = _normalized(dashboard_contract)
+
+    for phrase in (
+        "retained history",
+        "alerts",
+        "team visibility",
+        "spend trends",
+        "hosted decision history",
+        "dashboard-managed remote kill signals",
+    ):
+        assert phrase in combined
+
+    assert "The SDK is the free local proof path" in readme
+    assert "Start local. Add hosted ingest" in readme
+    assert "local guards remain authoritative" in normalized_readme
+    assert "it is not required for local safety" in normalized_contract
+    assert "does not replace in-process guards" in normalized_contract
+
+
+def test_handoff_docs_do_not_overstate_httpsink_remote_control() -> None:
+    readme = _read("README.md")
+    dashboard_contract = _read("docs/guides/dashboard-contract.md")
+    reporting = _read("sdk/agentguard/reporting.py")
+    normalized_readme = _normalized(readme)
+
+    assert "`HttpSink` mirrors trace and decision events" in readme
+    assert "does not execute remote kill signals by itself" in normalized_readme
+    assert "`HttpSink` does not poll for kill signals" in dashboard_contract
+    assert "Add hosted ingest" in reporting
+    assert "retained history, alerts, spend trends" in reporting

--- a/sdk/tests/test_dashboard_handoff_docs.py
+++ b/sdk/tests/test_dashboard_handoff_docs.py
@@ -16,9 +16,7 @@ def _normalized(text: str) -> str:
 def test_dashboard_handoff_copy_stays_local_first() -> None:
     readme = _read("README.md")
     dashboard_contract = _read("docs/guides/dashboard-contract.md")
-    mcp_readme = _read("mcp-server/README.md")
 
-    combined = "\n".join([readme, dashboard_contract, mcp_readme])
     normalized_readme = _normalized(readme)
     normalized_contract = _normalized(dashboard_contract)
 
@@ -30,10 +28,11 @@ def test_dashboard_handoff_copy_stays_local_first() -> None:
         "hosted decision history",
         "dashboard-managed remote kill signals",
     ):
-        assert phrase in combined
+        assert phrase in normalized_readme
+        assert phrase in normalized_contract
 
-    assert "The SDK is the free local proof path" in readme
-    assert "Start local. Add hosted ingest" in readme
+    assert "the sdk is the free local proof path" in normalized_readme
+    assert "start local. add hosted ingest" in normalized_readme
     assert "local guards remain authoritative" in normalized_readme
     assert "it is not required for local safety" in normalized_contract
     assert "does not replace in-process guards" in normalized_contract


### PR DESCRIPTION
## Summary
- Aligns README and dashboard-contract wording around the supported hosted dashboard value: retained history, alerts, team visibility, spend trends, hosted decision history, and dashboard-managed remote kill signals.
- Keeps the boundary explicit that hosted ingest is not required for local safety and does not replace in-process guards.
- Regenerates `sdk/PYPI_README.md` and adds docs guard tests so the handoff language does not drift.

## Validation
- `python -m pytest sdk\tests\test_dashboard_handoff_docs.py sdk\tests\test_pypi_readme_sync.py -v` -> 6 passed
- `python -m ruff check sdk\tests\test_dashboard_handoff_docs.py` -> passed
- `python scripts\generate_pypi_readme.py --check` -> passed
- `python scripts\sdk_release_guard.py` -> passed
- `python scripts\sdk_preflight.py` -> passed
- `git diff --check` -> passed

## Proof
See `proof/dashboard-handoff-sweep-2026-05-03/VALIDATION.md`.

## Risk / Rollback
Low risk. This is documentation plus docs-test coverage only. No SDK runtime behavior, MCP runtime behavior, package metadata, or dependency changes.