### PR TITLE
Improve SDK first-run proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,41 +104,28 @@ A 9-second sequence of destructive calls trips `LoopGuard` or
 in-process. Pair this with scoped credentials and out-of-environment
 backups for the rest of the blast radius.
 
-## Local Proof In 60 Seconds
+## Local Proof in 60 Seconds
 
 ```bash
+pip install agentguard47
 agentguard doctor
 agentguard demo
-agentguard quickstart --framework raw
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
 ```
 
-`doctor` verifies the install and local trace writing.
-`demo` proves budget, loop, and retry stops offline.
-`quickstart` prints the smallest starter for your stack.
+This stays fully local. No API key, dashboard, or network call is required
+after installation.
 
-Installed-package proof:
+What you should see:
 
-```bash
-agentguard demo
-```
-
-Source-checkout proof with local incident output and hosted-compatible NDJSON:
-
-```bash
-git clone https://github.com/bmdhodl/agent47.git
-cd agent47
-PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
-agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
-```
-
-Expected first value moment:
-
-```text
-BudgetGuard stops simulated spend.
-LoopGuard stops repeated tool calls.
-RetryGuard stops a retry storm.
-No API keys. No dashboard. No network calls.
-```
+- `doctor` verifies the installed package and writes a local trace.
+- `demo` visibly trips budget, loop, and retry guards offline.
+- `quickstart --write` creates `agentguard_raw_quickstart.py`.
+- The generated file exits cleanly after catching simulated budget and loop
+  stops.
+- `report` shows local trace counts, cost, savings, and guard events.
 
 Notebook version:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/main/examples/quickstart.ipynb)

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -106,41 +106,28 @@ A 9-second sequence of destructive calls trips `LoopGuard` or
 in-process. Pair this with scoped credentials and out-of-environment
 backups for the rest of the blast radius.
 
-## Local Proof In 60 Seconds
+## Local Proof in 60 Seconds
 
 ```bash
+pip install agentguard47
 agentguard doctor
 agentguard demo
-agentguard quickstart --framework raw
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
 ```
 
-`doctor` verifies the install and local trace writing.
-`demo` proves budget, loop, and retry stops offline.
-`quickstart` prints the smallest starter for your stack.
+This stays fully local. No API key, dashboard, or network call is required
+after installation.
 
-Installed-package proof:
+What you should see:
 
-```bash
-agentguard demo
-```
-
-Source-checkout proof with local incident output and hosted-compatible NDJSON:
-
-```bash
-git clone https://github.com/bmdhodl/agent47.git
-cd agent47
-PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
-agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
-```
-
-Expected first value moment:
-
-```text
-BudgetGuard stops simulated spend.
-LoopGuard stops repeated tool calls.
-RetryGuard stops a retry storm.
-No API keys. No dashboard. No network calls.
-```
+- `doctor` verifies the installed package and writes a local trace.
+- `demo` visibly trips budget, loop, and retry guards offline.
+- `quickstart --write` creates `agentguard_raw_quickstart.py`.
+- The generated file exits cleanly after catching simulated budget and loop
+  stops.
+- `report` shows local trace counts, cost, savings, and guard events.
 
 Notebook version:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.10/examples/quickstart.ipynb)

--- a/sdk/agentguard/cli.py
+++ b/sdk/agentguard/cli.py
@@ -44,6 +44,9 @@ def _report(path: str, as_json: bool = False) -> None:
     total = len(events)
     kinds = Counter(e.get("kind", "(unknown)") for e in events)
     names = Counter(e.get("name", "(unknown)") for e in events)
+    guard_counts = Counter(
+        name for name in names if isinstance(name, str) and name.startswith("guard.")
+    )
     loop_hits = names.get("guard.loop_detected", 0)
 
     span_durations: list[float] = []
@@ -74,6 +77,7 @@ def _report(path: str, as_json: bool = False) -> None:
             "llm_results": names.get("llm.result", 0),
             "estimated_cost_usd": round(total_cost, 4),
             "loop_guard_triggered": loop_hits,
+            "guard_events": dict(guard_counts),
             "savings": savings,
         }
         print(json.dumps(result))
@@ -100,6 +104,10 @@ def _report(path: str, as_json: bool = False) -> None:
         print(f"  Loop guard triggered: {loop_hits} time(s)")
     else:
         print("  Loop guard triggered: 0")
+    if guard_counts:
+        print("  Guard events:")
+        for guard_name, count in guard_counts.most_common():
+            print(f"    {guard_name}: {count}")
     incident_hits = sum(
         1 for e in events if isinstance(e.get("name"), str) and e["name"].startswith("guard.")
     )

--- a/sdk/agentguard/cli.py
+++ b/sdk/agentguard/cli.py
@@ -45,7 +45,11 @@ def _report(path: str, as_json: bool = False) -> None:
     kinds = Counter(e.get("kind", "(unknown)") for e in events)
     names = Counter(e.get("name", "(unknown)") for e in events)
     guard_counts = Counter(
-        name for name in names if isinstance(name, str) and name.startswith("guard.")
+        {
+            name: count
+            for name, count in names.items()
+            if isinstance(name, str) and name.startswith("guard.")
+        }
     )
     loop_hits = names.get("guard.loop_detected", 0)
 

--- a/sdk/agentguard/quickstart.py
+++ b/sdk/agentguard/quickstart.py
@@ -244,6 +244,7 @@ def _raw_payload(service: str, budget_usd: float, trace_file: str) -> Dict[str, 
     snippet = dedent(
         f"""
         import agentguard
+        from agentguard import BudgetExceeded, LoopDetected
 
         tracer = agentguard.init(
             profile="coding-agent",
@@ -252,22 +253,51 @@ def _raw_payload(service: str, budget_usd: float, trace_file: str) -> Dict[str, 
             trace_file={trace_file_literal},
             local_only=True,
         )
+        budget = agentguard.get_budget_guard()
+
+        def call_model(span, prompt: str) -> str:
+            # Replace this with your real LLM call. Keep the budget.consume()
+            # line near the provider response when you know the call cost.
+            simulated_cost = {budget_usd / 2 + 0.01:.2f}
+            span.event(
+                "llm.result",
+                data={{"model": "offline-demo-model", "prompt": prompt}},
+                cost_usd=simulated_cost,
+            )
+            if budget is not None:
+                budget.consume(calls=1, cost_usd=simulated_cost)
+            return f"offline answer for {{prompt}}"
 
         @agentguard.trace_tool(tracer)
         def search_docs(query: str) -> str:
             return f"results for {{query}}"
 
         with tracer.trace("agent.run") as span:
+            try:
+                call_model(span, "plan a safe coding-agent change")
+                call_model(span, "retry the same expensive plan")
+            except BudgetExceeded as exc:
+                span.event("guard.budget_exceeded", data={{"message": str(exc)}})
+                print("BudgetGuard stopped simulated spend: " + str(exc))
+
+            try:
+                for _ in range(3):
+                    span.event("tool.search", data={{"query": "agentguard quickstart"}})
+            except LoopDetected as exc:
+                span.event("guard.loop_detected", data={{"message": str(exc)}})
+                print("LoopGuard stopped repeated tool calls: " + str(exc))
+
             result = search_docs("agentguard quickstart")
             span.event("agent.answer", data={{"result": result}})
 
         print("Traces saved to " + {trace_file_literal})
+        print("Inspect with: agentguard report " + {trace_file_literal})
         """
     )
     return _base_payload(
         install_command="pip install agentguard47",
         filename="agentguard_raw_quickstart.py",
-        summary="Offline starter that proves local tracing and guard wiring without any API keys.",
+        summary="Offline starter that proves local tracing plus budget and loop stops without any API keys.",
         snippet=snippet,
         next_commands=[
             "agentguard doctor",
@@ -276,7 +306,8 @@ def _raw_payload(service: str, budget_usd: float, trace_file: str) -> Dict[str, 
         ],
         notes=[
             "This path is fully local. No dashboard and no provider API keys are required.",
-            "Start here if you want a safe first run before wiring a real LLM client.",
+            "The generated file catches simulated guard exceptions so the script exits cleanly.",
+            "Copy the call_model and tool-event pattern into the loop that drives your coding agent.",
             "Commit a .agentguard.json file if you want coding agents to reuse the same local defaults.",
         ],
     )

--- a/sdk/tests/test_cli_report.py
+++ b/sdk/tests/test_cli_report.py
@@ -121,6 +121,19 @@ class TestCliReport(unittest.TestCase):
                     "trace_id": "t1",
                     "span_id": "s1",
                     "parent_id": None,
+                    "name": "guard.budget_exceeded",
+                    "ts": 1,
+                    "duration_ms": None,
+                    "data": {"message": "budget exceeded again"},
+                    "error": None,
+                },
+                {
+                    "service": "demo",
+                    "kind": "event",
+                    "phase": "emit",
+                    "trace_id": "t1",
+                    "span_id": "s1",
+                    "parent_id": None,
                     "name": "guard.loop_detected",
                     "ts": 0,
                     "duration_ms": None,
@@ -138,7 +151,7 @@ class TestCliReport(unittest.TestCase):
 
             output = buf.getvalue()
             self.assertIn("Guard events:", output)
-            self.assertIn("guard.budget_exceeded: 1", output)
+            self.assertIn("guard.budget_exceeded: 2", output)
             self.assertIn("guard.loop_detected: 1", output)
 
             buf = io.StringIO()
@@ -146,7 +159,7 @@ class TestCliReport(unittest.TestCase):
                 cli._report(path, as_json=True)
 
             payload = json.loads(buf.getvalue())
-            self.assertEqual(payload["guard_events"]["guard.budget_exceeded"], 1)
+            self.assertEqual(payload["guard_events"]["guard.budget_exceeded"], 2)
             self.assertEqual(payload["guard_events"]["guard.loop_detected"], 1)
 
     def test_incident_command_markdown_format(self) -> None:

--- a/sdk/tests/test_cli_report.py
+++ b/sdk/tests/test_cli_report.py
@@ -97,6 +97,58 @@ class TestCliReport(unittest.TestCase):
             output = buf.getvalue()
             self.assertIn("Estimated cost: $0.0225", output)
 
+    def test_report_lists_guard_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "traces.jsonl")
+            events = [
+                {
+                    "service": "demo",
+                    "kind": "event",
+                    "phase": "emit",
+                    "trace_id": "t1",
+                    "span_id": "s1",
+                    "parent_id": None,
+                    "name": "guard.budget_exceeded",
+                    "ts": 0,
+                    "duration_ms": None,
+                    "data": {"message": "budget exceeded"},
+                    "error": None,
+                },
+                {
+                    "service": "demo",
+                    "kind": "event",
+                    "phase": "emit",
+                    "trace_id": "t1",
+                    "span_id": "s1",
+                    "parent_id": None,
+                    "name": "guard.loop_detected",
+                    "ts": 0,
+                    "duration_ms": None,
+                    "data": {"message": "loop detected"},
+                    "error": None,
+                },
+            ]
+            with open(path, "w", encoding="utf-8") as f:
+                for event in events:
+                    f.write(json.dumps(event) + "\n")
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli._report(path)
+
+            output = buf.getvalue()
+            self.assertIn("Guard events:", output)
+            self.assertIn("guard.budget_exceeded: 1", output)
+            self.assertIn("guard.loop_detected: 1", output)
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli._report(path, as_json=True)
+
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload["guard_events"]["guard.budget_exceeded"], 1)
+            self.assertEqual(payload["guard_events"]["guard.loop_detected"], 1)
+
     def test_incident_command_markdown_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "traces.jsonl")

--- a/sdk/tests/test_quickstart.py
+++ b/sdk/tests/test_quickstart.py
@@ -125,10 +125,16 @@ class TestQuickstart(unittest.TestCase):
                 result = run_quickstart(framework="raw", write_file=True, stream=buf)
                 self.assertEqual(result, 0)
 
+                env = os.environ.copy()
+                sdk_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+                env["PYTHONPATH"] = os.pathsep.join(
+                    path for path in [sdk_path, env.get("PYTHONPATH", "")] if path
+                )
                 completed = subprocess.run(
                     [sys.executable, "agentguard_raw_quickstart.py"],
                     check=True,
                     capture_output=True,
+                    env=env,
                     text=True,
                 )
 

--- a/sdk/tests/test_quickstart.py
+++ b/sdk/tests/test_quickstart.py
@@ -2,11 +2,13 @@ import ast
 import io
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 
-from agentguard.cli import _quickstart
+from agentguard.cli import _quickstart, _report
 from agentguard.quickstart import FRAMEWORK_CHOICES, _build_quickstart_payload, run_quickstart
 
 
@@ -111,6 +113,40 @@ class TestQuickstart(unittest.TestCase):
                 self.assertIn("pip install agentguard47", buf.getvalue())
                 self.assertIn("python agentguard_raw_quickstart.py", buf.getvalue())
                 self.assertIn("python -m agentguard.cli report .agentguard/traces.jsonl", buf.getvalue())
+            finally:
+                os.chdir(cwd)
+
+    def test_written_raw_quickstart_runs_and_reports_guard_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                buf = io.StringIO()
+                result = run_quickstart(framework="raw", write_file=True, stream=buf)
+                self.assertEqual(result, 0)
+
+                completed = subprocess.run(
+                    [sys.executable, "agentguard_raw_quickstart.py"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertIn("BudgetGuard stopped simulated spend", completed.stdout)
+                self.assertIn("LoopGuard stopped repeated tool calls", completed.stdout)
+                self.assertTrue(os.path.exists(os.path.join(".agentguard", "traces.jsonl")))
+                with open(os.path.join(".agentguard", "traces.jsonl"), encoding="utf-8") as handle:
+                    names = [json.loads(line)["name"] for line in handle if line.strip()]
+                self.assertIn("guard.budget_exceeded", names)
+                self.assertIn("guard.loop_detected", names)
+                self.assertIn("llm.result", names)
+
+                report = io.StringIO()
+                with redirect_stdout(report):
+                    _report(os.path.join(".agentguard", "traces.jsonl"))
+                self.assertIn("Estimated cost: $", report.getvalue())
+                self.assertIn("guard.budget_exceeded: 1", report.getvalue())
+                self.assertIn("guard.loop_detected: 1", report.getvalue())
             finally:
                 os.chdir(cwd)
 


### PR DESCRIPTION
## Summary
- make the raw quickstart generated by `agentguard quickstart --framework raw --write` visibly prove local budget and loop guard stops
- show `guard.*` events in `agentguard report` text and JSON output
- add focused tests and sync the README/PyPI README first-run proof path

## Proof
- `python -m pytest sdk/tests/test_doctor.py sdk/tests/test_demo.py sdk/tests/test_quickstart.py sdk/tests/test_cli_report.py sdk/tests/test_pypi_readme_sync.py -v` -> `40 passed`
- clean venv editable checkout proof confirmed `agentguard.__file__=K:\agent47\sdk\agentguard\__init__.py`
- clean venv ran `agentguard doctor`, `agentguard demo`, `agentguard quickstart --framework raw --write`, `python agentguard_raw_quickstart.py`, `agentguard report .agentguard\traces.jsonl`
- clean venv report showed `Total events: 14`, `Estimated cost: $5.0200`, `guard.budget_exceeded: 1`, `guard.loop_detected: 1`
- full SDK validation: ruff passed, full pytest passed (`742 passed`, coverage `92.91%`), architecture tests passed (`9 passed`), bandit passed, release guard passed, SDK preflight passed

## Scope
SDK-only. No dashboard, MCP server, registry, Glama, or marketing surfaces changed.