### PR TITLE
Refresh MCP indexing state and document blockers

### DIFF
--- a/memory/distribution.md
+++ b/memory/distribution.md
@@ -1,6 +1,6 @@
 # SDK Distribution
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-15
 
 ## Core Message
 AgentGuard stops coding agents from looping, retrying forever, and burning
@@ -12,11 +12,18 @@ budget.
 - teams worried about runaway spend and unsafe automation
 
 ## Channels
-- Official MCP Registry: live as `io.github.bmdhodl/agentguard47`; metadata
-  refresh needed because public search still reports MCP package `0.2.1`
-- Glama: first release live at `https://glama.ai/mcp/servers/bmdhodl/agent47`;
-  rendered tool/score pages exist, public API tool catalog still lags, and
-  related-server suggestions need manual Glama UI submission
+- npm `@agentguard47/mcp-server`: latest `0.2.2`, modified 2026-05-04; matches
+  `mcp-server/package.json` and `mcp-server/server.json`
+- Official MCP Registry: live as `io.github.bmdhodl/agentguard47`; public API
+  still reports `0.2.1` (statusChangedAt 2026-04-02). Republish requires
+  `mcp-publisher` CLI with maintainer credentials and is NOT scripted in this
+  repo; see `docs/release/mcp-publishing.md`
+- Glama: live at `https://glama.ai/mcp/servers/bmdhodl/agent47` (id
+  `y6zuc6wgtu`). Environment schema present; public API `tools: []` still
+  empty, so the seven expected tools (`query_traces`, `get_trace`,
+  `get_trace_decisions`, `get_alerts`, `get_usage`, `get_costs`,
+  `check_budget`) are not yet indexed. Requires manual Glama UI action; no
+  repo automation
 - `awesome-mcp-servers`: next distribution step after Glama listing/tool
   indexing is acceptable for badge/commenting
 - Show HN

--- a/proof/mcp-indexing-refresh-2026-05-15/README.md
+++ b/proof/mcp-indexing-refresh-2026-05-15/README.md
@@ -1,0 +1,93 @@
+# MCP Indexing Refresh — 2026-05-15
+
+Maintenance / distribution hygiene check for `@agentguard47/mcp-server`. No SDK
+or MCP runtime code change. Source task:
+`Queue/agent47/2026-05-09-refresh-agentguard-mcp-indexing.md`.
+
+## Repo state
+
+- `mcp-server/package.json` version: `0.2.2`
+- `mcp-server/server.json` version: `0.2.2`
+
+## Live state (verified 2026-05-15)
+
+### npm
+
+- Latest: `0.2.2` (versions: `0.1.0`, `0.2.0`, `0.2.1`, `0.2.2`)
+- Modified: `2026-05-04T19:38:49.604Z`
+- URL: https://www.npmjs.com/package/@agentguard47/mcp-server
+- API: https://registry.npmjs.org/@agentguard47/mcp-server
+- Status: matches repo. No action.
+
+### Official MCP Registry
+
+- Name: `io.github.bmdhodl/agentguard47`
+- Reported version: `0.2.1`
+- `statusChangedAt` / `updatedAt`: `2026-04-02T16:27:26.234163Z`
+- `isLatest`: `true` (but version lags npm)
+- URL: https://registry.modelcontextprotocol.io/v0/servers?search=agentguard47
+- Status: STALE. Registry still reports `0.2.1`. Needs a registry republish to
+  reflect npm `0.2.2`.
+
+### Glama
+
+- ID: `y6zuc6wgtu`, slug: `bmdhodl/agent47`
+- URL: https://glama.ai/mcp/servers/bmdhodl/agent47
+- API: https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47
+- Environment schema: present and current
+- `tools`: `[]` (empty)
+- Status: STALE. The seven expected tools are not exposed via Glama's public
+  API:
+  - `query_traces`
+  - `get_trace`
+  - `get_trace_decisions`
+  - `get_alerts`
+  - `get_usage`
+  - `get_costs`
+  - `check_budget`
+
+## Tool names verified in `mcp-server/src/tools.ts`
+
+All seven tools are present in source (lines 19, 73, 90, 112, 132, 149, 163).
+No code drift.
+
+## Blockers
+
+Both registry refresh and Glama re-indexing require external credentials /
+manual action and are NOT scripted in this repo (no `mcp-publisher`,
+`glama-cli`, or registry/Glama scripts under `scripts/`).
+
+### Blocker 1 — MCP Registry republish
+
+- **What it needs:** `mcp-publisher` CLI authenticated as the
+  `io.github.bmdhodl` maintainer, run against `mcp-server/server.json`.
+- **Why the worker cannot do it autonomously:** the publisher CLI is not
+  installed in this environment and would require maintainer credentials that
+  must not be auto-fetched. The repo docs
+  (`docs/release/mcp-publishing.md`) describe the publish step as a manual
+  operation gated on an OTP.
+- **Resume path:** Patrick (or a Patrick-credentialed session) runs
+  `mcp-publisher publish` against `mcp-server/server.json` from a logged-in
+  shell. After publish, re-curl the registry search endpoint and confirm
+  version `0.2.2`.
+
+### Blocker 2 — Glama tool catalog indexing
+
+- **What it needs:** manual action in Glama's UI to trigger a re-scan of the
+  server's tool list, OR contact Glama support to refresh the index.
+- **Why the worker cannot do it autonomously:** Glama's public API does not
+  expose an admin re-index endpoint. The repo's existing
+  `memory/distribution.md` already flagged this as needing manual UI work.
+- **Resume path:** sign in to Glama as `bmdhodl`, trigger a tool list refresh
+  on the server page. After refresh, re-curl
+  `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` and confirm `tools`
+  contains the seven names listed above.
+
+## Files changed in this PR
+
+- `memory/distribution.md` — updated channel state with verified live numbers,
+  links, and a precise description of each blocker. Replaces the earlier
+  "metadata refresh needed" / "public API tool catalog still lags" phrasing.
+
+No code change. No `mcp-server/` change. No SDK change. No dashboard change.
+No new dependency.


### PR DESCRIPTION
## Summary
- Live-verified npm `@agentguard47/mcp-server` is `0.2.2` (matches `mcp-server/package.json` and `mcp-server/server.json`).
- Live-verified Official MCP Registry still reports `0.2.1` (stale since 2026-04-02) and Glama still reports `tools: []`.
- Updated `memory/distribution.md` with the verified live state and precise blocker descriptions; added `proof/mcp-indexing-refresh-2026-05-15/README.md` recording curl evidence and resume paths.

No SDK, MCP runtime, or dashboard code changes. Registry republish and Glama re-index both require external credentials / manual action and are not scriptable from this worker.

## Test plan
- [x] `curl https://registry.npmjs.org/@agentguard47/mcp-server` -> latest 0.2.2
- [x] `curl 'https://registry.modelcontextprotocol.io/v0/servers?search=agentguard47'` -> version 0.2.1 (blocker recorded)
- [x] `curl https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` -> tools: [] (blocker recorded)
- [x] Source `mcp-server/src/tools.ts` confirms the seven expected tool names are present
- [x] No files in denylist (`.github/workflows/`, `.env*`, `supabase/migrations/`, `security/`, Stripe/Clerk)

## Artifacts
- `proof/mcp-indexing-refresh-2026-05-15/README.md` — verification record and blockers
- `memory/distribution.md` — updated channel state

## Risk
Low. Two text files only: a docs/memory update and a new proof folder. No build artifacts, runtime code, configs, or workflows touched.