### PR TITLE
feat(sdk): publish typed contracts for public SDK surface

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -269,6 +269,35 @@ export_csv("traces.jsonl", "traces.csv")
 python -m agentguard.bench
 ```
 
+## Typed contracts
+
+AgentGuard publishes typed schemas for its public configuration surface so
+agents and tools can introspect the contract instead of scraping prose.
+Schemas are stdlib-only frozen dataclasses (no pydantic dependency, no extra
+install).
+
+```python
+from agentguard import InitConfig, RepoConfig, ProfileDefaults, SUPPORTED_PROFILES
+
+cfg = InitConfig(budget_usd=5.00, profile="coding-agent", warn_pct=0.5)
+cfg.validate()  # raises ValueError on bad input
+
+import agentguard
+agentguard.init(**cfg.to_dict())
+```
+
+| Schema | What it shapes | Source |
+|---|---|---|
+| `InitConfig` | Keyword arguments to `agentguard.init()` | [`agentguard/schemas.py`](agentguard/schemas.py) |
+| `RepoConfig` | `.agentguard.json` repo-local defaults | [`agentguard/schemas.py`](agentguard/schemas.py) |
+| `ProfileDefaults` | Guard policy shape per built-in profile | [`agentguard/schemas.py`](agentguard/schemas.py) |
+| `SUPPORTED_PROFILES` | Tuple of valid profile names | [`agentguard/profiles.py`](agentguard/profiles.py) |
+
+Each schema has a `validate()` method that raises `ValueError` on bad input
+(out-of-range warn_pct, negative budget, unknown profile, header injection
+in api_key, etc.). Validation rules mirror the runtime checks already
+enforced by `init()` and `repo_config`.
+
 ## Migration Guide (v0.5 → v1.0)
 
 | v0.5 | v1.0 |

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -48,6 +48,12 @@ from .instrument import (
     unpatch_openai,
     unpatch_openai_async,
 )
+from .schemas import (
+    SUPPORTED_PROFILES,
+    InitConfig,
+    ProfileDefaults,
+    RepoConfig,
+)
 from .setup import get_budget_guard, get_tracer, init, shutdown
 from .sinks import HttpSink
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
@@ -80,12 +86,16 @@ __all__ = [
     "EvalSuite",
     "FuzzyLoopGuard",
     "HttpSink",
+    "InitConfig",
     "JsonlFileSink",
     "LoopDetected",
     "LoopGuard",
+    "ProfileDefaults",
     "RateLimitGuard",
+    "RepoConfig",
     "RetryGuard",
     "RetryLimitExceeded",
+    "SUPPORTED_PROFILES",
     "StdoutSink",
     "TimeoutExceeded",
     "TimeoutGuard",

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -70,6 +70,7 @@ if not any(isinstance(handler, logging.NullHandler) for handler in _logger.handl
     _logger.addHandler(logging.NullHandler())
 
 __all__ = [
+    "SUPPORTED_PROFILES",
     "AgentGuardError",
     "AssertionResult",
     "AsyncTraceContext",
@@ -95,7 +96,6 @@ __all__ = [
     "RepoConfig",
     "RetryGuard",
     "RetryLimitExceeded",
-    "SUPPORTED_PROFILES",
     "StdoutSink",
     "TimeoutExceeded",
     "TimeoutGuard",

--- a/sdk/agentguard/schemas.py
+++ b/sdk/agentguard/schemas.py
@@ -1,0 +1,208 @@
+"""Typed contracts for the agentguard47 public surface.
+
+Per "AI rewards strict APIs" — these dataclasses give agents and humans a
+single importable schema for the SDK's main configuration and policy shapes.
+They use only the standard library (frozen dataclasses + typing) so they do
+not violate AgentGuard's zero-dependency guarantee.
+
+Public schemas:
+
+- ``InitConfig``    — keyword arguments accepted by ``agentguard.init()``.
+- ``RepoConfig``    — schema for ``.agentguard.json`` repo-local defaults.
+- ``ProfileDefaults`` — guard policy shape for a built-in profile.
+
+Each schema has a ``validate()`` method that raises ``ValueError`` on bad
+input. Validation rules mirror the runtime checks already enforced by
+``agentguard.init()`` and ``agentguard.repo_config`` — these classes simply
+expose the contract so agents can introspect it without scraping prose.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any, Dict, Optional
+
+# Import the canonical profile names so the schema stays in sync.
+from agentguard.profiles import (
+    _PROFILE_DEFAULTS,
+    normalize_profile,
+)
+
+SUPPORTED_PROFILES = tuple(sorted(_PROFILE_DEFAULTS.keys()))
+
+
+@dataclass(frozen=True)
+class ProfileDefaults:
+    """Guard policy shape for a built-in profile.
+
+    Mirrors the dict returned by ``agentguard.profiles.get_profile_defaults``.
+    """
+
+    loop_max: int
+    warn_pct: float
+    retry_max: Optional[int] = None
+
+    def validate(self) -> None:
+        if not isinstance(self.loop_max, int) or self.loop_max < 1:
+            raise ValueError(f"loop_max must be a positive int, got {self.loop_max!r}")
+        if self.retry_max is not None and (
+            not isinstance(self.retry_max, int) or self.retry_max < 0
+        ):
+            raise ValueError(f"retry_max must be a non-negative int or None, got {self.retry_max!r}")
+        if not isinstance(self.warn_pct, (int, float)) or not (0.0 <= float(self.warn_pct) <= 1.0):
+            raise ValueError(f"warn_pct must be in [0.0, 1.0], got {self.warn_pct!r}")
+
+
+@dataclass(frozen=True)
+class RepoConfig:
+    """Schema for ``.agentguard.json`` repo-local defaults.
+
+    Every field is optional. Unknown keys are tolerated by the runtime loader
+    (``agentguard.repo_config.load_repo_config_safely``) but are not part of
+    the typed contract.
+    """
+
+    service: Optional[str] = None
+    trace_file: Optional[str] = None
+    budget_usd: Optional[float] = None
+    profile: Optional[str] = None
+    warn_pct: Optional[float] = None
+    loop_max: Optional[int] = None
+    retry_max: Optional[int] = None
+
+    def validate(self) -> None:
+        if self.service is not None:
+            if not isinstance(self.service, str) or not self.service.strip():
+                raise ValueError("service must be a non-empty string")
+        if self.trace_file is not None:
+            if not isinstance(self.trace_file, str) or not self.trace_file.strip():
+                raise ValueError("trace_file must be a non-empty string")
+        if self.budget_usd is not None:
+            if (
+                isinstance(self.budget_usd, bool)
+                or not isinstance(self.budget_usd, (int, float))
+                or self.budget_usd < 0
+            ):
+                raise ValueError("budget_usd must be a non-negative number")
+        if self.profile is not None:
+            # normalize_profile raises ValueError for unknown values.
+            normalize_profile(self.profile)
+        if self.warn_pct is not None:
+            if (
+                isinstance(self.warn_pct, bool)
+                or not isinstance(self.warn_pct, (int, float))
+                or not (0.0 <= float(self.warn_pct) <= 1.0)
+            ):
+                raise ValueError("warn_pct must be in [0.0, 1.0]")
+        if self.loop_max is not None:
+            if (
+                isinstance(self.loop_max, bool)
+                or not isinstance(self.loop_max, int)
+                or self.loop_max < 1
+            ):
+                raise ValueError("loop_max must be a positive int")
+        if self.retry_max is not None:
+            if (
+                isinstance(self.retry_max, bool)
+                or not isinstance(self.retry_max, int)
+                or self.retry_max < 0
+            ):
+                raise ValueError("retry_max must be a non-negative int")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dict of only the set (non-None) fields."""
+        return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}
+
+
+@dataclass(frozen=True)
+class InitConfig:
+    """Schema for keyword arguments accepted by ``agentguard.init()``.
+
+    Mirrors the public signature of ``agentguard.init`` exactly. Use this to
+    validate config payloads (e.g. from a control plane or a config file)
+    before passing them through to ``init``.
+
+    Example::
+
+        from agentguard import InitConfig, init
+
+        cfg = InitConfig(budget_usd=5.00, profile="coding-agent")
+        cfg.validate()
+        init(**cfg.to_dict())
+    """
+
+    api_key: Optional[str] = None
+    budget_usd: Optional[float] = None
+    service: Optional[str] = None
+    session_id: Optional[str] = None
+    trace_file: Optional[str] = None
+    warn_pct: Optional[float] = None
+    loop_max: Optional[int] = None
+    retry_max: Optional[int] = None
+    profile: Optional[str] = None
+    auto_patch: bool = True
+    watermark: bool = True
+    local_only: bool = False
+
+    def validate(self) -> None:
+        if self.warn_pct is not None and not (0.0 <= float(self.warn_pct) <= 1.0):
+            raise ValueError(f"warn_pct must be between 0.0 and 1.0, got {self.warn_pct!r}")
+        if self.local_only and self.api_key:
+            raise ValueError("local_only=True cannot be combined with api_key")
+        if self.api_key and ("\n" in self.api_key or "\r" in self.api_key):
+            raise ValueError(
+                "api_key must not contain newline or carriage return characters "
+                "(possible HTTP header injection)"
+            )
+        if self.budget_usd is not None:
+            if (
+                isinstance(self.budget_usd, bool)
+                or not isinstance(self.budget_usd, (int, float))
+                or self.budget_usd < 0
+            ):
+                raise ValueError("budget_usd must be a non-negative number")
+        if self.profile is not None:
+            normalize_profile(self.profile)
+        if self.loop_max is not None:
+            if (
+                isinstance(self.loop_max, bool)
+                or not isinstance(self.loop_max, int)
+                or self.loop_max < 1
+            ):
+                raise ValueError("loop_max must be a positive int")
+        if self.retry_max is not None:
+            if (
+                isinstance(self.retry_max, bool)
+                or not isinstance(self.retry_max, int)
+                or self.retry_max < 0
+            ):
+                raise ValueError("retry_max must be a non-negative int")
+        for name in ("service", "session_id", "trace_file"):
+            value = getattr(self, name)
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ValueError(f"{name} must be a non-empty string when set")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return all fields as a dict suitable for ``init(**cfg.to_dict())``.
+
+        Includes None values so callers can pass through unchanged. Use
+        ``to_set_dict`` if you only want explicitly set fields.
+        """
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+    def to_set_dict(self) -> Dict[str, Any]:
+        """Return only fields that differ from their defaults."""
+        out: Dict[str, Any] = {}
+        for f in fields(self):
+            default = f.default if f.default is not field else None
+            value = getattr(self, f.name)
+            if value != default:
+                out[f.name] = value
+        return out
+
+
+__all__ = [
+    "SUPPORTED_PROFILES",
+    "InitConfig",
+    "ProfileDefaults",
+    "RepoConfig",
+]

--- a/sdk/tests/test_exports.py
+++ b/sdk/tests/test_exports.py
@@ -138,6 +138,7 @@ class TestTopLevelExports(unittest.TestCase):
             "async_trace_agent", "async_trace_tool",
             "patch_openai_async", "patch_anthropic_async",
             "unpatch_openai_async", "unpatch_anthropic_async",
+            "InitConfig", "RepoConfig", "ProfileDefaults", "SUPPORTED_PROFILES",
         }
         self.assertEqual(set(agentguard.__all__), expected)
 

--- a/sdk/tests/test_schemas.py
+++ b/sdk/tests/test_schemas.py
@@ -1,0 +1,148 @@
+"""Tests for the typed-contracts public schemas (agentguard.schemas)."""
+from __future__ import annotations
+
+import pytest
+
+import agentguard
+from agentguard import SUPPORTED_PROFILES, InitConfig, ProfileDefaults, RepoConfig
+
+
+class TestSchemaExports:
+    def test_schemas_importable_from_package_root(self) -> None:
+        # The four typed contracts must be reachable via the top-level import.
+        assert agentguard.InitConfig is InitConfig
+        assert agentguard.RepoConfig is RepoConfig
+        assert agentguard.ProfileDefaults is ProfileDefaults
+        assert agentguard.SUPPORTED_PROFILES == SUPPORTED_PROFILES
+
+    def test_supported_profiles_matches_runtime(self) -> None:
+        # Schema constant must stay in sync with profiles.py.
+        from agentguard.profiles import _PROFILE_DEFAULTS
+
+        assert set(SUPPORTED_PROFILES) == set(_PROFILE_DEFAULTS.keys())
+
+
+class TestInitConfig:
+    def test_defaults_validate(self) -> None:
+        InitConfig().validate()  # should not raise
+
+    def test_valid_full_config(self) -> None:
+        cfg = InitConfig(
+            api_key="ag_abc",
+            budget_usd=5.0,
+            service="my-agent",
+            profile="coding-agent",
+            warn_pct=0.5,
+            loop_max=3,
+            retry_max=2,
+        )
+        cfg.validate()
+
+    def test_warn_pct_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="warn_pct"):
+            InitConfig(warn_pct=1.5).validate()
+
+    def test_local_only_with_api_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="local_only"):
+            InitConfig(api_key="ag_x", local_only=True).validate()
+
+    def test_api_key_with_newline_rejected(self) -> None:
+        with pytest.raises(ValueError, match="newline"):
+            InitConfig(api_key="ag_x\nInjected: header").validate()
+
+    def test_negative_budget_rejected(self) -> None:
+        with pytest.raises(ValueError, match="budget_usd"):
+            InitConfig(budget_usd=-1.0).validate()
+
+    def test_unknown_profile_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown AgentGuard profile"):
+            InitConfig(profile="not-a-real-profile").validate()
+
+    def test_zero_loop_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="loop_max"):
+            InitConfig(loop_max=0).validate()
+
+    def test_negative_retry_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="retry_max"):
+            InitConfig(retry_max=-1).validate()
+
+    def test_empty_string_service_rejected(self) -> None:
+        with pytest.raises(ValueError, match="service"):
+            InitConfig(service="   ").validate()
+
+    def test_to_dict_roundtrips_through_init_signature(self) -> None:
+        # The dict produced by to_dict() must be acceptable kwargs for init.
+        # We verify by introspection rather than calling init (no global state mutation).
+        import inspect
+
+        from agentguard.setup import init
+
+        cfg = InitConfig(budget_usd=1.0, profile="default", auto_patch=False)
+        sig = inspect.signature(init)
+        accepted = set(sig.parameters.keys())
+        for key in cfg.to_dict():
+            assert key in accepted, f"InitConfig field {key!r} not accepted by init()"
+
+
+class TestRepoConfig:
+    def test_defaults_validate(self) -> None:
+        RepoConfig().validate()
+
+    def test_valid_full_config(self) -> None:
+        RepoConfig(
+            service="svc",
+            trace_file="traces.jsonl",
+            budget_usd=10.0,
+            profile="deployed-agent",
+            warn_pct=0.5,
+            loop_max=2,
+            retry_max=1,
+        ).validate()
+
+    def test_to_dict_omits_unset_fields(self) -> None:
+        cfg = RepoConfig(service="svc", budget_usd=2.5)
+        assert cfg.to_dict() == {"service": "svc", "budget_usd": 2.5}
+
+    def test_negative_budget_rejected(self) -> None:
+        with pytest.raises(ValueError, match="budget_usd"):
+            RepoConfig(budget_usd=-0.01).validate()
+
+    def test_unknown_profile_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown AgentGuard profile"):
+            RepoConfig(profile="bogus").validate()
+
+    def test_warn_pct_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="warn_pct"):
+            RepoConfig(warn_pct=2.0).validate()
+
+
+class TestProfileDefaults:
+    def test_valid(self) -> None:
+        ProfileDefaults(loop_max=5, warn_pct=0.8, retry_max=None).validate()
+        ProfileDefaults(loop_max=2, warn_pct=0.5, retry_max=1).validate()
+
+    def test_zero_loop_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="loop_max"):
+            ProfileDefaults(loop_max=0, warn_pct=0.8).validate()
+
+    def test_warn_pct_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="warn_pct"):
+            ProfileDefaults(loop_max=3, warn_pct=-0.1).validate()
+
+    def test_negative_retry_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="retry_max"):
+            ProfileDefaults(loop_max=3, warn_pct=0.8, retry_max=-1).validate()
+
+    def test_matches_runtime_profile_defaults(self) -> None:
+        # Every built-in profile dict must be representable as a ProfileDefaults
+        # instance that validates cleanly.
+        from agentguard.profiles import get_profile_defaults
+
+        for name in SUPPORTED_PROFILES:
+            d = get_profile_defaults(name)
+            schema = ProfileDefaults(
+                loop_max=d["loop_max"],
+                warn_pct=d["warn_pct"],
+                retry_max=d.get("retry_max"),
+            )
+            schema.validate()


### PR DESCRIPTION
## Summary

- Adds `agentguard/schemas.py` with frozen-dataclass typed contracts for the public SDK surface: `InitConfig`, `RepoConfig`, `ProfileDefaults`, `SUPPORTED_PROFILES`.
- Exposes them at the package root (`from agentguard import InitConfig`).
- Adds a "Typed contracts" section to the SDK README pointing at the new schemas module.
- Stdlib-only — preserves the zero-dependency guarantee called out in `pyproject.toml`'s description. No pydantic dep.

Per dri.es "AI rewards strict APIs" — agents adopt SDKs faster when they can introspect the config contract rather than scrape prose.

## What

Each schema:
- mirrors the runtime checks already enforced by `agentguard.init()` and `agentguard.repo_config`
- has a `validate()` method that raises `ValueError` on bad input (out-of-range warn_pct, negative budget, unknown profile, header injection in api_key, non-positive loop_max, etc.)
- has `to_dict()` for round-tripping through `init()` and the JSON config file

`SUPPORTED_PROFILES` is generated from `_PROFILE_DEFAULTS` so it stays in sync automatically. A test asserts the two never drift.

## Test plan

- [x] 24 new tests in `tests/test_schemas.py` cover happy path + each rejection rule for all three dataclasses
- [x] `test_exports.py::test_all_list_complete` updated to include the four new exports
- [x] Full repo test suite green: `734 passed in 29.77s`
- [x] `ruff check agentguard/schemas.py tests/test_schemas.py` clean
- [x] `test_architecture.py::test_core_modules_stdlib_only` still passes (no new deps)
- [x] `test_architecture.py::test_all_public_exports_have_docstrings` still passes

## Risk

Low. Pure additive — new module + four exports, no existing behavior changed. No new dependencies.