### PR TITLE
Fix AgentGuard release hygiene docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,8 +345,9 @@ agentguard demo         # local proof run
 ```python
 from agentguard import Tracer, BudgetGuard, patch_openai
 
-tracer = Tracer(guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)])
-patch_openai(tracer)
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+tracer = Tracer(service="support-agent")
+patch_openai(tracer, budget_guard=budget)
 # All OpenAI calls are now tracked and budget-enforced
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,7 +348,7 @@ from agentguard import Tracer, BudgetGuard, patch_openai
 budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(service="support-agent")
 patch_openai(tracer, budget_guard=budget)
-# All OpenAI calls are now tracked and budget-enforced
+# OpenAI chat completions are now tracked and budget-enforced
 ```
 
 **Pattern 2: Stack multiple guards**

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(service="support-agent")
 patch_openai(tracer, budget_guard=budget)
 
-# OpenAI calls are now traced and budget-enforced.
+# OpenAI chat completions are now traced and budget-enforced.
 ```
 
 When accumulated cost crosses the hard limit, `BudgetExceeded` is raised and

--- a/README.md
+++ b/README.md
@@ -101,16 +101,17 @@ incidents, alerts, or team visibility matter.
 ```python
 from agentguard import BudgetGuard, JsonlFileSink, LoopGuard, Tracer
 
+budget = BudgetGuard(max_cost_usd=5.00, max_calls=50, warn_at_pct=0.8)
+loop = LoopGuard(max_repeats=3)
 tracer = Tracer(
     sink=JsonlFileSink(".agentguard/traces.jsonl"),
     service="support-agent",
-    guards=[
-        BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8),
-        LoopGuard(max_repeats=3),
-    ],
+    guards=[loop],
 )
 
 with tracer.trace("agent.run") as span:
+    budget.consume(calls=1, cost_usd=0.02)
+    loop.check("search", {"query": "refund policy"})
     span.event("tool.call", data={"tool": "search", "query": "refund policy"})
     # Call your agent or tool here.
 ```
@@ -130,8 +131,9 @@ provider normally:
 ```python
 from agentguard import BudgetGuard, Tracer, patch_openai
 
-tracer = Tracer(guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)])
-patch_openai(tracer)
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+tracer = Tracer(service="support-agent")
+patch_openai(tracer, budget_guard=budget)
 
 # OpenAI calls are now traced and budget-enforced.
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,8 +30,9 @@ agentguard doctor
 ```python
 from agentguard import Tracer, BudgetGuard, patch_openai
 
-tracer = Tracer(guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)])
-patch_openai(tracer)
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+tracer = Tracer(service="support-agent")
+patch_openai(tracer, budget_guard=budget)
 # Every OpenAI call is now tracked. At $4 you get a warning. At $5 the agent stops.
 ```
 
@@ -88,9 +89,10 @@ with tracer.trace("agent.run") as span:
 ```python
 from agentguard import Tracer, BudgetGuard, patch_openai, patch_anthropic
 
-tracer = Tracer(guards=[BudgetGuard(max_cost_usd=5.00)])
-patch_openai(tracer)      # tracks all ChatCompletion calls
-patch_anthropic(tracer)   # tracks all Messages calls
+budget = BudgetGuard(max_cost_usd=5.00)
+tracer = Tracer(service="support-agent")
+patch_openai(tracer, budget_guard=budget)      # tracks ChatCompletion calls
+patch_anthropic(tracer, budget_guard=budget)   # tracks Messages calls
 ```
 
 ## Framework Integrations

--- a/SKILL.md
+++ b/SKILL.md
@@ -33,7 +33,7 @@ from agentguard import Tracer, BudgetGuard, patch_openai
 budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(service="support-agent")
 patch_openai(tracer, budget_guard=budget)
-# Every OpenAI call is now tracked. At $4 you get a warning. At $5 the agent stops.
+# OpenAI chat completions are now tracked. At $4 you get a warning. At $5 the agent stops.
 ```
 
 ## Guards

--- a/docs/blog/002-budget-enforcement-patterns-devto.md
+++ b/docs/blog/002-budget-enforcement-patterns-devto.md
@@ -69,12 +69,12 @@ Skip manual `consume()` calls entirely — let AgentGuard estimate cost automati
 ```python
 from agentguard import Tracer, BudgetGuard, JsonlFileSink, patch_openai
 
+budget = BudgetGuard(max_cost_usd=5.00)
 tracer = Tracer(
     sink=JsonlFileSink("traces.jsonl"),
     service="my-agent",
-    guards=[BudgetGuard(max_cost_usd=5.00)],
 )
-patch_openai(tracer)
+patch_openai(tracer, budget_guard=budget)
 
 # Every OpenAI call is now auto-traced with cost estimates.
 # BudgetGuard checks after each call.
@@ -87,7 +87,7 @@ Works with Anthropic too:
 
 ```python
 from agentguard import patch_anthropic
-patch_anthropic(tracer)
+patch_anthropic(tracer, budget_guard=budget)
 ```
 
 ## Combining with Loop Detection
@@ -97,14 +97,15 @@ Budget overruns and loops often go together. A stuck agent burns through your bu
 ```python
 from agentguard import Tracer, LoopGuard, BudgetGuard, JsonlFileSink
 
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+loop = LoopGuard(max_repeats=3)
 tracer = Tracer(
     sink=JsonlFileSink("traces.jsonl"),
     service="my-agent",
-    guards=[
-        LoopGuard(max_repeats=3),
-        BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8),
-    ],
+    guards=[loop],
 )
+
+# Use budget.consume(...) where usage is known, or pass budget to provider patching.
 ```
 
 Whichever guard triggers first stops the agent.

--- a/docs/blog/002-budget-enforcement-patterns-devto.md
+++ b/docs/blog/002-budget-enforcement-patterns-devto.md
@@ -76,9 +76,9 @@ tracer = Tracer(
 )
 patch_openai(tracer, budget_guard=budget)
 
-# Every OpenAI call is now auto-traced with cost estimates.
+# OpenAI chat completions are now auto-traced with cost estimates.
 # BudgetGuard checks after each call.
-# Supports GPT-4o, GPT-4, GPT-3.5, and embedding models.
+# Supports patched chat-completion models such as GPT-4o, GPT-4, and GPT-3.5.
 ```
 
 `patch_openai` intercepts `ChatCompletion` responses, extracts token counts from the response, and feeds them into BudgetGuard. No manual tracking.

--- a/docs/blog/003-ci-cost-gates-devto.md
+++ b/docs/blog/003-ci-cost-gates-devto.md
@@ -50,13 +50,14 @@ jobs:
           python3 -c "
           from agentguard import Tracer, BudgetGuard, JsonlFileSink
 
+          budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
           tracer = Tracer(
               sink=JsonlFileSink('ci_traces.jsonl'),
               service='ci-agent-test',
-              guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)],
           )
 
           with tracer.trace('ci.agent_run') as span:
+              budget.consume(calls=1, cost_usd=0.02)
               # Your agent code here
               pass
           "
@@ -85,12 +86,12 @@ If your agent uses OpenAI, AgentGuard can auto-track cost per API call:
 ```python
 from agentguard import Tracer, BudgetGuard, JsonlFileSink, patch_openai
 
+budget = BudgetGuard(max_cost_usd=5.00)
 tracer = Tracer(
     sink=JsonlFileSink("ci_traces.jsonl"),
     service="ci-agent-test",
-    guards=[BudgetGuard(max_cost_usd=5.00)],
 )
-patch_openai(tracer)  # auto-tracks cost for every ChatCompletion call
+patch_openai(tracer, budget_guard=budget)  # traces and checks every ChatCompletion call
 
 # Now run your agent normally — costs are tracked automatically
 ```

--- a/docs/competitive/vercel-ai-gateway.md
+++ b/docs/competitive/vercel-ai-gateway.md
@@ -31,16 +31,14 @@ You run Claude Code on Vercel for production workloads. For development and test
 **With AgentGuard:**
 
 ```python
-from agentguard import Tracer, BudgetGuard, JsonlFileSink
+from agentguard import Tracer, BudgetGuard, JsonlFileSink, patch_anthropic, patch_openai
 
-tracer = Tracer(
-    sink=JsonlFileSink(".agentguard/traces.jsonl"),
-    guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)],
-)
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+tracer = Tracer(sink=JsonlFileSink(".agentguard/traces.jsonl"))
 
 # Same guards work for both providers
-# Production: patch_anthropic(tracer) for Claude
-# Dev: patch_openai(tracer) for local Ollama via OpenAI-compatible API
+# Production: patch_anthropic(tracer, budget_guard=budget) for Claude
+# Dev: patch_openai(tracer, budget_guard=budget) for local Ollama via OpenAI-compatible API
 ```
 
 One SDK. Same budget enforcement whether the call goes to Claude's API or to localhost:11434. Same trace format. Same audit log. The guard does not care where the model lives.

--- a/docs/cost-guardrails.md
+++ b/docs/cost-guardrails.md
@@ -123,15 +123,13 @@ Skip manual `consume()` calls — patch the SDK to auto-track costs:
 ```python
 from agentguard import Tracer, BudgetGuard, patch_openai, patch_anthropic
 
-tracer = Tracer(
-    service="my-agent",
-    guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)],
-)
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+tracer = Tracer(service="my-agent")
 
-patch_openai(tracer)      # auto-tracks all ChatCompletion calls
-patch_anthropic(tracer)   # auto-tracks all Messages calls
+patch_openai(tracer, budget_guard=budget)      # traces and checks ChatCompletion calls
+patch_anthropic(tracer, budget_guard=budget)   # traces and checks Messages calls
 
-# Use OpenAI/Anthropic normally — costs tracked automatically
+# Use OpenAI/Anthropic normally. Usage is recorded into the budget guard.
 ```
 
 When done, clean up:

--- a/docs/discussions/02_budget_enforcement_patterns.md
+++ b/docs/discussions/02_budget_enforcement_patterns.md
@@ -77,9 +77,9 @@ tracer = Tracer(
 )
 patch_openai(tracer, budget_guard=budget)
 
-# Every OpenAI call is now auto-traced with cost estimates.
+# OpenAI chat completions are now auto-traced with cost estimates.
 # BudgetGuard checks the budget after each call.
-# Supports GPT-4, GPT-3.5, and embedding models.
+# Supports patched chat-completion models such as GPT-4 and GPT-3.5.
 ```
 
 The cost estimates use published token pricing. You can override prices for custom or fine-tuned models:

--- a/docs/discussions/02_budget_enforcement_patterns.md
+++ b/docs/discussions/02_budget_enforcement_patterns.md
@@ -70,12 +70,12 @@ Skip manual `consume()` calls — let AgentGuard estimate cost automatically:
 ```python
 from agentguard import Tracer, BudgetGuard, JsonlFileSink, patch_openai
 
+budget = BudgetGuard(max_cost_usd=5.00)
 tracer = Tracer(
     sink=JsonlFileSink("traces.jsonl"),
     service="my-agent",
-    guards=[BudgetGuard(max_cost_usd=5.00)],
 )
-patch_openai(tracer)
+patch_openai(tracer, budget_guard=budget)
 
 # Every OpenAI call is now auto-traced with cost estimates.
 # BudgetGuard checks the budget after each call.
@@ -97,14 +97,15 @@ Budget overruns and loops often go together. An agent stuck in a loop burns thro
 ```python
 from agentguard import Tracer, LoopGuard, BudgetGuard, JsonlFileSink
 
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+loop = LoopGuard(max_repeats=3)
 tracer = Tracer(
     sink=JsonlFileSink("traces.jsonl"),
     service="my-agent",
-    guards=[
-        LoopGuard(max_repeats=3),
-        BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8),
-    ],
+    guards=[loop],
 )
+
+# Use budget.consume(...) where usage is known, or pass budget to provider patching.
 ```
 
 Whichever guard triggers first stops the agent. The loop guard catches pathological repeats; the budget guard catches legitimate-but-expensive runs.

--- a/docs/discussions/03_limit_openai_spend.md
+++ b/docs/discussions/03_limit_openai_spend.md
@@ -20,11 +20,9 @@ pip install agentguard47
 ```python
 from agentguard import Tracer, BudgetGuard, BudgetExceeded, patch_openai
 
-tracer = Tracer(
-    service="my-agent",
-    guards=[BudgetGuard(max_cost_usd=2.00, warn_at_pct=0.8)],
-)
-patch_openai(tracer)
+budget = BudgetGuard(max_cost_usd=2.00, warn_at_pct=0.8)
+tracer = Tracer(service="my-agent")
+patch_openai(tracer, budget_guard=budget)
 
 # Now use OpenAI normally:
 import openai

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -219,13 +219,15 @@ Cap spend per agent run:
 ```python
 from agentguard import Tracer, BudgetGuard, JsonlFileSink
 
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(
     sink=JsonlFileSink(".agentguard/traces.jsonl"),
     service="my-agent",
-    guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)],
 )
 
-# BudgetGuard tracks token usage and estimated cost.
+# Record usage where model calls happen.
+budget.consume(calls=1, cost_usd=0.02)
+
 # Raises BudgetExceeded when the limit is hit.
 # Fires BudgetWarning at 80% of the limit.
 ```
@@ -246,12 +248,13 @@ catching a single high-context spike before the run drifts further.
 Skip manual tracing — let AgentGuard patch the OpenAI client:
 
 ```python
-from agentguard import Tracer, JsonlFileSink, patch_openai
+from agentguard import BudgetGuard, Tracer, JsonlFileSink, patch_openai
 
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(sink=JsonlFileSink(".agentguard/traces.jsonl"), service="my-agent")
-patch_openai(tracer)
+patch_openai(tracer, budget_guard=budget)
 
-# Every OpenAI call is now traced with token counts and cost estimates.
+# Every OpenAI call is now traced with token counts, cost estimates, and budget checks.
 # Works with openai>=1.0 client instances.
 ```
 
@@ -259,7 +262,7 @@ Same for Anthropic:
 
 ```python
 from agentguard import patch_anthropic
-patch_anthropic(tracer)
+patch_anthropic(tracer, budget_guard=budget)
 ```
 
 ## 6. Use with LangChain

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -254,7 +254,7 @@ budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(sink=JsonlFileSink(".agentguard/traces.jsonl"), service="my-agent")
 patch_openai(tracer, budget_guard=budget)
 
-# Every OpenAI call is now traced with token counts, cost estimates, and budget checks.
+# OpenAI chat completions are now traced with token counts, cost estimates, and budget checks.
 # Works with openai>=1.0 client instances.
 ```
 

--- a/examples/crewai_with_guards.py
+++ b/examples/crewai_with_guards.py
@@ -34,8 +34,8 @@ tracer = Tracer(
 budget_guard = BudgetGuard(max_cost_usd=5.00, max_calls=100)
 loop_guard = LoopGuard(max_repeats=3, window=6)
 
-# Auto-trace all OpenAI calls (CrewAI uses OpenAI under the hood)
-patch_openai(tracer)
+# Auto-trace OpenAI calls (CrewAI uses OpenAI under the hood) and feed usage into BudgetGuard.
+patch_openai(tracer, budget_guard=budget_guard)
 
 # --- 2. Define CrewAI agents ---
 
@@ -89,8 +89,6 @@ if __name__ == "__main__":
     with tracer.trace("crew.kickoff") as span:
         try:
             # Check budget before each major step
-            budget_guard.consume(calls=1)
-
             result = crew.kickoff()
 
             span.event("crew.complete", data={"output_length": len(str(result))})

--- a/examples/crewai_with_guards.py
+++ b/examples/crewai_with_guards.py
@@ -34,7 +34,7 @@ tracer = Tracer(
 budget_guard = BudgetGuard(max_cost_usd=5.00, max_calls=100)
 loop_guard = LoopGuard(max_repeats=3, window=6)
 
-# Auto-trace OpenAI calls (CrewAI uses OpenAI under the hood) and feed usage into BudgetGuard.
+# Auto-trace OpenAI chat completions (CrewAI uses OpenAI under the hood) and feed usage into BudgetGuard.
 patch_openai(tracer, budget_guard=budget_guard)
 
 # --- 2. Define CrewAI agents ---

--- a/examples/openai_agents_with_guards.py
+++ b/examples/openai_agents_with_guards.py
@@ -35,7 +35,7 @@ tracer = Tracer(
 budget_guard = BudgetGuard(max_cost_usd=1.00, max_calls=20)
 loop_guard = LoopGuard(max_repeats=3, window=6)
 
-# Auto-trace all OpenAI API calls and feed usage into BudgetGuard.
+# Auto-trace OpenAI chat completions and feed usage into BudgetGuard.
 patch_openai(tracer, budget_guard=budget_guard)
 
 # --- 2. Define tools ---

--- a/examples/openai_agents_with_guards.py
+++ b/examples/openai_agents_with_guards.py
@@ -35,8 +35,8 @@ tracer = Tracer(
 budget_guard = BudgetGuard(max_cost_usd=1.00, max_calls=20)
 loop_guard = LoopGuard(max_repeats=3, window=6)
 
-# Auto-trace all OpenAI API calls with cost tracking
-patch_openai(tracer)
+# Auto-trace all OpenAI API calls and feed usage into BudgetGuard.
+patch_openai(tracer, budget_guard=budget_guard)
 
 # --- 2. Define tools ---
 
@@ -93,8 +93,6 @@ def run_agent(user_message: str, max_turns: int = 10):
     with tracer.trace("agent.run", data={"input": user_message}) as span:
         for turn in range(max_turns):
             # Check budget before each API call
-            budget_guard.consume(calls=1)
-
             response = client.chat.completions.create(
                 model="gpt-4o-mini",
                 messages=messages,

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -3,6 +3,11 @@
 **Last Updated:** 2026-04-02
 
 ## Active
+- **npm MCP package publish is OTP-blocked.** Repo metadata targets
+  `@agentguard47/mcp-server@0.2.2`, but `npm view @agentguard47/mcp-server version`
+  still returns `0.2.1`. Prior publish attempt was blocked by npm one-time
+  password requirements. Complete with `npm publish --access public --otp <code>`
+  from `mcp-server/`.
 - **Glama listing still blocked.** Official MCP Registry is live, but Glama has
   not detected the server from this repo yet even after adding root-level and
   package-level Smithery / Docker metadata. Revisit later via Glama support or

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -1,6 +1,6 @@
 # SDK Blockers
 
-**Last Updated:** 2026-04-02
+**Last Updated:** 2026-05-03
 
 ## Active
 - **npm MCP package publish is OTP-blocked.** Repo metadata targets

--- a/memory/state.md
+++ b/memory/state.md
@@ -10,7 +10,8 @@
 ## Public Artifacts
 - PyPI package: `agentguard47`
 - Latest shipped SDK release: `1.2.10`
-- npm MCP package: `@agentguard47/mcp-server@0.2.2`
+- npm MCP package: repo targets `@agentguard47/mcp-server@0.2.2`; npm registry
+  still serves `0.2.1` until the OTP-gated publish is completed.
 - Official MCP Registry listing: live as `io.github.bmdhodl/agentguard47`
 
 ## Repo Scope

--- a/memory/state.md
+++ b/memory/state.md
@@ -1,6 +1,6 @@
 # SDK State
 
-**Last Updated:** 2026-05-02
+**Last Updated:** 2026-05-03
 
 ## Product
 - AgentGuard = zero-dependency Python SDK for runtime guardrails.

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -7,7 +7,7 @@ they directly strengthen coding-agent adoption.
 
 ## Current Focus Notes
 
-- Latest shipped SDK release is `v1.2.9`; current work is post-release
+- Latest shipped SDK release is `v1.2.10`; current work is post-release
   hardening and activation, not a new feature push.
 - Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`;
   keep MCP narrow and read-only while Glama remains blocked.
@@ -40,7 +40,7 @@ they directly strengthen coding-agent adoption.
 | Coding-agent skillpack generation | Done - `agentguard skillpack` now generates `.agentguard.json` plus repo-local instructions for Codex, Claude Code, Copilot, and Cursor so coding-agent onboarding no longer depends on manual snippet copying |
 | Managed-agent session correlation | Done - `session_id` now lets disposable harnesses or short-lived workers emit separate traces that still roll up under one higher-level local session for coding-agent and managed-agent runtimes |
 | Budget-aware escalation guard | Done - `BudgetAwareEscalation` now lets apps keep a cheaper default model and escalate hard turns using token, confidence, tool-depth, or custom-rule signals without provider-specific SDK routing |
-| Dashboard contract alignment for v1.2.9 | Done - hosted ingest shape and decision-trace defaults are documented and covered by tests; remote-kill boundaries are documented |
+| Dashboard contract alignment for v1.2.10 | Done - hosted ingest shape and decision-trace defaults are documented and covered by tests; remote-kill boundaries are documented |
 | Coding-agent review-loop proof | Done - `examples/coding_agent_review_loop.py` demonstrates local budget and retry stops for review/refinement loops without API keys or network calls |
 | Follow-up handoff | Done - `FOLLOWUP.md` records next hygiene and activation-metrics work without burying it in PR notes |
 | Opt-in activation metrics design | Done - `docs/guides/activation-metrics-design.md` defines allowed questions, consent boundaries, forbidden fields, and local-first non-goals without adding telemetry |

--- a/proof/release-hygiene-2026-05-03/VALIDATION.md
+++ b/proof/release-hygiene-2026-05-03/VALIDATION.md
@@ -1,0 +1,102 @@
+# Release Hygiene Validation - 2026-05-03
+
+## Scope
+
+Post-release hygiene only. No SDK runtime code, MCP runtime code, package
+versions, dependencies, or hosted dashboard contracts changed.
+
+Changed:
+
+- `README.md`
+- `sdk/README.md`
+- `sdk/PYPI_README.md`
+- `docs/guides/getting-started.md`
+- `docs/cost-guardrails.md`
+- `docs/competitive/vercel-ai-gateway.md`
+- `docs/blog/002-budget-enforcement-patterns-devto.md`
+- `docs/blog/003-ci-cost-gates-devto.md`
+- `docs/discussions/02_budget_enforcement_patterns.md`
+- `docs/discussions/03_limit_openai_spend.md`
+- `examples/openai_agents_with_guards.py`
+- `examples/crewai_with_guards.py`
+- `sdk/examples/openai_agent.py`
+- `ops/03-ROADMAP_NOW_NEXT_LATER.md`
+- `memory/state.md`
+- `memory/blockers.md`
+- `AGENTS.md`
+- `SKILL.md`
+
+## Live Package Evidence
+
+```text
+python -m pip index versions agentguard47
+agentguard47 (1.2.10)
+Available versions: 1.2.10, 1.2.9, 1.2.8, 1.2.6, 1.2.5, 1.2.4, 1.2.3, 1.2.2, 1.2.1, 1.2.0, 1.0.0, 0.8.0, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.0, 0.2.0
+  INSTALLED: 1.2.10
+  LATEST:    1.2.10
+
+gh release view v1.2.10 --repo bmdhodl/agent47 --json tagName,name,publishedAt,url,isDraft,isPrerelease,targetCommitish
+{"isDraft":false,"isPrerelease":false,"name":"AgentGuard v1.2.10","publishedAt":"2026-05-02T15:48:03Z","tagName":"v1.2.10","targetCommitish":"main","url":"https://github.com/bmdhodl/agent47/releases/tag/v1.2.10"}
+
+node -p "require('./mcp-server/package.json').version"
+0.2.2
+
+npm view @agentguard47/mcp-server version
+0.2.1
+```
+
+## npm MCP Drift
+
+Repo metadata targets `@agentguard47/mcp-server@0.2.2`, but npm still serves
+`0.2.1`. This is a publish blocker, not a source drift blocker. Prior proof in
+`proof/mcp-release-consistency-2026-05-02/VALIDATION.md` records the OTP-blocked
+publish attempt and the required manual command.
+
+## Doc Accuracy Fix
+
+High-visibility docs now show budget enforcement through either:
+
+- explicit `BudgetGuard.consume(...)` at the point usage is known, or
+- provider patching with `patch_openai(..., budget_guard=budget)` /
+  `patch_anthropic(..., budget_guard=budget)`.
+
+This avoids implying that `BudgetGuard` enforces budgets merely by being present
+inside `Tracer(guards=[...])`.
+
+## Validation
+
+```text
+python -m py_compile examples\openai_agents_with_guards.py examples\crewai_with_guards.py sdk\examples\openai_agent.py
+PASS
+
+python scripts\sdk_release_guard.py
+PASS
+
+python scripts\sdk_preflight.py
+PASS
+
+python -m ruff check sdk\agentguard\ scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py
+PASS
+
+python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+702 passed, coverage 92.98%
+
+python -m pytest sdk/tests/test_architecture.py -v
+9 passed
+
+python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
+PASS
+
+npm --prefix mcp-server ci
+PASS
+
+npm --prefix mcp-server test
+5 passed
+```
+
+Notes:
+
+- `make` is not installed in this Windows shell, so documented `make` targets
+  were executed through their underlying Python/npm commands.
+- `ruff` is not on PATH as a console script, but `python -m ruff` is available
+  and passed.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -103,16 +103,17 @@ incidents, alerts, or team visibility matter.
 ```python
 from agentguard import BudgetGuard, JsonlFileSink, LoopGuard, Tracer
 
+budget = BudgetGuard(max_cost_usd=5.00, max_calls=50, warn_at_pct=0.8)
+loop = LoopGuard(max_repeats=3)
 tracer = Tracer(
     sink=JsonlFileSink(".agentguard/traces.jsonl"),
     service="support-agent",
-    guards=[
-        BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8),
-        LoopGuard(max_repeats=3),
-    ],
+    guards=[loop],
 )
 
 with tracer.trace("agent.run") as span:
+    budget.consume(calls=1, cost_usd=0.02)
+    loop.check("search", {"query": "refund policy"})
     span.event("tool.call", data={"tool": "search", "query": "refund policy"})
     # Call your agent or tool here.
 ```
@@ -132,8 +133,9 @@ provider normally:
 ```python
 from agentguard import BudgetGuard, Tracer, patch_openai
 
-tracer = Tracer(guards=[BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)])
-patch_openai(tracer)
+budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
+tracer = Tracer(service="support-agent")
+patch_openai(tracer, budget_guard=budget)
 
 # OpenAI calls are now traced and budget-enforced.
 ```

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -137,7 +137,7 @@ budget = BudgetGuard(max_cost_usd=5.00, warn_at_pct=0.8)
 tracer = Tracer(service="support-agent")
 patch_openai(tracer, budget_guard=budget)
 
-# OpenAI calls are now traced and budget-enforced.
+# OpenAI chat completions are now traced and budget-enforced.
 ```
 
 When accumulated cost crosses the hard limit, `BudgetExceeded` is raised and

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -79,13 +79,17 @@ the local-first runtime enforcement layer.
 from agentguard import Tracer, LoopGuard, BudgetGuard, JsonlFileSink
 
 sink = JsonlFileSink(".agentguard/traces.jsonl")
+budget = BudgetGuard(max_cost_usd=5.00, max_calls=50)
+loop = LoopGuard(max_repeats=3)
 tracer = Tracer(
     sink=sink,
     service="my-agent",
-    guards=[LoopGuard(max_repeats=3), BudgetGuard(max_cost_usd=5.00)],
+    guards=[loop],
 )
 
 with tracer.trace("agent.run") as span:
+    budget.consume(calls=1, cost_usd=0.02)
+    loop.check("search", {"query": "docs"})
     span.event("reasoning.step", data={"thought": "search docs"})
     with span.span("tool.search"):
         pass  # your tool here

--- a/sdk/examples/openai_agent.py
+++ b/sdk/examples/openai_agent.py
@@ -42,7 +42,7 @@ tracer = Tracer(sink=sink, service="openai-agent")
 loop_guard = LoopGuard(max_repeats=3)
 budget = BudgetGuard(max_tokens=50_000, max_calls=20)
 
-# Auto-instrument OpenAI; completions.create calls are traced and fed into BudgetGuard.
+# Auto-instrument OpenAI; chat.completions.create calls are traced and fed into BudgetGuard.
 patch_openai(tracer, budget_guard=budget)
 
 # --- Fake tools (replace with real ones) ---

--- a/sdk/examples/openai_agent.py
+++ b/sdk/examples/openai_agent.py
@@ -42,8 +42,8 @@ tracer = Tracer(sink=sink, service="openai-agent")
 loop_guard = LoopGuard(max_repeats=3)
 budget = BudgetGuard(max_tokens=50_000, max_calls=20)
 
-# Auto-instrument OpenAI — all completions.create calls get traced
-patch_openai(tracer)
+# Auto-instrument OpenAI; completions.create calls are traced and fed into BudgetGuard.
+patch_openai(tracer, budget_guard=budget)
 
 # --- Fake tools (replace with real ones) ---
 def get_weather(city: str) -> str:
@@ -77,8 +77,6 @@ def run(task: str) -> str:
     with tracer.trace("agent.openai_demo", data={"task": task}) as ctx:
         for step in range(10):
             ctx.event("reasoning.step", data={"step": step + 1})
-            budget.consume(calls=1)
-
             # LLM call (auto-traced by patch_openai)
             response = client.chat.completions.create(
                 model="gpt-4o-mini",


### PR DESCRIPTION
## Summary
- align AgentGuard docs, skillpack snippets, and examples with the real v1.2.10 SDK API
- document that budget enforcement needs explicit `BudgetGuard.consume(...)` or provider patching with `budget_guard=...`
- correct release-state notes for `agentguard47` v1.2.10 and record the OTP-blocked MCP npm publish drift

## Validation
- `python -m py_compile examples\openai_agents_with_guards.py examples\crewai_with_guards.py sdk\examples\openai_agent.py`
- `python scripts\sdk_release_guard.py`
- `python scripts\sdk_preflight.py`
- `python -m ruff check sdk\agentguard\ scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py`
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` (702 passed, 92.98% coverage)
- `python -m pytest sdk/tests/test_architecture.py -v` (9 passed)
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `npm --prefix mcp-server ci`
- `npm --prefix mcp-server test` (5 passed)

Notes: `make` is not installed in this Windows shell, so I ran the underlying Python/npm checks directly. `ruff` is available as `python -m ruff`, not as a PATH console script.

## Release Evidence
- PyPI `agentguard47`: latest `1.2.10`
- GitHub release `v1.2.10`: published, non-draft, non-prerelease
- MCP repo package: `@agentguard47/mcp-server@0.2.2`
- npm registry still serves `@agentguard47/mcp-server@0.2.1`; publish remains OTP-blocked and is documented in `memory/blockers.md`