### PR TITLE
docs: sync SDK memory with live package state

### DIFF
--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -1,13 +1,8 @@
 # SDK Blockers
 
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-05-07
 
 ## Active
-- **npm MCP package publish is OTP-blocked.** Repo metadata targets
-  `@agentguard47/mcp-server@0.2.2`, but `npm view @agentguard47/mcp-server version`
-  still returns `0.2.1`. Prior publish attempt was blocked by npm one-time
-  password requirements. Complete with `npm publish --access public --otp <code>`
-  from `mcp-server/`.
 - **Glama listing still blocked.** Official MCP Registry is live, but Glama has
   not detected the server from this repo yet even after adding root-level and
   package-level Smithery / Docker metadata. Revisit later via Glama support or

--- a/memory/state.md
+++ b/memory/state.md
@@ -1,6 +1,6 @@
 # SDK State
 
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-05-07
 
 ## Product
 - AgentGuard = zero-dependency Python SDK for runtime guardrails.
@@ -11,7 +11,7 @@
 - PyPI package: `agentguard47`
 - Latest shipped SDK release: `1.2.10`
 - npm MCP package: repo targets `@agentguard47/mcp-server@0.2.2`; npm registry
-  still serves `0.2.1` until the OTP-gated publish is completed.
+  now serves `0.2.2`.
 - Official MCP Registry listing: live as `io.github.bmdhodl/agentguard47`
 
 ## Repo Scope


### PR DESCRIPTION
## Summary
- update SDK memory to reflect that npm now serves @agentguard47/mcp-server@0.2.2
- remove the resolved OTP-blocked npm publish note from blockers
- refresh the memory file timestamps after live verification

## Proof
- 
pm view @agentguard47/mcp-server version -> 