### PR TITLE
Document managed-agent threat and cost surfaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,27 @@ Out of scope:
 - Third-party integrations (LangChain, OpenAI, etc.)
 - The AgentGuard dashboard (separate security policy)
 
+## Agent Threat Classes
+
+AgentGuard is an in-process runtime guardrail. It is not a filesystem sandbox,
+container runtime, or host isolation layer. These threat classes are in scope
+for documentation and examples because they affect autonomous coding-agent
+blast radius:
+
+- **Sandbox escape via symlink traversal.** CVE-2026-39861 /
+  GHSA-vp62-r36r-9xqp showed a Claude Code sandbox escape where a sandboxed
+  process could create a symlink that the unsandboxed app later followed,
+  allowing writes outside the workspace. AgentGuard does not prevent symlink
+  traversal or replace sandbox path validation. `BudgetGuard`, `LoopGuard`,
+  `RetryGuard`, `TimeoutGuard`, and session-scoped tracing can still limit how
+  long a compromised or prompt-injected autonomous run keeps acting.
+- **Provider-managed background work.** Managed-agent systems can add work
+  outside the traced application process, such as scheduled memory refinement,
+  external graders, or multi-agent orchestration. AgentGuard only enforces
+  limits on code paths that run through its tracers and guards. Provider
+  console limits and billing alerts remain required for provider-managed
+  background phases until explicit integration support exists.
+
 ## Security Design
 
 The AgentGuard SDK is designed with security in mind:

--- a/docs/competitive/agent-security-stack.md
+++ b/docs/competitive/agent-security-stack.md
@@ -2,7 +2,7 @@
 
 This is a living positioning doc. It explains how AgentGuard fits beside other
 emerging agent-security layers rather than pretending one product should do
-everything. Last updated: 2026-04-16.
+everything. Last updated: 2026-05-09.
 
 ## Why this comparison exists
 
@@ -23,6 +23,13 @@ Trusted credentials do not stop a retry storm. Tool-governance policy does not
 kill a stuck loop already running inside the process. A sandbox can contain
 damage, but it does not enforce a dollar budget or halt a runaway decision flow
 on its own.
+
+Recent coding-agent incidents make that boundary concrete. CVE-2026-39861 /
+GHSA-vp62-r36r-9xqp documented a Claude Code sandbox escape where a symlink
+created inside the sandbox was later followed by an unsandboxed write path,
+allowing a write outside the workspace. AgentGuard does not stop that path
+traversal. It can still cap the compromised run with budgets, retry limits,
+timeouts, and trace evidence once the agent process is instrumented.
 
 ## Layer map
 
@@ -54,7 +61,7 @@ That keeps the repo aligned with its real architecture:
 A coding agent gets a valid non-human identity, is allowed to call a small set
 of MCP tools, and runs inside a sandboxed worker.
 
-Three different failures can still happen:
+Four different failures can still happen:
 
 1. The identity layer correctly authenticates the agent, but the agent burns
    through the run budget with repeated retries.
@@ -62,9 +69,15 @@ Three different failures can still happen:
    an A-B-A-B tool loop after the call returns.
 3. The sandbox correctly contains filesystem access, but the agent keeps
    spawning expensive model turns until the run is no longer economical.
+4. A managed-agent platform performs scheduled memory refinement, grader
+   passes, or delegated subagent work outside the local process that AgentGuard
+   is tracing.
 
-Those are AgentGuard failures to prevent. They happen after identity,
-governance, and isolation have all done their jobs.
+The first three are AgentGuard failures to prevent. They happen after identity,
+governance, and isolation have all done their jobs. The fourth is a boundary to
+document clearly: AgentGuard can enforce the local calls it sees, but
+provider-managed background phases still need provider-side limits and billing
+monitoring.
 
 ```python
 from agentguard import BudgetGuard, LoopGuard, RetryGuard, Tracer

--- a/docs/guides/managed-agent-sessions.md
+++ b/docs/guides/managed-agent-sessions.md
@@ -12,6 +12,25 @@ AgentGuard already gives every top-level trace its own `trace_id`. `session_id`
 adds one level above that, so downstream systems can group multiple traces that
 belong to the same managed-agent session.
 
+## Cost surface boundary
+
+Managed-agent platforms can perform work outside the local process that
+AgentGuard instruments. Anthropic describes Managed Agents "Dreaming" as a
+scheduled process that reviews past sessions, memory stores, and feedback to
+surface patterns for future work. If a provider bills that background work, it
+is not currently modeled by AgentGuard's per-call tracking because no local
+`Tracer`, provider patch, or guard sees the call.
+
+Treat provider-managed background phases as an external cost surface:
+- keep `BudgetGuard` on the code and provider calls you run locally
+- use `session_id` to correlate the managed harness traces you can observe
+- keep provider console spend limits and billing alerts enabled for background
+  planning, memory refinement, grader passes, and delegated subagent work
+
+This is a documented gap, not a hidden feature. AgentGuard can enforce the
+runtime paths it instruments. It does not yet enforce provider-managed
+pre-call, between-call, or post-call work.
+
 ## When to use it
 
 Use `session_id` when:


### PR DESCRIPTION
## Summary
- document CVE-2026-39861 / GHSA-vp62-r36r-9xqp as a symlink-traversal sandbox-escape threat class
- clarify AgentGuard's boundary around sandboxing and provider-managed background phases
- document Managed Agents Dreaming as an external cost surface and create issue #464 for follow-up

## Proof
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-fail-under=80` -> 740 passed, coverage 92.90%
- `python -m pytest sdk/tests/test_architecture.py -v` -> 9 passed
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py` -> passed
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q` -> passed
- `python scripts/sdk_release_guard.py` -> passed
- `npm --prefix mcp-server ci` then `npm --prefix mcp-server test` -> 6 passed

## Notes
- First MCP test attempt failed because `mcp-server/node_modules` was missing in this worktree; `npm ci` restored dependencies and the test passed.
- A broader ad hoc ruff run against all tests surfaced pre-existing test lint debt outside this docs change; the repo's Makefile lint target passed.