### PR TITLE
docs: improve Glama metadata quality

### DIFF
--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -1,8 +1,10 @@
 # Follow-up
 
 - Verify Glama tool indexing after the first release. The listing is live and
-  env vars are indexed, but the public API still returned `tools: []` on
-  2026-05-08.
+  rendered tool/score pages exist, but the public API still returned `tools: []`
+  on 2026-05-08.
+- Submit related servers in Glama UI: Langfuse MCP, OpenTelemetry MCP, and
+  Sentry MCP are the closest monitoring / trace / incident neighbors.
 - Refresh official MCP Registry metadata so public search reports
   `@agentguard47/mcp-server@0.2.2` instead of `0.2.1`.
 - Comment `https://glama.ai/mcp/servers/bmdhodl/agent47` on

--- a/docs/launch/distribution-execution.md
+++ b/docs/launch/distribution-execution.md
@@ -44,9 +44,9 @@ curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.bmd
 Current listing:
 - URL: `https://glama.ai/mcp/servers/bmdhodl/agent47`
 - Namespace / slug: `bmdhodl/agent47`
-- Status: first release published on 2026-05-08. Glama API shows the
-  environment schema but still returns an empty `tools` array, so recheck before
-  treating the directory listing as fully indexed.
+- Status: first release published on 2026-05-08. Glama renders the tool pages
+  and score page; the public server API still returns an empty `tools` array, so
+  use rendered pages for quality checks until the API catches up.
 
 Listing details:
 - Name: `AgentGuard`
@@ -57,11 +57,13 @@ Listing details:
 - MCP metadata name: `io.github.bmdhodl/agentguard47`
 
 This repo now also ships:
+- [`glama.json`](../../glama.json)
 - [`mcp-server/Dockerfile`](../../mcp-server/Dockerfile)
 - [`mcp-server/smithery.yaml`](../../mcp-server/smithery.yaml)
 
-Those files make the Glama / Smithery build path explicit and document the
-required `AGENTGUARD_API_KEY` configuration for directory checks.
+Those files claim the Glama listing, make the Glama / Smithery build path
+explicit, and document the required `AGENTGUARD_API_KEY` configuration for
+directory checks.
 
 Important:
 - Glama currently scans the repository root when detecting Smithery metadata
@@ -95,6 +97,19 @@ curl "https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47"
 
 Expected tools once indexing completes: `query_traces`, `get_trace`,
 `get_trace_decisions`, `get_alerts`, `get_usage`, `get_costs`, `check_budget`.
+
+Glama quality follow-ups:
+- Keep every tool at A on the rendered score pages. `query_traces` should state
+  that it is read-only, returns a JSON `traces` array, defaults to `limit=20`,
+  and should be used to find `trace_id` values before calling `get_trace` or
+  `get_trace_decisions`.
+- If `glama.json` changes, run the Glama claim ownership flow again so the
+  directory picks up the new metadata.
+- Related servers are managed in the Glama UI via Related Servers -> Suggest
+  Server. Suggested related servers for AgentGuard:
+  - `https://glama.ai/mcp/servers/therealsachin/langfuse-mcp-server`
+  - `https://glama.ai/mcp/servers/agarwalvivek29/opentelemetry-mcp`
+  - `https://glama.ai/mcp/servers/getsentry/sentry-mcp`
 
 ## 3. awesome-mcp-servers
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "bmdhodl"
+  ]
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -16,16 +16,35 @@ export const tools: ToolDefinition[] = [
   {
     name: "query_traces",
     description:
-      "Search recent traces from your AgentGuard-instrumented agents. " +
-      "Filter by service name, time range, or paginate through results.",
+      "Search retained trace summaries from the AgentGuard Read API. " +
+      "This is read-only: it does not mutate agents, traces, budgets, or alerts; " +
+      "it returns JSON with a traces array, defaults to limit 20, and supports service, " +
+      "ISO since/until, and offset pagination filters. " +
+      "Use this to find candidate trace_id values; use get_trace for one full trace " +
+      "or get_trace_decisions for decision.* events from a known trace.",
     inputSchema: {
       type: "object",
       properties: {
-        limit: { type: "number", description: "Max traces to return (default 20, max 500)" },
-        offset: { type: "number", description: "Offset for pagination" },
-        service: { type: "string", description: "Filter by service name" },
-        since: { type: "string", description: "ISO timestamp — only traces after this time" },
-        until: { type: "string", description: "ISO timestamp — only traces before this time" },
+        limit: {
+          type: "number",
+          description: "Maximum trace summaries to return. Defaults to 20; API maximum is 500.",
+        },
+        offset: {
+          type: "number",
+          description: "Zero-based pagination offset for walking additional trace pages.",
+        },
+        service: {
+          type: "string",
+          description: "Exact AgentGuard service name to filter by, such as a repo or agent label.",
+        },
+        since: {
+          type: "string",
+          description: "ISO 8601 timestamp; include only traces that started at or after this time.",
+        },
+        until: {
+          type: "string",
+          description: "ISO 8601 timestamp; include only traces that started at or before this time.",
+        },
       },
     },
     handler: async (client, args) => {

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -4,9 +4,12 @@
 
 ## Active
 - **Glama tool catalog is not indexed yet.** Patrick published the first Glama
-  release on 2026-05-08 and the listing is live, but
-  `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` still returns
-  `tools: []`. Recheck before advertising the listing as fully indexed.
+  release on 2026-05-08 and the listing is live. Glama renders tool and score
+  pages, but `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` still
+  returns `tools: []`. Recheck before relying on the API for tool inventory.
+- **Glama related servers need manual submission.** `glama.json` only claims
+  maintainers. Related servers are added through the Glama UI; use the
+  candidates in `docs/launch/distribution-execution.md`.
 - **Official MCP Registry metadata is stale.** npm serves
   `@agentguard47/mcp-server@0.2.2`, but registry search still reports package
   version `0.2.1`. Refresh / republish registry metadata without changing SDK

--- a/memory/distribution.md
+++ b/memory/distribution.md
@@ -15,7 +15,8 @@ budget.
 - Official MCP Registry: live as `io.github.bmdhodl/agentguard47`; metadata
   refresh needed because public search still reports MCP package `0.2.1`
 - Glama: first release live at `https://glama.ai/mcp/servers/bmdhodl/agent47`;
-  environment schema is indexed, tool catalog still pending in public API
+  rendered tool/score pages exist, public API tool catalog still lags, and
+  related-server suggestions need manual Glama UI submission
 - `awesome-mcp-servers`: next distribution step after Glama listing/tool
   indexing is acceptable for badge/commenting
 - Show HN

--- a/sdk/tests/test_mcp_registry_metadata.py
+++ b/sdk/tests/test_mcp_registry_metadata.py
@@ -4,6 +4,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROOT_DOCKERFILE = REPO_ROOT / "Dockerfile"
 ROOT_DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+ROOT_GLAMA = REPO_ROOT / "glama.json"
 ROOT_SMITHERY = REPO_ROOT / "smithery.yaml"
 MCP_PACKAGE = REPO_ROOT / "mcp-server" / "package.json"
 MCP_SERVER = REPO_ROOT / "mcp-server" / "server.json"
@@ -48,6 +49,7 @@ def test_mcp_registry_metadata_declares_required_env_vars():
 def test_mcp_glama_packaging_files_are_present():
     assert ROOT_DOCKERFILE.exists()
     assert ROOT_DOCKERIGNORE.exists()
+    assert ROOT_GLAMA.exists()
     assert ROOT_SMITHERY.exists()
     assert MCP_DOCKERFILE.exists()
     assert MCP_DOCKERIGNORE.exists()
@@ -87,3 +89,10 @@ def test_mcp_smithery_config_matches_runtime_contract():
     root_dockerignore = ROOT_DOCKERIGNORE.read_text(encoding="utf-8")
     assert "mcp-server/node_modules" in root_dockerignore
     assert ".codex-proof" in root_dockerignore
+
+
+def test_glama_claim_file_matches_schema():
+    claim = _load_json(ROOT_GLAMA)
+
+    assert claim["$schema"] == "https://glama.ai/mcp/schemas/server.json"
+    assert claim["maintainers"] == ["bmdhodl"]

--- a/sdk/tests/test_mcp_registry_metadata.py
+++ b/sdk/tests/test_mcp_registry_metadata.py
@@ -91,8 +91,11 @@ def test_mcp_smithery_config_matches_runtime_contract():
     assert ".codex-proof" in root_dockerignore
 
 
-def test_glama_claim_file_matches_schema():
+def test_glama_claim_file_declares_maintainer():
     claim = _load_json(ROOT_GLAMA)
+    maintainers = claim["maintainers"]
 
     assert claim["$schema"] == "https://glama.ai/mcp/schemas/server.json"
-    assert claim["maintainers"] == ["bmdhodl"]
+    assert isinstance(maintainers, list)
+    assert "bmdhodl" in maintainers
+    assert all(isinstance(maintainer, str) for maintainer in maintainers)


### PR DESCRIPTION
## Summary
- add root glama.json so the Glama listing can be claimed from the GitHub repo
- improve query_traces tool metadata for Glama TDQS: read-only behavior, output shape, defaults, parameter semantics, and sibling-tool guidance
- document related-server submission as a manual Glama UI step with concrete monitoring/trace/incident candidates
- add test coverage for the Glama claim file

## Tests
- npm --prefix mcp-server test
- python -m pytest sdk/tests/test_mcp_registry_metadata.py -v
- python scripts/sdk_release_guard.py
- git diff --check origin/main...HEAD
- MCP stdio smoke confirmed query_traces exposes the new read-only/output/trace_id guidance

## Notes
- Glama glama.json schema currently only accepts maintainers, so related servers are documented as a manual UI submission instead of unsupported JSON.