### PR TITLE
fix: report source version in local doctor runs

### DIFF
--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -68,10 +68,32 @@ def _read_source_version() -> Optional[str]:
         return None
 
     content = pyproject_path.read_text(encoding="utf-8")
-    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
-    if match is None:
+    in_project_table = False
+    project_name = None
+    project_version = None
+
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_project_table = line == "[project]"
+            continue
+        if not in_project_table:
+            continue
+
+        name_match = re.match(r'^name\s*=\s*"([^"]+)"', line)
+        if name_match is not None:
+            project_name = name_match.group(1)
+            continue
+
+        version_match = re.match(r'^version\s*=\s*"([^"]+)"', line)
+        if version_match is not None:
+            project_version = version_match.group(1)
+
+    if project_name != "agentguard47" or project_version is None:
         return None
-    return match.group(1)
+    return project_version
 
 
 def _discover_version() -> str:

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -2,6 +2,7 @@ import logging
 import re
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Optional
 
 from .atracing import AsyncTraceContext, AsyncTracer
 from .cost import estimate_cost
@@ -61,7 +62,7 @@ from .sinks import HttpSink
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
 
 
-def _read_source_version() -> str | None:
+def _read_source_version() -> Optional[str]:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     if not pyproject_path.exists():
         return None

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 from .atracing import AsyncTraceContext, AsyncTracer
 from .cost import estimate_cost
@@ -58,10 +60,31 @@ from .setup import get_budget_guard, get_tracer, init, shutdown
 from .sinks import HttpSink
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
 
-try:
-    __version__ = version("agentguard47")
-except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.0.0-dev"
+
+def _read_source_version() -> str | None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject_path.exists():
+        return None
+
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _discover_version() -> str:
+    source_version = _read_source_version()
+    if source_version:
+        return source_version
+
+    try:
+        return version("agentguard47")
+    except PackageNotFoundError:  # pragma: no cover
+        return "0.0.0-dev"
+
+
+__version__ = _discover_version()
 
 # Libraries should not configure logging; only add a NullHandler so
 # consumers do not see "No handler found" warnings.

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -162,12 +162,9 @@ def _verify_local_init(trace_path: str) -> int:
 
 
 def _package_version() -> str:
-    try:
-        from importlib.metadata import version
+    from agentguard import __version__
 
-        return version("agentguard47")
-    except Exception:
-        return "0.0.0-dev"
+    return __version__
 
 
 def _recommended_snippet(repo_config_present: bool = False) -> str:

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -44,6 +44,7 @@ class TestDoctor(unittest.TestCase):
             self.assertGreaterEqual(payload["events_written"], 4)
             self.assertIn("recommended_snippet", payload)
             self.assertEqual(payload["recommended_repo_config"]["profile"], "coding-agent")
+            self.assertEqual(payload["package_version"], agentguard.__version__)
 
     def test_run_doctor_ignores_api_key_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/sdk/tests/test_init.py
+++ b/sdk/tests/test_init.py
@@ -503,6 +503,47 @@ class TestModuleLevelAccess:
         assert match is not None
         assert agentguard.__version__ == match.group(1)
 
+    def test_source_version_ignores_non_agentguard_project_table(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_root = Path(tmpdir) / "sdk" / "agentguard"
+            package_root.mkdir(parents=True)
+            pyproject_path = package_root.parent / "pyproject.toml"
+            pyproject_path.write_text(
+                '\n'.join(
+                    [
+                        "[project]",
+                        'name = "some-other-package"',
+                        'version = "9.9.9"',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            monkeypatch.setattr(agentguard, "__file__", str(package_root / "__init__.py"))
+
+            assert agentguard._read_source_version() is None
+
+    def test_source_version_uses_project_table_version_only(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_root = Path(tmpdir) / "sdk" / "agentguard"
+            package_root.mkdir(parents=True)
+            pyproject_path = package_root.parent / "pyproject.toml"
+            pyproject_path.write_text(
+                '\n'.join(
+                    [
+                        "[tool.poetry]",
+                        'version = "9.9.9"',
+                        "",
+                        "[project]",
+                        'name = "agentguard47"',
+                        'version = "1.2.10"',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            monkeypatch.setattr(agentguard, "__file__", str(package_root / "__init__.py"))
+
+            assert agentguard._read_source_version() == "1.2.10"
+
     def test_module_has_init(self):
         assert hasattr(agentguard, "init")
         assert callable(agentguard.init)

--- a/sdk/tests/test_init.py
+++ b/sdk/tests/test_init.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import tempfile
 import types
+from pathlib import Path
 from typing import Any, Dict, List
 from unittest.mock import patch
 
@@ -492,6 +494,14 @@ class TestGetters:
 
 class TestModuleLevelAccess:
     """Test that init/shutdown are accessible via agentguard module."""
+
+    def test_module_version_matches_repo_pyproject(self):
+        pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        content = pyproject_path.read_text(encoding="utf-8")
+        match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+
+        assert match is not None
+        assert agentguard.__version__ == match.group(1)
 
     def test_module_has_init(self):
         assert hasattr(agentguard, "init")


### PR DESCRIPTION
## Summary
- make repo-local `agentguard.__version__` prefer the checkout `sdk/pyproject.toml` version when running from source
- make `agentguard doctor` report that same source-aware version
- add focused tests that pin doctor/version output to the repo metadata

## Why
The dogfood proof path was loading source from this checkout with `PYTHONPATH=./sdk`, but `agentguard doctor` still reported the globally installed dist version (`1.2.7`) instead of the checkout version (`1.2.10`). That made local proof runs misleading even when the source tree was correct.

## Proof
- `PYTHONPATH=./sdk python -m pytest sdk/tests/test_init.py sdk/tests/test_doctor.py sdk/tests/test_example_starters.py sdk/tests/test_cli_report.py -q`
- `PYTHONPATH=./sdk python -m agentguard.cli doctor`
- `PYTHONPATH=./sdk python -m agentguard.cli demo`
- `PYTHONPATH=./sdk python examples/coding_agent_review_loop.py`
- `py -3.9 -c "import sys; sys.path.insert(0, r''C:\Users\patri\Documents\GitHub\agent47\sdk''); import agentguard; print(agentguard.__version__)"`

## Dogfood guard evidence
- `agentguard_demo_traces.jsonl` emits `guard.budget_warning`, `guard.budget_exceeded`, `guard.loop_detected`, and `guard.retry_limit_exceeded`
- `coding_agent_review_loop_traces.jsonl` emits `guard.budget_exceeded` at `$0.0510 > $0.0450` and `guard.retry_limit_exceeded` for `apply_patch` attempt 4
