### PR TITLE
Make budget MCP entrypoint dogfoodable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,21 @@ jobs:
         run: npm --prefix mcp-server ci
       - name: MCP build and tests
         run: npm --prefix mcp-server test
+
+  mcp-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+      - name: Install tools
+        run: python -m pip install --require-hashes -r .github/requirements/ci-tools.txt
+      - name: Install local budget MCP
+        run: python -m pip install -e ./agentguard-mcp
+      - name: Local budget MCP lint and tests
+        run: |
+          cd agentguard-mcp
+          ruff check agentguard_mcp tests
+          python -m pytest

--- a/agentguard-mcp/README.md
+++ b/agentguard-mcp/README.md
@@ -6,14 +6,20 @@ This is the MCP-native sibling of [`agentguard47`](https://pypi.org/project/agen
 
 ## Install
 
+`agentguard-mcp` is currently developed from this repository checkout and is
+not published to PyPI or npm yet.
+
 ```bash
-pip install agentguard-mcp
+cd agentguard-mcp
+python -m pip install -e .
 ```
 
-Or run through npm:
+Run the stdio server with either the editable console script or the module
+entrypoint:
 
 ```bash
-npx -y agentguard-mcp
+agentguard-mcp
+python -m agentguard_mcp
 ```
 
 By default, local state is stored at `~/.agentguard/state.db`. Set `AGENTGUARD_DB_PATH` to use a different SQLite file.
@@ -24,8 +30,8 @@ By default, local state is stored at `~/.agentguard/state.db`. Set `AGENTGUARD_D
 {
   "mcpServers": {
     "agentguard-mcp": {
-      "command": "agentguard-mcp",
-      "args": [],
+      "command": "python",
+      "args": ["-m", "agentguard_mcp"],
       "env": {
         "AGENTGUARD_DB_PATH": "~/.agentguard/state.db"
       }
@@ -37,7 +43,7 @@ By default, local state is stored at `~/.agentguard/state.db`. Set `AGENTGUARD_D
 ## Claude Code
 
 ```bash
-claude mcp add agentguard-mcp -- agentguard-mcp
+claude mcp add agentguard-mcp -- python -m agentguard_mcp
 ```
 
 ## Cursor
@@ -46,8 +52,8 @@ claude mcp add agentguard-mcp -- agentguard-mcp
 {
   "mcpServers": {
     "agentguard-mcp": {
-      "command": "npx",
-      "args": ["-y", "agentguard-mcp"]
+      "command": "python",
+      "args": ["-m", "agentguard_mcp"]
     }
   }
 }
@@ -59,8 +65,8 @@ claude mcp add agentguard-mcp -- agentguard-mcp
 {
   "mcpServers": {
     "agentguard-mcp": {
-      "command": "agentguard-mcp",
-      "args": []
+      "command": "python",
+      "args": ["-m", "agentguard_mcp"]
     }
   }
 }

--- a/agentguard-mcp/agentguard_mcp/__main__.py
+++ b/agentguard-mcp/agentguard_mcp/__main__.py
@@ -1,4 +1,4 @@
-"""Module entry point for `python -m agentguard_mcp`."""
+"""Run the AgentGuard MCP budget server with ``python -m agentguard_mcp``."""
 
 from agentguard_mcp.server import main
 

--- a/agentguard-mcp/agentguard_mcp/server.py
+++ b/agentguard-mcp/agentguard_mcp/server.py
@@ -72,3 +72,7 @@ def create_server(
 def main() -> None:
     mcp = create_server()
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/agentguard-mcp/tests/test_server.py
+++ b/agentguard-mcp/tests/test_server.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import os
 import sys
+from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -43,6 +44,12 @@ def test_module_entrypoint_serves_budget_tools_over_stdio(tmp_path):
     async def run_smoke() -> None:
         env = os.environ.copy()
         env["AGENTGUARD_DB_PATH"] = str(tmp_path / "state.db")
+        package_root = Path(__file__).resolve().parents[1]
+        env["PYTHONPATH"] = (
+            f"{package_root}{os.pathsep}{env['PYTHONPATH']}"
+            if env.get("PYTHONPATH")
+            else str(package_root)
+        )
         env.pop("AGENTGUARD_SYNC_URL", None)
         env.pop("AGENTGUARD_SYNC_TOKEN", None)
 

--- a/agentguard-mcp/tests/test_server.py
+++ b/agentguard-mcp/tests/test_server.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
+import json
+import os
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def _tool_payload(result):
+    assert result.isError is False
+    assert result.content
+    return json.loads(result.content[0].text)
 
 
 def test_importing_server_does_not_create_state_db(tmp_path, monkeypatch):
@@ -24,3 +37,75 @@ def test_create_server_initializes_store_when_called(tmp_path, monkeypatch):
 
     assert app is not None
     assert db_path.exists()
+
+
+def test_module_entrypoint_serves_budget_tools_over_stdio(tmp_path):
+    async def run_smoke() -> None:
+        env = os.environ.copy()
+        env["AGENTGUARD_DB_PATH"] = str(tmp_path / "state.db")
+        env.pop("AGENTGUARD_SYNC_URL", None)
+        env.pop("AGENTGUARD_SYNC_TOKEN", None)
+
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "agentguard_mcp"],
+            env=env,
+        )
+
+        async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            tool_names = {tool.name for tool in tools.tools}
+            assert {
+                "set_budget",
+                "record_call",
+                "check_remaining",
+                "kill_switch",
+                "list_budgets",
+            } <= tool_names
+
+            scope = "session:release-operator-dogfood"
+            set_budget = _tool_payload(
+                await session.call_tool(
+                    "set_budget",
+                    {"scope": scope, "limit_tokens": 100, "period": "session"},
+                )
+            )
+            assert set_budget["scope"] == scope
+            assert set_budget["tokens_limit"] == 100
+
+            record_call = _tool_payload(
+                await session.call_tool(
+                    "record_call",
+                    {
+                        "server": "github",
+                        "tool": "create_issue",
+                        "tokens_in": 10,
+                        "tokens_out": 5,
+                        "cost_usd": 0.01,
+                        "session_id": "release-operator-dogfood",
+                    },
+                )
+            )
+            assert record_call["allowed"] is True
+
+            remaining = _tool_payload(await session.call_tool("check_remaining", {"scope": scope}))
+            assert remaining["tokens_used"] == 15
+            assert remaining["usd_used"] == 0.01
+
+            enabled = _tool_payload(
+                await session.call_tool("kill_switch", {"scope": scope, "enable": True})
+            )
+            assert enabled["kill_switch"] is True
+
+            disabled = _tool_payload(
+                await session.call_tool("kill_switch", {"scope": scope, "enable": False})
+            )
+            assert disabled["kill_switch"] is False
+
+            budgets = _tool_payload(await session.call_tool("list_budgets", {}))
+            assert budgets["budgets"]
+            assert budgets["budgets"][0]["scope"] == scope
+
+    asyncio.run(asyncio.wait_for(run_smoke(), timeout=10))

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -1,13 +1,8 @@
 # SDK Blockers
 
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-05-08
 
 ## Active
-- **npm MCP package publish is OTP-blocked.** Repo metadata targets
-  `@agentguard47/mcp-server@0.2.2`, but `npm view @agentguard47/mcp-server version`
-  still returns `0.2.1`. Prior publish attempt was blocked by npm one-time
-  password requirements. Complete with `npm publish --access public --otp <code>`
-  from `mcp-server/`.
 - **Glama listing still blocked.** Official MCP Registry is live, but Glama has
   not detected the server from this repo yet even after adding root-level and
   package-level Smithery / Docker metadata. Revisit later via Glama support or

--- a/memory/state.md
+++ b/memory/state.md
@@ -1,6 +1,6 @@
 # SDK State
 
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-05-08
 
 ## Product
 - AgentGuard = zero-dependency Python SDK for runtime guardrails.
@@ -10,8 +10,9 @@
 ## Public Artifacts
 - PyPI package: `agentguard47`
 - Latest shipped SDK release: `1.2.10`
-- npm MCP package: repo targets `@agentguard47/mcp-server@0.2.2`; npm registry
-  still serves `0.2.1` until the OTP-gated publish is completed.
+- npm MCP package: `@agentguard47/mcp-server@0.2.2` is published.
+- Local budget MCP package: `agentguard-mcp` exists in this repo but is not
+  published to npm or PyPI; dogfood installs it from the checkout.
 - Official MCP Registry listing: live as `io.github.bmdhodl/agentguard47`
 
 ## Repo Scope


### PR DESCRIPTION
## Summary
- make the Python budget MCP server runnable through both `python -m agentguard_mcp` and `python -m agentguard_mcp.server`
- add a deterministic stdio MCP smoke test for local budget tools using a temp `AGENTGUARD_DB_PATH`
- sync SDK memory now that `@agentguard47/mcp-server@0.2.2` is published and `agentguard-mcp` remains checkout-installed

## Proof
- `python -m pip install -e .\agentguard-mcp`
- `cd agentguard-mcp && python -m ruff check agentguard_mcp tests && python -m pytest`
- `python -m pip install -e .\sdk && python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py && python -m pytest sdk\tests\test_architecture.py -q`
- `npm --prefix mcp-server test`
- `python -m pytest sdk\tests\ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`
- `python -m bandit -r sdk\agentguard -s B101,B110,B112,B311 -q`
- manual stdio proof for installed `agentguard-mcp.exe`: listed `set_budget`, `check_remaining`, `record_call`, `kill_switch`, `list_budgets`
- manual stdio proof for `python -m agentguard_mcp.server`: listed `set_budget`, `check_remaining`, `record_call`, `kill_switch`, `list_budgets`

## Notes
- `make` is not installed on this Windows host, so I ran the Makefile commands directly.