### PR TITLE
Add Glama badges and clean up root docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ enough to create surprise spend.
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bmdhodl/agent47/badge)](https://scorecard.dev/viewer/?uri=github.com/bmdhodl/agent47)
+[![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/score.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
 ```bash
@@ -392,6 +392,8 @@ assert result.passed
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
 - MCP package: [`@agentguard47/mcp-server`](mcp-server/)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
+
+[![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/card.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 ## Docs
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -18,7 +18,7 @@ enough to create surprise spend.
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.10/LICENSE)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bmdhodl/agent47/badge)](https://scorecard.dev/viewer/?uri=github.com/bmdhodl/agent47)
+[![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/score.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
 ```bash
@@ -394,6 +394,8 @@ assert result.passed
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
 - MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.10/mcp-server)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
+
+[![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/card.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 ## Docs
 


### PR DESCRIPTION
## Summary
- replace the top-level OpenSSF Scorecard badge with the Glama MCP score badge
- add the Glama MCP card badge near the existing Package Facts / Glama listing
- archive stale one-off root Markdown reports under `docs/archive/root-reports/`
- update `CLAUDE.md` so future agents do not recreate root report clutter
- improve the Glama-facing `query_traces` MCP metadata with read-only annotations, auth/rate-limit details, ordering, output shape, and sibling-tool guidance

## Proof
- Glama page inspected: current `query_traces` grade complained about missing side-effect/auth/rate-limit/ordering/output/usage guidance and no annotations
- Glama score badge, card badge, and listing returned 200 before the cleanup commit
- `python scripts/generate_pypi_readme.py --check`
- `python -m pytest sdk/tests/test_pypi_readme_sync.py sdk/tests/test_mcp_registry_metadata.py -q`
- `python scripts/sdk_preflight.py --changed-file README.md --changed-file sdk/PYPI_README.md`
- `python scripts/sdk_preflight.py`
- `npm --prefix mcp-server test`
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py`
- `python -m pytest sdk/tests/test_architecture.py -v`
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` (735 passed, 93.04% coverage)
- `python scripts/sdk_release_guard.py`
- `python -m pip install -e ./agentguard-mcp && cd agentguard-mcp && python -m ruff check agentguard_mcp tests && python -m pytest` (11 passed)

## Notes
The OpenSSF badge is still accessible through Scorecard directly, but I removed it from the top README badge strip because Glama is more useful distribution real estate for the MCP listing work.