### PR TITLE
Add audit-only MCP tool-call audit-log primitive

### DIFF
--- a/QA_REPORT.md
+++ b/QA_REPORT.md
@@ -1,0 +1,68 @@
+# QA_REPORT — MCP tool-call audit-log primitive
+
+**Verdict: ✅**
+
+Reviewed the diff (`git diff origin/main...HEAD`) against the queue task,
+WORK_PLAN.md, RESEARCH.md, and the repo's AGENTS.md / GOLDEN_PRINCIPLES.md /
+architecture tests.
+
+## Scope match
+
+The diff matches WORK_PLAN.md exactly: one new core module, `__init__.py` export
+update, one test file, one architecture-test list entry, one example. No scope
+creep.
+
+## Acceptance criteria
+
+- [x] Audit helper writes one parseable JSONL row per stub MCP tool call —
+      `test_logger_writes_one_jsonl_row_per_call_to_file`.
+- [x] Tests cover row schema, digest behavior, and no raw-argument leakage —
+      `test_build_row_has_full_schema_*`, `test_digest_*`,
+      `test_row_does_not_leak_raw_arguments`, `test_logger_does_not_leak_raw_arguments`.
+- [x] Existing suite still passes — 762 passed, 0 failed.
+- [x] PR body states audit-only / no policy enforcement.
+
+## Non-goals — all respected
+
+- No `agentguard47.mcp_policy` module.
+- No allowlists, denylists, PHI regexes, rate limits, or short-circuit enforcement.
+  `decision` is a recorded label; `test_logger_records_decision_label_without_enforcing`
+  proves a `"deny"` value still produces a written row with no raise.
+- No new dependencies — `mcp_audit.py` is stdlib-only (`hashlib`, `json`,
+  `datetime`, `typing`) plus the core `tracing` module. Added to `CORE_MODULES`
+  in `test_architecture.py`, and the stdlib-only test passes.
+- No public-positioning changes, no blog post.
+
+## Security / safety confirmations
+
+- **No secrets added.** Verified — diff contains no keys, tokens, or credentials.
+- **No denylist paths touched.** Diff is confined to `sdk/` plus two root
+  artifact docs. No `.github/workflows/`, `.env*`, `supabase/migrations/`,
+  `security/`, or auth config.
+- **No test coverage regression.** 762 tests pass (291 baseline + new). All
+  pre-existing tests still pass; `test_exports.py` and `test_architecture.py`
+  were updated to register the three new public names — required, not a
+  weakening of the checks.
+- **No raw-argument leakage.** `build_mcp_audit_row` never stores `payload`;
+  only a `"<algo>:<hexdigest>"` digest. Two tests assert secrets are absent
+  from serialized rows.
+
+## Pattern compliance
+
+- Reuses `JsonlFileSink`, `TraceSink`, `_coerce_json_value` rather than
+  re-implementing.
+- `_require_non_empty` / `_timestamp_now` mirror the existing `decision.py`
+  helpers.
+- `__init__.py` import grouping and sorted `__all__` follow the existing style.
+- Thread safety comes from the sink's own lock; the logger holds no mutable
+  state, consistent with the architecture test's `THREAD_SAFE_CLASSES` model.
+
+## Issues
+
+None blocking.
+
+Note for the merge gate: source + test changes total ~499 lines (module 204,
+tests 220, wiring 6, example 65); with the two artifact docs the full diff is
+588 lines, above the 400-LOC auto-merge threshold. The size is inherent to a
+new module plus its test file, not avoidable scope. Flagging per the mechanical
+gate.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,0 +1,40 @@
+# RESEARCH — verification of WORK_PLAN assumptions
+
+## Existing decision/audit surface
+
+- `sdk/agentguard/decision.py` — decision events (`decision.proposed/edited/...`)
+  are emitted as **trace events** through a `TraceContext`. They are span-bound and
+  carry proposal/final/diff. This is review-flow oriented, not per-tool-call audit.
+  Reusing `DecisionTrace` would force MCP calls into a span/workflow model they do
+  not have. Decision: build a standalone row-writer that reuses only the sink.
+- `sdk/agentguard/tracing.py:67` — `JsonlFileSink(path)`: thread-safe, appends one
+  `json.dumps(event, sort_keys=True)` line per `emit()`. Exactly the sink semantics
+  needed. `StdoutSink` and the `TraceSink` ABC are also reusable.
+- `sdk/agentguard/tracing.py:97` — `_coerce_json_value()` recursively coerces
+  arbitrary values into JSON-serializable structures (bytes, sets, non-serializable
+  fall back to a marker). Used to make the digest input deterministic and safe.
+
+## Architecture constraints (GOLDEN_PRINCIPLES.md / test_architecture.py)
+
+- `tests/test_architecture.py:27` `CORE_MODULES` is an explicit list; the
+  stdlib-only import test (line 175) and the public-API test (line 218) iterate it.
+  A new core module MUST be added to that list or it is not covered. Verified by
+  reading lines 175-260.
+- `MAX_MODULE_LINES = 800`, enforced via `rglob` (line 253) — new module is well
+  under.
+- `test_no_hardcoded_absolute_paths` (line 308) rglobs all files — example/module
+  must use relative paths only.
+- Core modules must be stdlib-only. `hashlib`, `json`, `datetime`, `threading` are
+  all stdlib — no new dependency, satisfies the explicit non-goal.
+
+## Package export pattern
+
+- `sdk/agentguard/__init__.py` imports public names per-module and lists every one
+  in a sorted `__all__`. New names (`MCPAuditLogger`, `build_mcp_audit_row`,
+  `digest_payload`) follow that pattern.
+
+## Conclusion
+
+Plan holds. Build a standalone stdlib-only `mcp_audit.py` that reuses `JsonlFileSink`
+and `_coerce_json_value`; do not route through `DecisionTrace`. Add the module to
+`CORE_MODULES`. No policy enforcement anywhere — `decision` is a recorded string.

--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -1,0 +1,54 @@
+# WORK_PLAN — MCP tool-call audit-log primitive
+
+## Problem statement
+
+AgentGuard has no first-class way to record MCP (Model Context Protocol) tool-call
+decisions to a durable, parseable log. The queue task asks for a NARROW, audit-only
+primitive: a helper that writes one JSONL row per MCP tool call with timestamp,
+server, tool, payload digest, decision label, reason, and agent id. This is an
+observability extension of the existing decision/audit surface — NOT a policy
+engine, allowlist/denylist, PHI regex bundle, rate limiter, or governance product.
+
+## Approach
+
+Add a new stdlib-only core module `agentguard/mcp_audit.py` exposing:
+
+- `digest_payload(payload, *, algorithm="sha256") -> str` — deterministic hex digest
+  of a JSON-canonicalized tool-call payload. Raw arguments are never stored.
+- `build_mcp_audit_row(*, server, tool, payload, decision, reason=None, agent_id=None,
+  timestamp=None, payload_digest=None) -> dict` — constructs a normalized,
+  JSON-serializable audit row. `decision` is a free-form label (e.g. "allow",
+  "deny", "observed") that the helper RECORDS but does NOT enforce.
+- `MCPAuditLogger` — thin wrapper that owns a `TraceSink` (defaults to
+  `JsonlFileSink`) and exposes `.record(...)` writing one row per call. Thread-safe
+  via the sink's own lock; the logger holds no mutable state.
+
+Reuse existing primitives: `JsonlFileSink` from `tracing.py`, `_coerce_json_value`
+for serialization safety. No new dependencies — `hashlib`, `json`, `datetime` are
+all stdlib.
+
+## Files likely to touch
+
+- `sdk/agentguard/mcp_audit.py` (new)
+- `sdk/agentguard/__init__.py` (export new names + `__all__`)
+- `sdk/tests/test_mcp_audit.py` (new)
+- `sdk/tests/test_architecture.py` (add `mcp_audit.py` to `CORE_MODULES`)
+- `sdk/examples/mcp_audit_example.py` (new, tiny example)
+
+## What "done" looks like
+
+- [ ] `build_mcp_audit_row` returns a parseable dict with all required fields.
+- [ ] `MCPAuditLogger.record(...)` writes exactly one JSONL line per call.
+- [ ] Payloads are digested; raw tool arguments never appear in the row.
+- [ ] `decision` is recorded as a label; no code path enforces/short-circuits.
+- [ ] Unit tests cover allow-style and deny-style row shapes, digest behavior,
+      and no-raw-argument-leakage.
+- [ ] Existing test suite still passes.
+- [ ] No new dependency. No `agentguard47.mcp_policy` module.
+
+## Risks / assumptions
+
+- `test_architecture.py::CORE_MODULES` is an explicit list — a new core module not
+  added there is silently uncovered by the stdlib-only check. Mitigation: add it.
+- Module must stay stdlib-only (Golden Principle). `hashlib`/`json`/`datetime` only.
+- Keep diff under 400 LOC for auto-merge eligibility.

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -48,6 +48,7 @@ from .instrument import (
     unpatch_openai,
     unpatch_openai_async,
 )
+from .mcp_audit import MCPAuditLogger, build_mcp_audit_row, digest_payload
 from .schemas import (
     SUPPORTED_PROFILES,
     InitConfig,
@@ -91,6 +92,7 @@ __all__ = [
     "JsonlFileSink",
     "LoopDetected",
     "LoopGuard",
+    "MCPAuditLogger",
     "ProfileDefaults",
     "RateLimitGuard",
     "RepoConfig",
@@ -104,7 +106,9 @@ __all__ = [
     "__version__",
     "async_trace_agent",
     "async_trace_tool",
+    "build_mcp_audit_row",
     "decision_flow",
+    "digest_payload",
     "estimate_cost",
     "extract_decision_events",
     "extract_decision_payload",

--- a/sdk/agentguard/mcp_audit.py
+++ b/sdk/agentguard/mcp_audit.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -156,12 +157,14 @@ class MCPAuditLogger:
         *,
         digest_algorithm: str = "sha256",
     ) -> None:
-        if isinstance(sink, str):
-            self._sink: TraceSink = JsonlFileSink(sink)
+        if isinstance(sink, (str, os.PathLike)):
+            self._sink: TraceSink = JsonlFileSink(os.fspath(sink))
         elif isinstance(sink, TraceSink):
             self._sink = sink
         else:
-            raise TypeError("sink must be a file path string or a TraceSink instance")
+            raise TypeError(
+                "sink must be a file path, path-like object, or a TraceSink instance"
+            )
         if digest_algorithm not in _SUPPORTED_ALGORITHMS:
             raise ValueError(
                 f"digest_algorithm must be one of {sorted(_SUPPORTED_ALGORITHMS)}, "

--- a/sdk/agentguard/mcp_audit.py
+++ b/sdk/agentguard/mcp_audit.py
@@ -1,0 +1,204 @@
+"""Audit-log primitive for MCP (Model Context Protocol) tool calls.
+
+This module records one parseable JSONL row per MCP tool call. It is an
+observability extension of AgentGuard's existing decision/audit surface — it
+does **not** enforce policy. The ``decision`` field is a free-form label that
+the caller supplies and this module records verbatim; nothing here allows,
+denies, rate-limits, or short-circuits a tool call.
+
+Raw tool arguments are never stored. Payloads are reduced to a deterministic
+digest so an audit log can be kept without leaking arguments.
+
+Usage::
+
+    from agentguard import MCPAuditLogger
+
+    audit = MCPAuditLogger("mcp_audit.jsonl")
+    audit.record(
+        server="github",
+        tool="create_issue",
+        payload={"repo": "acme/app", "title": "Bug"},
+        decision="allow",
+        reason="within session scope",
+        agent_id="planner",
+    )
+
+The recorded row is a flat JSON object. An MCP wrapper calls ``record`` after it
+has decided what to do with a tool call; this module only writes the row down.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .tracing import JsonlFileSink, TraceSink, _coerce_json_value
+
+__all__ = [
+    "MCPAuditLogger",
+    "build_mcp_audit_row",
+    "digest_payload",
+]
+
+# Schema marker so downstream parsers can branch on row type without guessing.
+MCP_AUDIT_KIND = "mcp.tool_call.audit"
+
+_SUPPORTED_ALGORITHMS = frozenset({"sha256", "sha1", "md5"})
+
+
+def _require_non_empty(name: str, value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _timestamp_now() -> str:
+    """Return an ISO-8601 UTC timestamp with a trailing ``Z``."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def digest_payload(payload: Any, *, algorithm: str = "sha256") -> str:
+    """Return a deterministic hex digest of an MCP tool-call payload.
+
+    The payload is coerced into a JSON-serializable structure and serialized
+    with sorted keys so the digest is stable regardless of dict ordering. The
+    raw payload is never returned or stored — only this digest.
+
+    Args:
+        payload: Any tool-call argument structure. Non-serializable values are
+            coerced via the same path the tracing sinks use.
+        algorithm: Hash algorithm name. One of ``sha256``, ``sha1``, ``md5``.
+
+    Returns:
+        A ``"<algorithm>:<hexdigest>"`` string, e.g. ``"sha256:ab12..."``.
+    """
+    if algorithm not in _SUPPORTED_ALGORITHMS:
+        raise ValueError(
+            f"algorithm must be one of {sorted(_SUPPORTED_ALGORITHMS)}, got {algorithm!r}"
+        )
+    coerced = _coerce_json_value(payload)
+    canonical = json.dumps(coerced, sort_keys=True, ensure_ascii=True)
+    hexdigest = hashlib.new(algorithm, canonical.encode("utf-8")).hexdigest()
+    return f"{algorithm}:{hexdigest}"
+
+
+def build_mcp_audit_row(
+    *,
+    server: str,
+    tool: str,
+    payload: Any,
+    decision: str,
+    reason: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    timestamp: Optional[str] = None,
+    payload_digest: Optional[str] = None,
+    digest_algorithm: str = "sha256",
+) -> Dict[str, Any]:
+    """Build one normalized, JSON-serializable MCP tool-call audit row.
+
+    The row records a *decision label* — it does not enforce it. Raw ``payload``
+    is digested, never copied into the row.
+
+    Args:
+        server: MCP server name the tool belongs to.
+        tool: Tool name being called.
+        payload: Tool-call arguments. Digested, not stored raw.
+        decision: Free-form decision label, e.g. ``"allow"``, ``"deny"``,
+            ``"observed"``. Recorded verbatim; no enforcement happens here.
+        reason: Optional human-readable rationale for the decision.
+        agent_id: Optional identifier of the agent making the call.
+        timestamp: Optional ISO-8601 timestamp. Generated (UTC) if omitted.
+        payload_digest: Optional precomputed digest. Computed from ``payload``
+            if omitted.
+        digest_algorithm: Algorithm used when computing the digest.
+
+    Returns:
+        A flat dict suitable for a single JSONL line.
+    """
+    row = {
+        "kind": MCP_AUDIT_KIND,
+        "timestamp": timestamp or _timestamp_now(),
+        "server": _require_non_empty("server", server),
+        "tool": _require_non_empty("tool", tool),
+        "payload_digest": payload_digest
+        or digest_payload(payload, algorithm=digest_algorithm),
+        "decision": _require_non_empty("decision", decision),
+        "reason": reason,
+        "agent_id": agent_id,
+    }
+    return row
+
+
+class MCPAuditLogger:
+    """Writes MCP tool-call audit rows to a JSONL sink.
+
+    This logger is audit-only. It records the ``decision`` label supplied by the
+    caller and never enforces a policy. It holds no mutable state of its own;
+    thread safety comes from the underlying sink (``JsonlFileSink`` is
+    thread-safe).
+
+    Usage::
+
+        audit = MCPAuditLogger("mcp_audit.jsonl")
+        audit.record(server="github", tool="create_issue",
+                      payload={"repo": "acme/app"}, decision="allow")
+
+    Args:
+        sink: Either a path string (wrapped in a :class:`JsonlFileSink`) or any
+            :class:`~agentguard.TraceSink` instance.
+        digest_algorithm: Hash algorithm used for payload digests.
+    """
+
+    def __init__(
+        self,
+        sink: Any,
+        *,
+        digest_algorithm: str = "sha256",
+    ) -> None:
+        if isinstance(sink, str):
+            self._sink: TraceSink = JsonlFileSink(sink)
+        elif isinstance(sink, TraceSink):
+            self._sink = sink
+        else:
+            raise TypeError("sink must be a file path string or a TraceSink instance")
+        if digest_algorithm not in _SUPPORTED_ALGORITHMS:
+            raise ValueError(
+                f"digest_algorithm must be one of {sorted(_SUPPORTED_ALGORITHMS)}, "
+                f"got {digest_algorithm!r}"
+            )
+        self._digest_algorithm = digest_algorithm
+
+    def record(
+        self,
+        *,
+        server: str,
+        tool: str,
+        payload: Any,
+        decision: str,
+        reason: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        timestamp: Optional[str] = None,
+        payload_digest: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build an audit row and write it to the sink as one JSONL line.
+
+        Returns the row that was written so callers can assert on or forward it.
+        This does not enforce ``decision`` — it only records it.
+        """
+        row = build_mcp_audit_row(
+            server=server,
+            tool=tool,
+            payload=payload,
+            decision=decision,
+            reason=reason,
+            agent_id=agent_id,
+            timestamp=timestamp,
+            payload_digest=payload_digest,
+            digest_algorithm=self._digest_algorithm,
+        )
+        self._sink.emit(row)
+        return row
+
+    def __repr__(self) -> str:
+        return f"MCPAuditLogger(sink={self._sink!r})"

--- a/sdk/agentguard/mcp_audit.py
+++ b/sdk/agentguard/mcp_audit.py
@@ -45,7 +45,7 @@ __all__ = [
 # Schema marker so downstream parsers can branch on row type without guessing.
 MCP_AUDIT_KIND = "mcp.tool_call.audit"
 
-_SUPPORTED_ALGORITHMS = frozenset({"sha256", "sha1", "md5"})
+_SUPPORTED_ALGORITHMS = frozenset({"sha256"})
 
 
 def _require_non_empty(name: str, value: str) -> str:
@@ -69,7 +69,7 @@ def digest_payload(payload: Any, *, algorithm: str = "sha256") -> str:
     Args:
         payload: Any tool-call argument structure. Non-serializable values are
             coerced via the same path the tracing sinks use.
-        algorithm: Hash algorithm name. One of ``sha256``, ``sha1``, ``md5``.
+        algorithm: Hash algorithm name. Currently only ``sha256`` is allowed.
 
     Returns:
         A ``"<algorithm>:<hexdigest>"`` string, e.g. ``"sha256:ab12..."``.

--- a/sdk/examples/mcp_audit_example.py
+++ b/sdk/examples/mcp_audit_example.py
@@ -1,0 +1,65 @@
+"""Audit-log an MCP tool call with AgentGuard.
+
+This shows how an MCP wrapper records one JSONL audit row per tool call. The
+logger is audit-only: it writes down the ``decision`` label the wrapper has
+already made. It does not allow, deny, or rate-limit anything.
+
+Raw tool arguments are never written — only a digest of the payload.
+
+Usage:
+    PYTHONPATH=sdk python examples/mcp_audit_example.py
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from agentguard import MCPAuditLogger
+
+
+def handle_mcp_tool_call(audit: MCPAuditLogger, server: str, tool: str, args: dict):
+    """Stand-in for an MCP wrapper handling one tool call.
+
+    The wrapper decides what to do with the call (here, a trivial label) and
+    then records that decision. AgentGuard only writes the audit row.
+    """
+    # The wrapper's own logic decides the label — AgentGuard does not.
+    decision = "deny" if tool == "delete_everything" else "allow"
+    reason = "destructive tool" if decision == "deny" else "within session scope"
+
+    audit.record(
+        server=server,
+        tool=tool,
+        payload=args,
+        decision=decision,
+        reason=reason,
+        agent_id="example-agent",
+    )
+    return decision
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "mcp_audit.jsonl"
+        audit = MCPAuditLogger(str(log_path))
+
+        # Two stub MCP tool calls — one allowed, one denied.
+        handle_mcp_tool_call(
+            audit, "github", "create_issue", {"repo": "acme/app", "title": "Bug"}
+        )
+        handle_mcp_tool_call(
+            audit, "filesystem", "delete_everything", {"path": "/"}
+        )
+
+        print(f"Audit log written to {log_path}:")
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            row = json.loads(line)
+            print(
+                f"  {row['timestamp']} {row['server']}.{row['tool']} "
+                f"-> {row['decision']} ({row['payload_digest'][:23]}...)"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/tests/test_architecture.py
+++ b/sdk/tests/test_architecture.py
@@ -36,6 +36,7 @@ CORE_MODULES = [
     "export.py",
     "guards.py",
     "instrument.py",
+    "mcp_audit.py",
     "profiles.py",
     "quickstart.py",
     "savings.py",

--- a/sdk/tests/test_exports.py
+++ b/sdk/tests/test_exports.py
@@ -129,6 +129,7 @@ class TestTopLevelExports(unittest.TestCase):
             "log_decision_overridden", "log_decision_approved",
             "log_decision_bound",
             "estimate_cost",
+            "MCPAuditLogger", "build_mcp_audit_row", "digest_payload",
             "HttpSink",
             "EvalSuite", "EvalResult", "AssertionResult", "summarize_trace",
             "trace_agent", "trace_tool",

--- a/sdk/tests/test_mcp_audit.py
+++ b/sdk/tests/test_mcp_audit.py
@@ -1,0 +1,219 @@
+"""Tests for the MCP tool-call audit-log primitive.
+
+These cover audit-only behavior: row schema, payload digesting, no raw-argument
+leakage, and that ``decision`` is recorded as a label without enforcement.
+"""
+import json
+
+import pytest
+
+from agentguard import MCPAuditLogger, build_mcp_audit_row, digest_payload
+from agentguard.mcp_audit import MCP_AUDIT_KIND
+from agentguard.tracing import TraceSink
+
+_REQUIRED_FIELDS = {
+    "kind",
+    "timestamp",
+    "server",
+    "tool",
+    "payload_digest",
+    "decision",
+    "reason",
+    "agent_id",
+}
+
+
+class _CaptureSink(TraceSink):
+    """Sink that keeps emitted rows in memory for assertions."""
+
+    def __init__(self):
+        self.rows = []
+
+    def emit(self, event):
+        # Round-trip through JSON to prove rows are parseable.
+        self.rows.append(json.loads(json.dumps(event, sort_keys=True)))
+
+
+# ---------------------------------------------------------------------------
+# build_mcp_audit_row — schema
+# ---------------------------------------------------------------------------
+
+def test_build_row_has_full_schema_for_allow_decision():
+    row = build_mcp_audit_row(
+        server="github",
+        tool="create_issue",
+        payload={"repo": "acme/app", "title": "Bug"},
+        decision="allow",
+        reason="within session scope",
+        agent_id="planner",
+    )
+    assert set(row) == _REQUIRED_FIELDS
+    assert row["kind"] == MCP_AUDIT_KIND
+    assert row["server"] == "github"
+    assert row["tool"] == "create_issue"
+    assert row["decision"] == "allow"
+    assert row["reason"] == "within session scope"
+    assert row["agent_id"] == "planner"
+    assert row["payload_digest"].startswith("sha256:")
+    assert row["timestamp"].endswith("Z")
+
+
+def test_build_row_has_full_schema_for_deny_decision():
+    row = build_mcp_audit_row(
+        server="filesystem",
+        tool="delete_file",
+        payload={"path": "/etc/passwd"},
+        decision="deny",
+        reason="path outside workspace",
+        agent_id="worker-7",
+    )
+    assert set(row) == _REQUIRED_FIELDS
+    assert row["decision"] == "deny"
+    assert row["reason"] == "path outside workspace"
+
+
+def test_build_row_optional_fields_default_to_none():
+    row = build_mcp_audit_row(
+        server="github",
+        tool="list_repos",
+        payload={},
+        decision="observed",
+    )
+    assert row["reason"] is None
+    assert row["agent_id"] is None
+
+
+def test_build_row_is_json_serializable():
+    row = build_mcp_audit_row(
+        server="github", tool="x", payload={"a": 1}, decision="allow"
+    )
+    parsed = json.loads(json.dumps(row, sort_keys=True))
+    assert parsed == row
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 123])
+def test_build_row_rejects_empty_required_strings(bad):
+    with pytest.raises((ValueError, TypeError)):
+        build_mcp_audit_row(server=bad, tool="x", payload={}, decision="allow")
+    with pytest.raises((ValueError, TypeError)):
+        build_mcp_audit_row(server="s", tool=bad, payload={}, decision="allow")
+    with pytest.raises((ValueError, TypeError)):
+        build_mcp_audit_row(server="s", tool="x", payload={}, decision=bad)
+
+
+# ---------------------------------------------------------------------------
+# digest_payload — digest behavior
+# ---------------------------------------------------------------------------
+
+def test_digest_is_deterministic_regardless_of_key_order():
+    a = digest_payload({"a": 1, "b": 2})
+    b = digest_payload({"b": 2, "a": 1})
+    assert a == b
+
+
+def test_digest_differs_for_different_payloads():
+    assert digest_payload({"a": 1}) != digest_payload({"a": 2})
+
+
+def test_digest_carries_algorithm_prefix():
+    assert digest_payload({"x": 1}, algorithm="sha1").startswith("sha1:")
+    assert digest_payload({"x": 1}, algorithm="sha256").startswith("sha256:")
+
+
+def test_digest_rejects_unknown_algorithm():
+    with pytest.raises(ValueError):
+        digest_payload({"x": 1}, algorithm="rot13")
+
+
+def test_digest_handles_non_serializable_payload():
+    # Sets and other non-JSON values are coerced, not raised on.
+    digest = digest_payload({"tags": {"b", "a"}})
+    assert digest.startswith("sha256:")
+
+
+# ---------------------------------------------------------------------------
+# No raw-argument leakage
+# ---------------------------------------------------------------------------
+
+def test_row_does_not_leak_raw_arguments():
+    secret = "super-secret-token-value"
+    row = build_mcp_audit_row(
+        server="api",
+        tool="call",
+        payload={"token": secret, "body": "sensitive payload text"},
+        decision="allow",
+    )
+    serialized = json.dumps(row)
+    assert secret not in serialized
+    assert "sensitive payload text" not in serialized
+    # Only the digest represents the payload.
+    assert "payload" not in row
+    assert row["payload_digest"].startswith("sha256:")
+
+
+def test_logger_does_not_leak_raw_arguments():
+    sink = _CaptureSink()
+    audit = MCPAuditLogger(sink)
+    secret = "another-secret-99"
+    audit.record(
+        server="api", tool="call", payload={"key": secret}, decision="deny"
+    )
+    serialized = json.dumps(sink.rows)
+    assert secret not in serialized
+
+
+# ---------------------------------------------------------------------------
+# MCPAuditLogger — writes one parseable JSONL row per call
+# ---------------------------------------------------------------------------
+
+def test_logger_writes_one_jsonl_row_per_call_to_file(tmp_path):
+    path = tmp_path / "mcp_audit.jsonl"
+    audit = MCPAuditLogger(str(path))
+    audit.record(
+        server="github", tool="create_issue", payload={"repo": "a/b"},
+        decision="allow", agent_id="planner",
+    )
+    audit.record(
+        server="filesystem", tool="delete_file", payload={"path": "x"},
+        decision="deny", reason="out of scope",
+    )
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    rows = [json.loads(line) for line in lines]
+    assert rows[0]["decision"] == "allow"
+    assert rows[1]["decision"] == "deny"
+    assert all(r["kind"] == MCP_AUDIT_KIND for r in rows)
+
+
+def test_logger_record_returns_written_row():
+    sink = _CaptureSink()
+    audit = MCPAuditLogger(sink)
+    returned = audit.record(
+        server="github", tool="x", payload={"a": 1}, decision="observed"
+    )
+    assert returned == sink.rows[0]
+
+
+def test_logger_records_decision_label_without_enforcing():
+    # A "deny" decision must still produce a written row — the logger never
+    # raises or short-circuits based on the decision value.
+    sink = _CaptureSink()
+    audit = MCPAuditLogger(sink)
+    row = audit.record(
+        server="api", tool="dangerous_tool", payload={}, decision="deny"
+    )
+    assert row["decision"] == "deny"
+    assert len(sink.rows) == 1
+
+
+def test_logger_rejects_invalid_sink_type():
+    with pytest.raises(TypeError):
+        MCPAuditLogger(12345)
+
+
+def test_logger_honors_digest_algorithm():
+    sink = _CaptureSink()
+    audit = MCPAuditLogger(sink, digest_algorithm="sha1")
+    row = audit.record(server="s", tool="t", payload={"a": 1}, decision="allow")
+    assert row["payload_digest"].startswith("sha1:")

--- a/sdk/tests/test_mcp_audit.py
+++ b/sdk/tests/test_mcp_audit.py
@@ -186,6 +186,16 @@ def test_logger_writes_one_jsonl_row_per_call_to_file(tmp_path):
     assert all(r["kind"] == MCP_AUDIT_KIND for r in rows)
 
 
+def test_logger_accepts_pathlike_sink(tmp_path):
+    path = tmp_path / "mcp_audit.jsonl"
+    audit = MCPAuditLogger(path)
+    audit.record(server="github", tool="create_issue", payload={}, decision="allow")
+
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["tool"] == "create_issue"
+
+
 def test_logger_record_returns_written_row():
     sink = _CaptureSink()
     audit = MCPAuditLogger(sink)

--- a/sdk/tests/test_mcp_audit.py
+++ b/sdk/tests/test_mcp_audit.py
@@ -116,7 +116,6 @@ def test_digest_differs_for_different_payloads():
 
 
 def test_digest_carries_algorithm_prefix():
-    assert digest_payload({"x": 1}, algorithm="sha1").startswith("sha1:")
     assert digest_payload({"x": 1}, algorithm="sha256").startswith("sha256:")
 
 
@@ -224,6 +223,6 @@ def test_logger_rejects_invalid_sink_type():
 
 def test_logger_honors_digest_algorithm():
     sink = _CaptureSink()
-    audit = MCPAuditLogger(sink, digest_algorithm="sha1")
+    audit = MCPAuditLogger(sink, digest_algorithm="sha256")
     row = audit.record(server="s", tool="t", payload={"a": 1}, decision="allow")
-    assert row["payload_digest"].startswith("sha1:")
+    assert row["payload_digest"].startswith("sha256:")


### PR DESCRIPTION
## Summary

- Adds a narrow, **audit-only** logging primitive for MCP (Model Context Protocol) tool calls. New stdlib-only core module `agentguard/mcp_audit.py` exposing `digest_payload`, `build_mcp_audit_row`, and `MCPAuditLogger`.
- Records one parseable JSONL row per tool call: timestamp, server, tool, payload digest, decision label, reason, agent id. Extends AgentGuard's existing decision/audit surface.
- **This is audit-only. It does NOT add policy enforcement.** The `decision` field is a free-form label the caller supplies and the helper records verbatim — nothing here allows, denies, rate-limits, or short-circuits a tool call. No `mcp_policy` module, no allowlists/denylists/PHI regexes/rate limits.
- Raw tool arguments are never stored — payloads are reduced to a deterministic `<algorithm>:<hexdigest>` digest.
- No new dependencies. Reuses `JsonlFileSink` and `_coerce_json_value`.

## Test plan

- [x] `pytest sdk/tests/test_mcp_audit.py` — 20 new tests: allow/deny row schema, digest determinism + algorithm + non-serializable payloads, no-raw-argument leakage, one-JSONL-row-per-call, invalid sink rejection.
- [x] `pytest sdk/tests/` — full suite, 762 passed, 0 failed (no regressions).
- [x] `ruff check sdk/agentguard/` — clean.
- [x] `mcp_audit.py` added to `CORE_MODULES` in `test_architecture.py`; stdlib-only architecture test passes.
- [x] `examples/mcp_audit_example.py` runs and prints two audit rows.

## Artifacts

`WORK_PLAN.md`, `RESEARCH.md`, and `QA_REPORT.md` are committed at repo root. QA verdict: ✅ (no secrets added, no denylist paths touched, no coverage regression).

## Risk

Low. Additive new module; no existing behavior changed. Only the export-list tests (`test_exports.py`, `test_architecture.py`) were updated to register the three new public names. Diff is ~500 LOC of source+tests (new module 204 + test file 220), above the mechanical 400-LOC auto-merge gate — flagged for review.