### PR TITLE
docs: record first Glama MCP release

### DIFF
--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -1,3 +1,10 @@
 # Follow-up
 
-No active SDK follow-up items.
+- Verify Glama tool indexing after the first release. The listing is live and
+  env vars are indexed, but the public API still returned `tools: []` on
+  2026-05-08.
+- Refresh official MCP Registry metadata so public search reports
+  `@agentguard47/mcp-server@0.2.2` instead of `0.2.1`.
+- Comment `https://glama.ai/mcp/servers/bmdhodl/agent47` on
+  `punkpeye/awesome-mcp-servers#4012` once the Glama listing is acceptable for
+  the badge requirement.

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ assert result.passed
 - Trace format: JSONL
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
 - MCP package: [`@agentguard47/mcp-server`](mcp-server/)
+- Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 ## Docs
 

--- a/docs/launch/distribution-execution.md
+++ b/docs/launch/distribution-execution.md
@@ -50,8 +50,8 @@ Current listing:
 
 Listing details:
 - Name: `AgentGuard`
-- One-liner: `Runtime safety infrastructure for AI agents`
-- Description: `AgentGuard47 is runtime safety infrastructure for AI agents. It adds budget caps, loop detection, retry limits, timeouts, local traces, and incident reports so agents can stop bad runs while they are happening, not just explain them afterward.`
+- One-liner: `MCP server for coding-agent traces, alerts, costs, usage, and budget health`
+- Description: `Read-only MCP server for coding-agent traces, decision events, alerts, costs, usage, and budget health.`
 - npm package: `@agentguard47/mcp-server`
 - Repo: `https://github.com/bmdhodl/agent47`
 - MCP metadata name: `io.github.bmdhodl/agentguard47`

--- a/docs/launch/distribution-execution.md
+++ b/docs/launch/distribution-execution.md
@@ -41,14 +41,21 @@ curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.bmd
 
 ## 2. Glama
 
-Listing details to reuse:
+Current listing:
+- URL: `https://glama.ai/mcp/servers/bmdhodl/agent47`
+- Namespace / slug: `bmdhodl/agent47`
+- Status: first release published on 2026-05-08. Glama API shows the
+  environment schema but still returns an empty `tools` array, so recheck before
+  treating the directory listing as fully indexed.
+
+Listing details:
 - Name: `AgentGuard`
-- One-liner: `MCP server for coding-agent traces, alerts, costs, usage, and budget health`
+- One-liner: `Runtime safety infrastructure for AI agents`
+- Description: `AgentGuard47 is runtime safety infrastructure for AI agents. It adds budget caps, loop detection, retry limits, timeouts, local traces, and incident reports so agents can stop bad runs while they are happening, not just explain them afterward.`
 - npm package: `@agentguard47/mcp-server`
 - Repo: `https://github.com/bmdhodl/agent47`
 - MCP metadata name: `io.github.bmdhodl/agentguard47`
 
-Use the same description and install command as `mcp-server/server.json`.
 This repo now also ships:
 - [`mcp-server/Dockerfile`](../../mcp-server/Dockerfile)
 - [`mcp-server/smithery.yaml`](../../mcp-server/smithery.yaml)
@@ -63,6 +70,32 @@ Important:
 - keep the root shim aligned with the real package-local files in
   [`mcp-server/`](../../mcp-server/)
 
+Release procedure used for `0.2.2`:
+
+1. Open `https://glama.ai/mcp/servers/bmdhodl/agent47/admin/dockerfile`.
+2. Use the repository root Dockerfile. It builds `mcp-server/` and runs
+   `node /app/mcp-server/dist/index.js`.
+3. Configure environment variables:
+
+   | Variable | Required | Secret | Default | Description |
+   |---|---:|---:|---|---|
+   | `AGENTGUARD_API_KEY` | Yes | Yes | | AgentGuard read API key for traces, alerts, costs, usage, and budget health |
+   | `AGENTGUARD_URL` | No | No | `https://app.agentguard47.com` | Optional AgentGuard API base URL |
+
+4. Deploy the build test.
+5. After the test passes, create and publish the Glama release with version
+   `0.2.2` and changelog `Initial Glama release for AgentGuard MCP server.`
+
+After release, verify the public API exposes the environment schema and the 7
+tools:
+
+```bash
+curl "https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47"
+```
+
+Expected tools once indexing completes: `query_traces`, `get_trace`,
+`get_trace_decisions`, `get_alerts`, `get_usage`, `get_costs`, `check_budget`.
+
 ## 3. awesome-mcp-servers
 
 Open a PR against the upstream list with:
@@ -70,6 +103,7 @@ Open a PR against the upstream list with:
 - category: monitoring / devtools / safety
 - short description: `Runtime guardrails and read access for coding-agent traces, alerts, and budget health`
 - install target: `npx -y @agentguard47/mcp-server`
+- Glama URL: `https://glama.ai/mcp/servers/bmdhodl/agent47`
 
 ## 4. Show HN
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -16,6 +16,8 @@ The boundary is deliberate:
 npx -y @agentguard47/mcp-server
 ```
 
+Glama listing: <https://glama.ai/mcp/servers/bmdhodl/agent47>
+
 ## Tools
 
 | Tool | Description |
@@ -86,20 +88,36 @@ the default branch root:
 Those root files delegate straight to `mcp-server/` and should stay aligned
 with the package-local versions here.
 
-## Registry Readiness
+## Registry Status
 
-This repo now includes official MCP registry metadata in
-[`server.json`](server.json). The npm package is already public, and the Glama /
-Smithery config now lives next to the source, so the remaining registry work is
-metadata publication:
+This repo includes official MCP registry metadata in [`server.json`](server.json).
+The npm package is public, and the Glama / Smithery config lives next to the
+source.
+
+Current public status:
+
+- npm: `@agentguard47/mcp-server@0.2.2`
+- Official MCP Registry: live as `io.github.bmdhodl/agentguard47`; registry
+  search still reports package `0.2.1` and needs metadata refresh
+- Glama: first release live at <https://glama.ai/mcp/servers/bmdhodl/agent47>;
+  environment schema is indexed, but the public API still returns an empty
+  `tools` array as of 2026-05-08
+
+Official MCP registry publication:
 
 ```bash
 mcp-publisher login github
 mcp-publisher publish
 ```
 
-After that, verify the server is searchable from the MCP Registry API and then
-submit it to downstream directories like Glama and `awesome-mcp-servers`.
+Glama release verification:
+
+```bash
+curl "https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47"
+```
+
+Expected tools after Glama finishes indexing: `query_traces`, `get_trace`,
+`get_trace_decisions`, `get_alerts`, `get_usage`, `get_costs`, `check_budget`.
 
 ## Architecture
 

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -3,14 +3,20 @@
 **Last Updated:** 2026-05-08
 
 ## Active
-- **Glama listing still blocked.** Official MCP Registry is live, but Glama has
-  not detected the server from this repo yet even after adding root-level and
-  package-level Smithery / Docker metadata. Revisit later via Glama support or
-  manual reindex instead of spending more cycles now.
-- **`awesome-mcp-servers` PR is blocked on Glama.** PR
-  `punkpeye/awesome-mcp-servers#4012` only needs the Glama badge once the
-  listing exists.
+- **Glama tool catalog is not indexed yet.** Patrick published the first Glama
+  release on 2026-05-08 and the listing is live, but
+  `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` still returns
+  `tools: []`. Recheck before advertising the listing as fully indexed.
+- **Official MCP Registry metadata is stale.** npm serves
+  `@agentguard47/mcp-server@0.2.2`, but registry search still reports package
+  version `0.2.1`. Refresh / republish registry metadata without changing SDK
+  runtime code.
+- **`awesome-mcp-servers` PR needs the Glama URL.** PR
+  `punkpeye/awesome-mcp-servers#4012` can be unblocked with
+  `https://glama.ai/mcp/servers/bmdhodl/agent47` once the Glama tool catalog is
+  confirmed or Patrick accepts posting the live listing while indexing catches
+  up.
 
 ## Do Not Route Around
-- Do not build new guards just because Glama is blocked.
+- Do not build new guards just because registry indexing lags.
 - Do not put business or consulting workaround plans in this repo.

--- a/memory/distribution.md
+++ b/memory/distribution.md
@@ -1,6 +1,6 @@
 # SDK Distribution
 
-**Last Updated:** 2026-04-02
+**Last Updated:** 2026-05-08
 
 ## Core Message
 AgentGuard stops coding agents from looping, retrying forever, and burning
@@ -12,9 +12,12 @@ budget.
 - teams worried about runaway spend and unsafe automation
 
 ## Channels
-- Official MCP Registry
-- Glama
-- `awesome-mcp-servers`
+- Official MCP Registry: live as `io.github.bmdhodl/agentguard47`; metadata
+  refresh needed because public search still reports MCP package `0.2.1`
+- Glama: first release live at `https://glama.ai/mcp/servers/bmdhodl/agent47`;
+  environment schema is indexed, tool catalog still pending in public API
+- `awesome-mcp-servers`: next distribution step after Glama listing/tool
+  indexing is acceptable for badge/commenting
 - Show HN
 - LangChain / GitHub community posts
 

--- a/memory/state.md
+++ b/memory/state.md
@@ -13,7 +13,12 @@
 - npm MCP package: `@agentguard47/mcp-server@0.2.2` is published.
 - Local budget MCP package: `agentguard-mcp` exists in this repo but is not
   published to npm or PyPI; dogfood installs it from the checkout.
-- Official MCP Registry listing: live as `io.github.bmdhodl/agentguard47`
+- Official MCP Registry listing: live as `io.github.bmdhodl/agentguard47`;
+  public registry search still reports package version `0.2.1` and needs a
+  metadata refresh / republish check.
+- Glama listing: live at `https://glama.ai/mcp/servers/bmdhodl/agent47`.
+  First Glama release is published; Glama API shows the environment schema, but
+  still returns an empty `tools` array as of 2026-05-08.
 
 ## Repo Scope
 - `sdk/` = public runtime guardrails SDK

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,14 +3,18 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
-**Last reviewed:** 2026-05-02
+**Last reviewed:** 2026-05-08
 
 ## Current Focus Notes
 
 - Latest shipped SDK release is `v1.2.10`; current work is post-release
   hardening and activation, not a new feature push.
-- Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`;
-  keep MCP narrow and read-only while Glama remains blocked.
+- Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`,
+  but public registry search still reports MCP package version `0.2.1`; refresh
+  metadata without changing SDK runtime code.
+- Glama first release is live at `https://glama.ai/mcp/servers/bmdhodl/agent47`;
+  the public API has indexed env vars but still returns an empty `tools` array
+  as of 2026-05-08.
 - Dashboard alignment is current for hosted ingest and decision traces. The
   remote-kill boundary is documented: the SDK emits events and enforces local
   guards, while the dashboard owns retained history, alerts, and team
@@ -50,7 +54,7 @@ they directly strengthen coding-agent adoption.
 | Item | Success Signal |
 |------|---------------|
 | Activation proof polish | A fresh local flow from `pip install` to `agentguard doctor`, `agentguard demo`, and `agentguard quickstart` stays deterministic; repo-only examples and starters remain offline and easy to copy into real repos |
-| MCP distribution hygiene | Official MCP Registry metadata remains current; Glama and `awesome-mcp-servers` stay tracked without building unrelated features to route around the blocker |
+| MCP distribution hygiene | Official MCP Registry metadata is refreshed to `0.2.2`; Glama tool catalog indexes the seven MCP tools; `awesome-mcp-servers` receives the Glama URL without building unrelated features |
 | Dashboard contract drift checks | Hosted ingest, decision-trace event names, required fields, and remote-kill boundaries remain documented and covered by tests before any release |
 | Ops/doc freshness | `ops/02-ARCHITECTURE.md`, this roadmap, `FOLLOWUP.md`, and memory files stay concise and current enough that agents do not start from stale assumptions |
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -393,6 +393,7 @@ assert result.passed
 - Trace format: JSONL
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
 - MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.10/mcp-server)
+- Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 ## Docs
 


### PR DESCRIPTION
## Summary
- record the first Glama release for the AgentGuard MCP server across README, MCP docs, launch docs, repo memory, roadmap, and follow-up notes
- document the current live state: env schema is indexed, Glama API still returns an empty tools array, and official MCP Registry metadata still reports 0.2.1
- regenerate sdk/PYPI_README.md so release guard stays aligned

## Tests
- npm --prefix mcp-server test
- python -m pytest sdk/tests/test_mcp_registry_metadata.py -v
- python scripts/sdk_release_guard.py
- git diff --check
- MCP stdio smoke listed all 7 local tools
- curl https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47 confirmed release/env schema live and tools still empty