### PR TITLE
docs(readme): add Real Incidents section with PocketOS entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,48 @@ Design constraints:
 - no network calls unless you configure `HttpSink`
 - guards raise exceptions inside the running process
 
+## Real Incidents AgentGuard Prevents
+
+### PocketOS — agent deleted prod DB and backups in 9 seconds (May 2026)
+
+A Cursor agent ran a destructive sequence against PocketOS production and
+wiped the live database. Backups went with it.
+
+Reported root cause from the team's postmortem:
+
+- one API key had write + delete on both prod and backups
+- backups lived in the same Railway environment as prod
+- no confirmation step before destructive actions
+- the agent was given enough rope to chain the calls in one turn
+
+Source: [r/devops thread](https://www.reddit.com/r/devops/comments/1t4au5h/pocketos_lost_their_prod_db_backups_to_a_cursor/)
+
+The "AI did it" framing buries the actual lesson: the blast radius was
+infra, not the model. AgentGuard does not replace least-privilege creds or
+isolated backups. It does kill the run before a loop, retry storm, or
+runaway turn finishes the job.
+
+A `BudgetGuard` plus `LoopGuard` wired around the agent loop caps how much
+it can do in one session:
+
+```python
+from agentguard import BudgetGuard, LoopGuard, RateLimitGuard, Tracer
+
+budget = BudgetGuard(max_calls=20, max_cost_usd=1.00)
+loop = LoopGuard(max_repeats=2)
+rate = RateLimitGuard(max_calls_per_minute=10)
+tracer = Tracer(service="cursor-agent", guards=[loop, rate])
+
+with tracer.trace("agent.run"):
+    budget.consume(calls=1)
+    # tool call here — guards raise on overrun
+```
+
+A 9-second sequence of destructive calls trips `LoopGuard` or
+`RateLimitGuard` long before it finishes. The exception kills the run
+in-process. Pair this with scoped credentials and out-of-environment
+backups for the rest of the blast radius.
+
 ## Local Proof In 60 Seconds
 
 ```bash

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -48,6 +48,48 @@ Design constraints:
 - no network calls unless you configure `HttpSink`
 - guards raise exceptions inside the running process
 
+## Real Incidents AgentGuard Prevents
+
+### PocketOS — agent deleted prod DB and backups in 9 seconds (May 2026)
+
+A Cursor agent ran a destructive sequence against PocketOS production and
+wiped the live database. Backups went with it.
+
+Reported root cause from the team's postmortem:
+
+- one API key had write + delete on both prod and backups
+- backups lived in the same Railway environment as prod
+- no confirmation step before destructive actions
+- the agent was given enough rope to chain the calls in one turn
+
+Source: [r/devops thread](https://www.reddit.com/r/devops/comments/1t4au5h/pocketos_lost_their_prod_db_backups_to_a_cursor/)
+
+The "AI did it" framing buries the actual lesson: the blast radius was
+infra, not the model. AgentGuard does not replace least-privilege creds or
+isolated backups. It does kill the run before a loop, retry storm, or
+runaway turn finishes the job.
+
+A `BudgetGuard` plus `LoopGuard` wired around the agent loop caps how much
+it can do in one session:
+
+```python
+from agentguard import BudgetGuard, LoopGuard, RateLimitGuard, Tracer
+
+budget = BudgetGuard(max_calls=20, max_cost_usd=1.00)
+loop = LoopGuard(max_repeats=2)
+rate = RateLimitGuard(max_calls_per_minute=10)
+tracer = Tracer(service="cursor-agent", guards=[loop, rate])
+
+with tracer.trace("agent.run"):
+    budget.consume(calls=1)
+    # tool call here — guards raise on overrun
+```
+
+A 9-second sequence of destructive calls trips `LoopGuard` or
+`RateLimitGuard` long before it finishes. The exception kills the run
+in-process. Pair this with scoped credentials and out-of-environment
+backups for the rest of the blast radius.
+
 ## Local Proof In 60 Seconds
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a new \"Real Incidents AgentGuard Prevents\" section to the README, between \"Why AgentGuard\" and \"Local Proof In 60 Seconds\".
- First entry is the May 2026 PocketOS incident (Cursor agent wiped prod DB + backups in 9s), with the actual postmortem root causes (one API key, same Railway env, no confirm) and a link back to the r/devops source.
- Includes a 5-line guard snippet (BudgetGuard + LoopGuard + RateLimitGuard) showing how the run would have been killed in-process. Snippet was executed locally and runs clean.

## Test plan
- [x] Snippet executes against the installed SDK (\`PYTHONPATH=sdk python -c ...\`) and emits trace events without error.
- [x] No banned words (harness/leverage/streamline/seamless/robust/etc.) in the diff.
- [x] No fabricated quotes — only the bullet list from the public postmortem framing, with the source link inline.
- [x] Markdown renders (tables/headers/code blocks consistent with existing README style).

## Risk
low — README-only change, additive section, no code/config touched.

Routed from intel card \`security-threat-pocketos-cursor-deleted-prod-db\`.