### PR TITLE
fix: report source version in local doctor runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Release Proof
+- Added a deterministic sticky agent proof example that simulates a
+  CrewAI-style retry storm, repeated tool loop, budget burn, local incident
+  output, and dashboard-compatible hosted NDJSON without adding dependencies.
+- Added contract tests that post the sticky proof NDJSON to the local hosted
+  ingest harness so SDK proof events stay aligned with dashboard expectations.
+
 ### Activation
 - Added a post-demo next-step block so `agentguard demo` points directly to
   `agentguard quickstart --framework raw --write`, the generated starter, and

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
-Sales-ready proof with local incident output and hosted-compatible NDJSON:
+Installed-package proof:
 
 ```bash
+agentguard demo
+```
+
+Source-checkout proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+git clone https://github.com/bmdhodl/agent47.git
+cd agent47
 PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
 agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
+Sales-ready proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+```
+
 Expected first value moment:
 
 ```text
@@ -161,6 +168,7 @@ All examples are local-first. No API key is required unless the example says so.
 | Example | What it proves |
 |---|---|
 | [`examples/try_it_now.py`](examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/sticky_agent_proof.py`](examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
 | [`examples/coding_agent_review_loop.py`](examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
 | [`examples/per_token_budget_spike.py`](examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
 | [`examples/budget_aware_escalation.py`](examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |

--- a/docs/examples/proof-gallery.md
+++ b/docs/examples/proof-gallery.md
@@ -41,7 +41,28 @@ Proves:
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](coding-agent-review-loop-incident.md)
 
-## 3. Token-Budget Spike
+## 3. Sticky Agent Proof
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+```
+
+Proves:
+
+- one CrewAI-style workflow can show retry storm, loop detection, and budget burn
+- the SDK can write a local incident report and hosted-compatible NDJSON
+- dashboard proof can be validated without adding framework dependencies
+
+Expected artifacts:
+
+```text
+sticky_agent_proof_traces.jsonl
+sticky_agent_proof_hosted.ndjson
+sticky_agent_proof_incident.md
+```
+
+## 4. Token-Budget Spike
 
 ```bash
 python examples/per_token_budget_spike.py
@@ -60,7 +81,7 @@ Expected stop condition:
 Cost budget exceeded:
 ```
 
-## 4. Decision Trace Workflow
+## 5. Decision Trace Workflow
 
 ```bash
 python examples/decision_trace_workflow.py
@@ -82,7 +103,7 @@ decision.approved
 decision.bound
 ```
 
-## 5. Budget-Aware Escalation
+## 6. Budget-Aware Escalation
 
 ```bash
 python examples/budget_aware_escalation.py
@@ -100,7 +121,7 @@ Expected stop condition:
 Escalation reason: token_count 2430 exceeded 2000
 ```
 
-## 6. Starter File Smoke Test
+## 7. Starter File Smoke Test
 
 ```bash
 agentguard quickstart --framework raw --write
@@ -116,12 +137,13 @@ Proves:
 
 ## What To Share
 
-The most shareable public demo is the coding-agent review loop:
+The most shareable public demo for the release train is the sticky agent proof:
 
 ```bash
-python examples/coding_agent_review_loop.py
-agentguard incident coding_agent_review_loop_traces.jsonl
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
 ```
 
-It maps directly to the product wedge: a coding agent gets stuck reviewing and
-retrying, then AgentGuard stops the run before it keeps burning tokens.
+It maps directly to the product wedge: a production-style agent workflow retries,
+loops, burns budget, then AgentGuard produces a local incident and a
+dashboard-ready event stream.

--- a/docs/guides/dashboard-contract.md
+++ b/docs/guides/dashboard-contract.md
@@ -57,6 +57,25 @@ with:
 - network failures are logged instead of crashing the calling agent
 - retries are bounded by `max_retries`
 
+## Contract proof fixture
+
+Use the sticky proof example when you need one local artifact that can also be
+validated by the dashboard ingest contract:
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+```
+
+It writes:
+
+- `sticky_agent_proof_traces.jsonl` for local reports and incident output
+- `sticky_agent_proof_incident.md` for local review or PR evidence
+- `sticky_agent_proof_hosted.ndjson` with dashboard-compatible `span` and
+  `event` records
+
+The hosted NDJSON drops local-only records and mirrors each event `kind` into
+`type`, matching the same normalization boundary used by `HttpSink`.
+
 ## Decision history
 
 Decision traces are ordinary AgentGuard events. The hosted dashboard recognizes

--- a/examples/sticky_agent_proof.py
+++ b/examples/sticky_agent_proof.py
@@ -1,0 +1,255 @@
+"""Sticky local proof for a runaway CrewAI-style agent workflow.
+
+Run:
+
+    PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+    agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+
+No API keys, dashboard, framework installs, or network calls are required.
+The optional hosted NDJSON output mirrors the shape posted by ``HttpSink`` so
+the dashboard can validate the same proof contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, TextIO
+
+from agentguard import (
+    BudgetExceeded,
+    BudgetGuard,
+    JsonlFileSink,
+    LoopDetected,
+    LoopGuard,
+    RetryGuard,
+    RetryLimitExceeded,
+    Tracer,
+)
+from agentguard.reporting import render_incident_report
+
+DEFAULT_OUT_DIR = Path("sticky_agent_proof_output")
+TRACE_NAME = "sticky_agent_proof_traces.jsonl"
+HOSTED_NAME = "sticky_agent_proof_hosted.ndjson"
+INCIDENT_NAME = "sticky_agent_proof_incident.md"
+SERVICE = "crewai-vendor-review-sticky-proof"
+
+
+def run_sticky_agent_proof(
+    out_dir: Path | str = DEFAULT_OUT_DIR,
+    stream: Optional[TextIO] = None,
+) -> Dict[str, Path]:
+    """Run a deterministic local proof and write trace, hosted, and incident files."""
+    output = stream or sys.stdout
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    trace_path = out_path / TRACE_NAME
+    hosted_path = out_path / HOSTED_NAME
+    incident_path = out_path / INCIDENT_NAME
+    for path in (trace_path, hosted_path, incident_path):
+        if path.exists():
+            path.unlink()
+
+    tracer = Tracer(
+        sink=JsonlFileSink(str(trace_path)),
+        service=SERVICE,
+        metadata={"framework": "crewai", "proof": "sticky-agent-proof"},
+        watermark=False,
+    )
+
+    _print(output, "AgentGuard sticky agent proof")
+    _print(output, "Synthetic CrewAI-style vendor review. No API keys. No network.")
+    _run_retry_storm(tracer, output)
+    _run_loop_detection(tracer, output)
+    _run_budget_burn(tracer, output)
+    _write_hosted_ndjson(trace_path, hosted_path)
+    incident_path.write_text(
+        render_incident_report(str(trace_path), output_format="markdown"),
+        encoding="utf-8",
+    )
+
+    _print(output, "")
+    _print(output, "Proof complete.")
+    _print(output, f"Trace: {trace_path}")
+    _print(output, f"Hosted NDJSON: {hosted_path}")
+    _print(output, f"Incident: {incident_path}")
+    return {
+        "trace": trace_path,
+        "hosted": hosted_path,
+        "incident": incident_path,
+    }
+
+
+def _run_retry_storm(tracer: Tracer, out: TextIO) -> None:
+    retry_guard = RetryGuard(max_retries=3)
+    _print(out, "")
+    _print(out, "1. RetryGuard: catching a clause lookup retry storm")
+    with tracer.trace(
+        "crewai.vendor_review.retry_storm",
+        data={"crew": "vendor-review", "agent": "risk-reviewer"},
+    ) as span:
+        for attempt in range(1, 6):
+            span.event(
+                "tool.retry",
+                data={
+                    "framework": "crewai",
+                    "agent": "risk-reviewer",
+                    "task": "vendor-contract-review",
+                    "tool_name": "clause_lookup",
+                    "attempt": attempt,
+                    "reason": "same upstream timeout",
+                },
+            )
+            try:
+                retry_guard.check("clause_lookup")
+                _print(out, f"  clause_lookup retry {attempt} allowed")
+            except RetryLimitExceeded as exc:
+                span.event(
+                    "guard.retry_limit_exceeded",
+                    data={
+                        "framework": "crewai",
+                        "tool_name": "clause_lookup",
+                        "attempt": attempt,
+                        "message": str(exc),
+                    },
+                )
+                _print(out, f"  stopped retry storm on attempt {attempt}: {exc}")
+                return
+
+
+def _run_loop_detection(tracer: Tracer, out: TextIO) -> None:
+    loop_guard = LoopGuard(max_repeats=3, window=5)
+    args = {"vendor": "acme-medical", "clause": "termination-for-convenience"}
+    _print(out, "")
+    _print(out, "2. LoopGuard: catching the same tool call repeating")
+    with tracer.trace(
+        "crewai.vendor_review.loop_detection",
+        data={"crew": "vendor-review", "agent": "risk-reviewer"},
+    ) as span:
+        for attempt in range(1, 5):
+            span.event(
+                "tool.clause_lookup",
+                data={
+                    "framework": "crewai",
+                    "agent": "risk-reviewer",
+                    "task": "vendor-contract-review",
+                    "tool_name": "clause_lookup",
+                    "attempt": attempt,
+                    "args": args,
+                },
+            )
+            try:
+                loop_guard.check("clause_lookup", args)
+                _print(out, f"  repeated lookup {attempt} allowed")
+            except LoopDetected as exc:
+                span.event(
+                    "guard.loop_detected",
+                    data={
+                        "framework": "crewai",
+                        "tool_name": "clause_lookup",
+                        "attempt": attempt,
+                        "message": str(exc),
+                    },
+                )
+                _print(out, f"  stopped repeated tool loop: {exc}")
+                return
+
+
+def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
+    budget = BudgetGuard(max_cost_usd=0.05, warn_at_pct=0.8)
+    costs = (0.013, 0.014, 0.014, 0.016)
+    _print(out, "")
+    _print(out, "3. BudgetGuard: stopping cost before it compounds")
+    with tracer.trace(
+        "crewai.vendor_review.budget_burn",
+        data={"crew": "vendor-review", "agent": "risk-reviewer"},
+    ) as span:
+        for attempt, cost in enumerate(costs, 1):
+            span.event(
+                "llm.result",
+                data={
+                    "framework": "crewai",
+                    "agent": "risk-reviewer",
+                    "task": "vendor-contract-review",
+                    "model": "gpt-4o",
+                    "usage": {
+                        "prompt_tokens": 1800 + attempt * 250,
+                        "completion_tokens": 420,
+                        "total_tokens": 2220 + attempt * 250,
+                    },
+                    "cost_usd": cost,
+                },
+                cost_usd=cost,
+            )
+            warned_before = budget._warned
+            try:
+                budget.consume(tokens=2220 + attempt * 250, calls=1, cost_usd=cost)
+                _print(out, f"  model call {attempt}: ${budget.state.cost_used:.3f} used")
+            except BudgetExceeded as exc:
+                span.event(
+                    "guard.budget_exceeded",
+                    data={
+                        "framework": "crewai",
+                        "attempt": attempt,
+                        "message": str(exc),
+                        "cost_used": round(budget.state.cost_used, 6),
+                        "limit_usd": budget.max_cost_usd,
+                    },
+                )
+                _print(out, f"  stopped budget burn: {exc}")
+                return
+            if not warned_before and budget._warned:
+                span.event(
+                    "guard.budget_warning",
+                    data={
+                        "framework": "crewai",
+                        "cost_used": round(budget.state.cost_used, 6),
+                        "limit_usd": budget.max_cost_usd,
+                    },
+                )
+                _print(out, f"  budget warning at ${budget.state.cost_used:.3f}")
+
+
+def _write_hosted_ndjson(trace_path: Path, hosted_path: Path) -> None:
+    with trace_path.open(encoding="utf-8") as source, hosted_path.open(
+        "w",
+        encoding="utf-8",
+    ) as target:
+        for event in _hosted_events(source):
+            target.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _hosted_events(lines: Iterable[str]) -> Iterable[Dict[str, Any]]:
+    for line in lines:
+        if not line.strip():
+            continue
+        event = json.loads(line)
+        kind = event.get("kind")
+        if kind not in {"span", "event"}:
+            continue
+        hosted_event = dict(event)
+        hosted_event.setdefault("type", kind)
+        yield hosted_event
+
+
+def _print(stream: TextIO, line: str) -> None:
+    stream.write(line + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        default=str(DEFAULT_OUT_DIR),
+        help="Directory for trace, hosted NDJSON, and incident artifacts.",
+    )
+    args = parser.parse_args(argv)
+    run_sticky_agent_proof(Path(args.out_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/sticky_agent_proof.py
+++ b/examples/sticky_agent_proof.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, TextIO
@@ -159,7 +158,12 @@ def _run_loop_detection(tracer: Tracer, out: TextIO) -> None:
 
 
 def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
-    budget = BudgetGuard(max_cost_usd=0.05, warn_at_pct=0.8)
+    warnings: list[str] = []
+    budget = BudgetGuard(
+        max_cost_usd=0.05,
+        warn_at_pct=0.8,
+        on_warning=warnings.append,
+    )
     costs = (0.013, 0.014, 0.014, 0.016)
     _print(out, "")
     _print(out, "3. BudgetGuard: stopping cost before it compounds")
@@ -184,7 +188,7 @@ def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
                 },
                 cost_usd=cost,
             )
-            warned_before = budget._warned
+            warning_count = len(warnings)
             try:
                 budget.consume(tokens=2220 + attempt * 250, calls=1, cost_usd=cost)
                 _print(out, f"  model call {attempt}: ${budget.state.cost_used:.3f} used")
@@ -201,11 +205,12 @@ def _run_budget_burn(tracer: Tracer, out: TextIO) -> None:
                 )
                 _print(out, f"  stopped budget burn: {exc}")
                 return
-            if not warned_before and budget._warned:
+            if len(warnings) > warning_count:
                 span.event(
                     "guard.budget_warning",
                     data={
                         "framework": "crewai",
+                        "message": warnings[-1],
                         "cost_used": round(budget.state.cost_used, 6),
                         "limit_usd": budget.max_cost_usd,
                     },
@@ -227,10 +232,11 @@ def _hosted_events(lines: Iterable[str]) -> Iterable[Dict[str, Any]]:
         if not line.strip():
             continue
         event = json.loads(line)
-        kind = event.get("kind")
+        kind = event.get("kind") or event.get("type")
         if kind not in {"span", "event"}:
             continue
         hosted_event = dict(event)
+        hosted_event.setdefault("kind", kind)
         hosted_event.setdefault("type", kind)
         yield hosted_event
 

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -33,6 +33,7 @@ UNRELEASED_PATHS = {
     "docs/guides/decision-tracing.md",
     "docs/guides/managed-agent-sessions.md",
     "docs/release/trusted-publishing.md",
+    "examples/sticky_agent_proof.py",
 }
 
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -60,6 +60,13 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
+Sales-ready proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
+agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
+```
+
 Expected first value moment:
 
 ```text
@@ -163,6 +170,7 @@ All examples are local-first. No API key is required unless the example says so.
 | Example | What it proves |
 |---|---|
 | [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
 | [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
 | [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
 | [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -60,9 +60,17 @@ agentguard quickstart --framework raw
 `demo` proves budget, loop, and retry stops offline.
 `quickstart` prints the smallest starter for your stack.
 
-Sales-ready proof with local incident output and hosted-compatible NDJSON:
+Installed-package proof:
 
 ```bash
+agentguard demo
+```
+
+Source-checkout proof with local incident output and hosted-compatible NDJSON:
+
+```bash
+git clone https://github.com/bmdhodl/agent47.git
+cd agent47
 PYTHONPATH=sdk python examples/sticky_agent_proof.py --out-dir proof/sticky-agent-proof
 agentguard incident proof/sticky-agent-proof/sticky_agent_proof_traces.jsonl
 ```
@@ -170,7 +178,7 @@ All examples are local-first. No API key is required unless the example says so.
 | Example | What it proves |
 |---|---|
 | [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/try_it_now.py) | budget, loop, and retry stops |
-| [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
+| [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/main/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
 | [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
 | [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
 | [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 from .atracing import AsyncTraceContext, AsyncTracer
 from .cost import estimate_cost
@@ -52,10 +54,31 @@ from .setup import get_budget_guard, get_tracer, init, shutdown
 from .sinks import HttpSink
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
 
-try:
-    __version__ = version("agentguard47")
-except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.0.0-dev"
+
+def _read_source_version() -> str | None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject_path.exists():
+        return None
+
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _discover_version() -> str:
+    source_version = _read_source_version()
+    if source_version:
+        return source_version
+
+    try:
+        return version("agentguard47")
+    except PackageNotFoundError:  # pragma: no cover
+        return "0.0.0-dev"
+
+
+__version__ = _discover_version()
 
 # Libraries should not configure logging; only add a NullHandler so
 # consumers do not see "No handler found" warnings.

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -2,6 +2,7 @@ import logging
 import re
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Optional
 
 from .atracing import AsyncTraceContext, AsyncTracer
 from .cost import estimate_cost
@@ -55,7 +56,7 @@ from .sinks import HttpSink
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
 
 
-def _read_source_version() -> str | None:
+def _read_source_version() -> Optional[str]:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     if not pyproject_path.exists():
         return None

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -162,12 +162,9 @@ def _verify_local_init(trace_path: str) -> int:
 
 
 def _package_version() -> str:
-    try:
-        from importlib.metadata import version
+    from agentguard import __version__
 
-        return version("agentguard47")
-    except Exception:
-        return "0.0.0-dev"
+    return __version__
 
 
 def _recommended_snippet(repo_config_present: bool = False) -> str:

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -41,6 +41,7 @@ class TestDoctor(unittest.TestCase):
             self.assertGreaterEqual(payload["events_written"], 4)
             self.assertIn("recommended_snippet", payload)
             self.assertEqual(payload["recommended_repo_config"]["profile"], "coding-agent")
+            self.assertEqual(payload["package_version"], agentguard.__version__)
 
     def test_run_doctor_ignores_api_key_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/sdk/tests/test_init.py
+++ b/sdk/tests/test_init.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import tempfile
 import types
+from pathlib import Path
 from typing import Any, Dict, List
 from unittest.mock import patch
 
@@ -478,6 +480,14 @@ class TestGetters:
 
 class TestModuleLevelAccess:
     """Test that init/shutdown are accessible via agentguard module."""
+
+    def test_module_version_matches_repo_pyproject(self):
+        pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        content = pyproject_path.read_text(encoding="utf-8")
+        match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+
+        assert match is not None
+        assert agentguard.__version__ == match.group(1)
 
     def test_module_has_init(self):
         assert hasattr(agentguard, "init")

--- a/sdk/tests/test_sticky_agent_proof.py
+++ b/sdk/tests/test_sticky_agent_proof.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import urllib.request
+from pathlib import Path
+
+from conftest import EXPECTED_API_KEY, IngestHandler
+
+EXAMPLE_PATH = Path(__file__).resolve().parents[2] / "examples" / "sticky_agent_proof.py"
+
+
+def _load_example_module():
+    spec = importlib.util.spec_from_file_location("sticky_agent_proof", EXAMPLE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sticky_agent_proof_writes_local_and_hosted_artifacts(tmp_path):
+    module = _load_example_module()
+    output = io.StringIO()
+
+    paths = module.run_sticky_agent_proof(tmp_path, stream=output)
+
+    assert paths["trace"].exists()
+    assert paths["hosted"].exists()
+    assert paths["incident"].exists()
+    text = output.getvalue()
+    assert "No API keys. No network." in text
+    assert "stopped retry storm" in text
+    assert "stopped repeated tool loop" in text
+    assert "stopped budget burn" in text
+
+    local_events = [
+        json.loads(line)
+        for line in paths["trace"].read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    hosted_events = [
+        json.loads(line)
+        for line in paths["hosted"].read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    names = [event["name"] for event in local_events]
+
+    assert "guard.retry_limit_exceeded" in names
+    assert "guard.loop_detected" in names
+    assert "guard.budget_warning" in names
+    assert "guard.budget_exceeded" in names
+    assert hosted_events
+    assert len(hosted_events) == len(local_events)
+    assert all(event["kind"] in {"span", "event"} for event in hosted_events)
+    assert all(event["type"] == event["kind"] for event in hosted_events)
+    assert all(event["service"] == module.SERVICE for event in hosted_events)
+
+    incident = paths["incident"].read_text(encoding="utf-8")
+    assert "# AgentGuard Incident Report" in incident
+    assert "retry_limit_exceeded" in incident
+    assert "retained history, alerts, spend trends" in incident
+
+
+def test_sticky_agent_proof_hosted_ndjson_matches_ingest_contract(tmp_path, ingest_url):
+    module = _load_example_module()
+    paths = module.run_sticky_agent_proof(tmp_path, stream=io.StringIO())
+
+    request = urllib.request.Request(
+        ingest_url,
+        data=paths["hosted"].read_bytes(),
+        headers={
+            "Authorization": f"Bearer {EXPECTED_API_KEY}",
+            "Content-Type": "application/x-ndjson",
+        },
+        method="POST",
+    )
+
+    with urllib.request.urlopen(request) as response:
+        payload = json.loads(response.read().decode())
+
+    request_log = IngestHandler.request_log()
+    assert payload["accepted"] > 0
+    assert payload["rejected"] == 0
+    assert request_log[-1]["status"] == 200


### PR DESCRIPTION
## Summary
- make repo-local `agentguard.__version__` prefer the checkout `sdk/pyproject.toml` version when running from source
- make `agentguard doctor` report that same source-aware version
- add focused tests that pin doctor/version output to the repo metadata

## Why
The dogfood proof path was loading source from this checkout with `PYTHONPATH=./sdk`, but `agentguard doctor` still reported the globally installed dist version (`1.2.7`) instead of the checkout version (`1.2.10`). That made local proof runs misleading even when the source tree was correct.

## Proof
- `PYTHONPATH=./sdk python -m pytest sdk/tests/test_init.py sdk/tests/test_doctor.py sdk/tests/test_example_starters.py sdk/tests/test_cli_report.py -q`
- `PYTHONPATH=./sdk python -m agentguard.cli doctor`
- `PYTHONPATH=./sdk python -m agentguard.cli demo`
- `PYTHONPATH=./sdk python examples/coding_agent_review_loop.py`

## Dogfood guard evidence
- `agentguard_demo_traces.jsonl` emits `guard.budget_warning`, `guard.budget_exceeded`, `guard.loop_detected`, and `guard.retry_limit_exceeded`
- `coding_agent_review_loop_traces.jsonl` emits `guard.budget_exceeded` at `$0.0510 > $0.0450` and `guard.retry_limit_exceeded` for `apply_patch` attempt 4