### PR TITLE
Add local-first agent template example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ after the optional `pydantic-ai` package is installed.
 
 | File | Framework | What it shows |
 |------|-----------|---------------|
+| `local-first-template/` | Raw AgentGuard | Framework-free agent loop against a local llama.cpp/Ollama server with budget, rate-limit, and tool-allowlist guards + JSONL audit (runs offline, no GPU) |
 | `budget_aware_escalation.py` | Raw AgentGuard | Advisor-style escalation from a cheaper local model to a stronger model on hard turns |
 | `coding_agent_review_loop.py` | Raw AgentGuard | Local coding-agent review loop proof: repeated review/edit retries trip `BudgetGuard` and `RetryGuard` without network calls |
 | `disposable_harness_session.py` | Raw AgentGuard | Two tracer instances sharing one `session_id` to simulate a managed-agent session across disposable harnesses |
@@ -71,6 +72,10 @@ python examples/per_token_budget_spike.py
 # Coding-agent review loop demo (local-only)
 python examples/coding_agent_review_loop.py
 agentguard incident coding_agent_review_loop_traces.jsonl
+
+# Local-first agent template (local-only, no GPU, no model server needed)
+python examples/local-first-template/agent.py
+agentguard report local_first_template_traces.jsonl
 
 # Advisor-style escalation demo (local-only)
 python examples/budget_aware_escalation.py

--- a/examples/local-first-template/README.md
+++ b/examples/local-first-template/README.md
@@ -1,0 +1,84 @@
+# Local-first agent template
+
+A minimal, framework-free agent loop that runs against a **local** model
+server while AgentGuard enforces a budget cap, a rate limit, and a tool
+allowlist -- and writes a JSONL audit log of every decision.
+
+Use this as a copy-paste starting point when your model runs on hardware you
+own (llama.cpp, Ollama, LM Studio) and there is no hosted provider to stop a
+runaway loop for you.
+
+## What it shows
+
+- A hand-rolled agent loop -- no LangChain, no CrewAI, nothing to learn.
+- `BudgetGuard` capping tokens and calls, warning at 80%.
+- `RateLimitGuard` checked before every model call.
+- A tool allowlist: the agent may only call `read_file`; an attempt to call
+  `run_shell` is denied and logged.
+- A `JsonlFileSink` audit log -- one line per model call, tool call, and guard
+  decision.
+
+## Run it
+
+Offline is the default. It uses a deterministic canned model reply, so it
+needs **no model server, no GPU, and no network** -- this is also what CI runs:
+
+```bash
+pip install agentguard47
+python examples/local-first-template/agent.py
+agentguard report local_first_template_traces.jsonl
+```
+
+Expected: turn 1 attempts a disallowed tool (denied), turn 2 uses `read_file`,
+turn 3 produces the final answer. The audit log captures all of it.
+
+## Run it against a real local model
+
+Start an OpenAI-compatible server first. Both of these expose
+`POST /v1/chat/completions`:
+
+```bash
+# llama.cpp
+llama-server -m ./model.gguf --port 8080
+
+# or Ollama (default port 11434)
+ollama serve
+```
+
+Then point the example at it:
+
+```bash
+AGENTGUARD_LOCAL_DEMO=live \
+AGENTGUARD_LOCAL_BASE_URL=http://localhost:8080 \
+AGENTGUARD_LOCAL_MODEL=llama3.1:8b \
+python examples/local-first-template/agent.py
+```
+
+The loop is identical in both modes -- only the model call differs.
+
+## Swap models
+
+Everything tunable lives in `config.py`:
+
+- `base_url` / `model` -- which server and model (or set the env vars above).
+- `max_tokens`, `max_calls`, `max_cost_usd`, `warn_at_pct` -- the budget.
+- `max_calls_per_minute` -- the rate limit.
+- `allowed_tools` -- the tool allowlist. Keep it tight.
+
+Any server that speaks the OpenAI chat-completions shape works without code
+changes. On a Mac, an MLX-based server (e.g. `mlx_lm.server`) exposes the same
+endpoint and works the same way -- point `AGENTGUARD_LOCAL_BASE_URL` at it.
+
+## Honest limits
+
+- The offline reply is canned. It exists to make the example testable, not to
+  simulate a real model's reasoning. Run in `live` mode for real behavior.
+- Tool-call parsing here is a simple `TOOL_CALL: name {json}` convention, not a
+  production protocol. Real loops should use the model's native tool/function
+  calling. The AgentGuard wiring -- budget, rate, allowlist, audit -- is the
+  part meant for reuse.
+- Local models still cost electricity and time. The token budget is the real
+  guardrail; the dollar cap is near-zero and only matters if you later swap in
+  a paid model.
+- No GPU is required to run the example. Running a real local model at usable
+  speed usually does need one.

--- a/examples/local-first-template/agent.py
+++ b/examples/local-first-template/agent.py
@@ -1,0 +1,238 @@
+"""Local-first agent template, guarded by AgentGuard.
+
+A hand-rolled agent loop -- no framework -- that calls a *local*
+OpenAI-compatible model server (llama.cpp, Ollama, LM Studio) while AgentGuard
+enforces a budget cap, a rate limit, and a tool allowlist, and writes a JSONL
+audit line for every decision.
+
+Defaults to offline mode (no model server, no GPU, no network) so it runs in
+CI. Set AGENTGUARD_LOCAL_DEMO=live to call a real server. See README.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Allow `python examples/local-first-template/agent.py` from a source checkout
+# without an editable install. A real consumer just `pip install agentguard47`.
+_SDK = Path(__file__).resolve().parents[2] / "sdk"
+if _SDK.is_dir() and str(_SDK) not in sys.path:
+    sys.path.insert(0, str(_SDK))
+
+from agentguard import (  # noqa: E402
+    BudgetExceeded,
+    BudgetGuard,
+    JsonlFileSink,
+    RateLimitGuard,
+    Tracer,
+)
+
+from config import AgentPolicy  # noqa: E402
+
+
+class ToolDenied(RuntimeError):
+    """Raised when the agent tries to call a tool outside the allowlist."""
+
+
+class LocalChatClient:
+    """Minimal client for an OpenAI-compatible local chat endpoint.
+
+    Uses only the standard library -- no `openai`, no `requests`. llama.cpp's
+    `llama-server` and Ollama both serve `POST /v1/chat/completions`.
+
+    In offline mode (`AGENTGUARD_LOCAL_DEMO` != "live") no socket is opened;
+    a deterministic canned reply is returned so the example runs in CI.
+    """
+
+    def __init__(self, policy: AgentPolicy, *, offline: bool) -> None:
+        self._policy = policy
+        self._offline = offline
+
+    def complete(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+        """Return a dict with `content`, `prompt_tokens`, `completion_tokens`."""
+        if self._offline:
+            return self._offline_reply(messages)
+        return self._live_reply(messages)
+
+    def _live_reply(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+        url = self._policy.base_url.rstrip("/") + "/v1/chat/completions"
+        body = json.dumps(
+            {"model": self._policy.model, "messages": messages, "stream": False}
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=body, headers={"Content-Type": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, OSError) as exc:
+            raise RuntimeError(
+                f"Could not reach local model server at {url}. "
+                f"Start llama-server / Ollama first, or run in offline mode. ({exc})"
+            ) from exc
+        choice = payload["choices"][0]["message"]["content"]
+        usage = payload.get("usage", {})
+        return {
+            "content": choice,
+            "prompt_tokens": int(usage.get("prompt_tokens", 0)),
+            "completion_tokens": int(usage.get("completion_tokens", 0)),
+        }
+
+    def _offline_reply(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+        """Deterministic stand-in for a local model. No network.
+
+        Drives the loop through every guard path so the audit log is
+        representative: turn 1 attempts a disallowed tool (allowlist denial),
+        turn 2 uses the allowed tool, turn 3 answers.
+        """
+        last = messages[-1]["content"]
+        if last.startswith("read_file returned:"):
+            content = "The summary is ready; the file describes a local-first agent."
+        elif "not allowed" in last:
+            content = 'TOOL_CALL: read_file {"path": "sample_task.txt"}'
+        else:
+            # First user turn: model hallucinates a tool outside the allowlist.
+            content = 'TOOL_CALL: run_shell {"cmd": "cat /etc/passwd"}'
+        approx_tokens = max(1, len(last) // 4)
+        return {
+            "content": content,
+            "prompt_tokens": approx_tokens,
+            "completion_tokens": max(1, len(content) // 4),
+        }
+
+
+def read_file_tool(path: str, *, base_dir: Path) -> str:
+    """The one allowed tool: read a text file under base_dir."""
+    target = (base_dir / path).resolve()
+    if base_dir.resolve() not in target.parents and target != base_dir.resolve():
+        raise ToolDenied(f"read_file refused path outside base dir: {path}")
+    return target.read_text(encoding="utf-8")
+
+
+def parse_tool_call(content: str) -> Dict[str, Any] | None:
+    """Parse a `TOOL_CALL: name {json-args}` line, or return None."""
+    if not content.startswith("TOOL_CALL:"):
+        return None
+    rest = content[len("TOOL_CALL:") :].strip()
+    name, _, raw_args = rest.partition(" ")
+    try:
+        args = json.loads(raw_args) if raw_args else {}
+    except json.JSONDecodeError:
+        args = {}
+    return {"name": name, "args": args}
+
+
+def run_agent(policy: AgentPolicy, *, offline: bool, base_dir: Path) -> int:
+    """Run the guarded local agent loop. Returns a process exit code."""
+    sink = JsonlFileSink(policy.audit_log_path)
+    tracer = Tracer(sink=sink, service="local-first-template")
+
+    budget = BudgetGuard(
+        max_tokens=policy.max_tokens,
+        max_calls=policy.max_calls,
+        max_cost_usd=policy.max_cost_usd,
+        warn_at_pct=policy.warn_at_pct,
+        on_warning=lambda msg: print(f"  [budget warning] {msg}"),
+    )
+    rate = RateLimitGuard(max_calls_per_minute=policy.max_calls_per_minute)
+    client = LocalChatClient(policy, offline=offline)
+
+    print(f"Model server : {policy.base_url} (offline={offline})")
+    print(f"Budget       : {policy.max_tokens} tokens / {policy.max_calls} calls")
+    print(f"Rate limit   : {policy.max_calls_per_minute}/min")
+    print(f"Allowed tools: {', '.join(policy.allowed_tools)}")
+    print(f"Audit log    : {policy.audit_log_path}")
+    print("-" * 60)
+
+    messages: List[Dict[str, str]] = [
+        {"role": "system", "content": "You are a local agent. Use tools when needed."},
+        {"role": "user", "content": "Please summarize the local task file."},
+    ]
+    for turn in range(1, policy.max_calls + 2):
+        try:
+            with tracer.trace(f"agent.turn.{turn}") as ctx:
+                # Rate check before every model call.
+                rate.check()
+                ctx.event("guard.rate_check", data={"turn": turn, "ok": True})
+
+                reply = client.complete(messages)
+                tokens = reply["prompt_tokens"] + reply["completion_tokens"]
+                budget.consume(tokens=tokens, calls=1, cost_usd=0.0)
+                ctx.event(
+                    "llm.call",
+                    data={
+                        "turn": turn,
+                        "tokens": tokens,
+                        "tokens_used": budget.state.tokens_used,
+                        "content": reply["content"][:120],
+                    },
+                )
+                print(
+                    f"  [{turn}] tokens={tokens} "
+                    f"total={budget.state.tokens_used}/{policy.max_tokens}  "
+                    f"{reply['content'][:60]}"
+                )
+
+                call = parse_tool_call(reply["content"])
+                if call is None:
+                    ctx.event("agent.final", data={"answer": reply["content"][:120]})
+                    print(f"\nFinal answer: {reply['content']}")
+                    break
+
+                # --- Tool allowlist enforcement ---
+                if call["name"] not in policy.allowed_tools:
+                    ctx.event(
+                        "guard.tool_denied",
+                        data={"tool": call["name"], "args": call["args"]},
+                    )
+                    print(f"  [tool DENIED] '{call['name']}' not in allowlist")
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                f"Tool '{call['name']}' is not allowed. "
+                                f"Answer directly instead."
+                            ),
+                        }
+                    )
+                    continue
+
+                with ctx.span(f"tool.{call['name']}") as tool_ctx:
+                    tool_ctx.event("tool.call", data={"tool": call["name"], "args": call["args"]})
+                    result = read_file_tool(
+                        call["args"].get("path", ""), base_dir=base_dir
+                    )
+                    tool_ctx.event("tool.result", data={"chars": len(result)})
+                messages.append(
+                    {"role": "user", "content": f"read_file returned: {result}"}
+                )
+        except BudgetExceeded as exc:
+            print(f"\n  [budget STOP] {exc}")
+            break
+    else:
+        print("\n  Loop hit max_calls without a final answer.")
+
+    print("-" * 60)
+    print(
+        f"Done. {budget.state.calls_used} calls, "
+        f"{budget.state.tokens_used} tokens. Audit log: {policy.audit_log_path}"
+    )
+    print("View it:  agentguard report " + policy.audit_log_path)
+    return 0
+
+
+def main() -> int:
+    offline = os.environ.get("AGENTGUARD_LOCAL_DEMO", "offline").lower() != "live"
+    policy = AgentPolicy.from_env()
+    base_dir = Path(__file__).resolve().parent
+    return run_agent(policy, offline=offline, base_dir=base_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/local-first-template/agent.py
+++ b/examples/local-first-template/agent.py
@@ -16,8 +16,9 @@ import os
 import sys
 import urllib.error
 import urllib.request
+import warnings
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 # Allow `python examples/local-first-template/agent.py` from a source checkout
 # without an editable install. A real consumer just `pip install agentguard47`.
@@ -31,6 +32,7 @@ from agentguard import (  # noqa: E402
     JsonlFileSink,
     RateLimitGuard,
     Tracer,
+    estimate_cost,
 )
 
 from config import AgentPolicy  # noqa: E402
@@ -77,11 +79,20 @@ class LocalChatClient:
                 f"Start llama-server / Ollama first, or run in offline mode. ({exc})"
             ) from exc
         choice = payload["choices"][0]["message"]["content"]
-        usage = payload.get("usage", {})
+        usage = payload.get("usage") or {}
+        # Some local servers omit `usage`. Falling back to 0 would silently
+        # disable the token budget, so estimate from text length (~4 chars
+        # per token) when the server does not report counts.
+        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        completion_tokens = int(usage.get("completion_tokens") or 0)
+        if prompt_tokens == 0:
+            prompt_tokens = max(1, sum(len(m["content"]) for m in messages) // 4)
+        if completion_tokens == 0:
+            completion_tokens = max(1, len(choice) // 4)
         return {
             "content": choice,
-            "prompt_tokens": int(usage.get("prompt_tokens", 0)),
-            "completion_tokens": int(usage.get("completion_tokens", 0)),
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
         }
 
     def _offline_reply(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
@@ -109,23 +120,35 @@ class LocalChatClient:
 
 def read_file_tool(path: str, *, base_dir: Path) -> str:
     """The one allowed tool: read a text file under base_dir."""
+    if not path:
+        raise ToolDenied("read_file requires a non-empty 'path' argument")
     target = (base_dir / path).resolve()
     if base_dir.resolve() not in target.parents and target != base_dir.resolve():
         raise ToolDenied(f"read_file refused path outside base dir: {path}")
+    if not target.is_file():
+        raise ToolDenied(f"read_file: not a readable file: {path}")
     return target.read_text(encoding="utf-8")
 
 
-def parse_tool_call(content: str) -> Dict[str, Any] | None:
-    """Parse a `TOOL_CALL: name {json-args}` line, or return None."""
+def parse_tool_call(content: str) -> Optional[Dict[str, Any]]:
+    """Parse a `TOOL_CALL: name {json-args}` line.
+
+    Returns None if the content is not a tool call. For a tool call with
+    malformed JSON args, returns the call with ``"valid_args": False`` so the
+    loop can treat it as a failed call instead of crashing on empty args.
+    """
     if not content.startswith("TOOL_CALL:"):
         return None
     rest = content[len("TOOL_CALL:") :].strip()
     name, _, raw_args = rest.partition(" ")
+    valid_args = True
     try:
         args = json.loads(raw_args) if raw_args else {}
+        if not isinstance(args, dict):
+            args, valid_args = {}, False
     except json.JSONDecodeError:
-        args = {}
-    return {"name": name, "args": args}
+        args, valid_args = {}, False
+    return {"name": name, "args": args, "valid_args": valid_args}
 
 
 def run_agent(policy: AgentPolicy, *, offline: bool, base_dir: Path) -> int:
@@ -163,13 +186,25 @@ def run_agent(policy: AgentPolicy, *, offline: bool, base_dir: Path) -> int:
 
                 reply = client.complete(messages)
                 tokens = reply["prompt_tokens"] + reply["completion_tokens"]
-                budget.consume(tokens=tokens, calls=1, cost_usd=0.0)
+                # estimate_cost is ~0 for an unknown local model, but real if
+                # the user points the template at a paid OpenAI-compatible
+                # endpoint -- so the dollar budget actually enforces there.
+                # A local model name is unpriced; suppress that expected warning.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    cost = estimate_cost(
+                        policy.model,
+                        input_tokens=reply["prompt_tokens"],
+                        output_tokens=reply["completion_tokens"],
+                    )
+                budget.consume(tokens=tokens, calls=1, cost_usd=cost)
                 ctx.event(
                     "llm.call",
                     data={
                         "turn": turn,
                         "tokens": tokens,
                         "tokens_used": budget.state.tokens_used,
+                        "cost_usd": cost,
                         "content": reply["content"][:120],
                     },
                 )
@@ -203,17 +238,46 @@ def run_agent(policy: AgentPolicy, *, offline: bool, base_dir: Path) -> int:
                     )
                     continue
 
+                # Malformed tool args: treat as a failed call, do not crash.
+                if not call["valid_args"]:
+                    ctx.event(
+                        "guard.tool_failed",
+                        data={"tool": call["name"], "reason": "malformed args"},
+                    )
+                    print(f"  [tool FAILED] '{call['name']}' had malformed args")
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": f"Tool '{call['name']}' args were invalid. "
+                            f"Answer directly instead.",
+                        }
+                    )
+                    continue
+
                 with ctx.span(f"tool.{call['name']}") as tool_ctx:
                     tool_ctx.event("tool.call", data={"tool": call["name"], "args": call["args"]})
-                    result = read_file_tool(
-                        call["args"].get("path", ""), base_dir=base_dir
-                    )
+                    try:
+                        result = read_file_tool(
+                            call["args"].get("path", ""), base_dir=base_dir
+                        )
+                    except ToolDenied as exc:
+                        tool_ctx.event("guard.tool_failed", data={"reason": str(exc)})
+                        print(f"  [tool FAILED] {exc}")
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": f"read_file failed: {exc}. Answer directly.",
+                            }
+                        )
+                        continue
                     tool_ctx.event("tool.result", data={"chars": len(result)})
                 messages.append(
                     {"role": "user", "content": f"read_file returned: {result}"}
                 )
         except BudgetExceeded as exc:
-            print(f"\n  [budget STOP] {exc}")
+            # RateLimitGuard and BudgetGuard both raise BudgetExceeded; use a
+            # neutral label since either guard could be the stop reason.
+            print(f"\n  [guard STOP] {exc}")
             break
     else:
         print("\n  Loop hit max_calls without a final answer.")

--- a/examples/local-first-template/config.py
+++ b/examples/local-first-template/config.py
@@ -1,0 +1,61 @@
+"""Policy configuration for the local-first agent template.
+
+One place to set every AgentGuard knob the example uses: budget caps, the
+rate limit, the tool allowlist, and where the JSONL audit log is written.
+
+Copy this file into your own project and adjust the numbers. Nothing here
+talks to a hosted service -- the local-first template runs against a model
+server on your own machine.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(frozen=True)
+class AgentPolicy:
+    """Everything the agent loop is allowed to do, in one object."""
+
+    # --- Model server ---
+    # llama.cpp (`llama-server`) and Ollama both expose an OpenAI-compatible
+    # chat endpoint. Point base_url at yours; the path is appended by the loop.
+    base_url: str = "http://localhost:8080"
+    model: str = "local-model"
+
+    # --- Budget ---
+    # Token cap is the real guardrail for a local model (electricity, not API
+    # dollars). max_calls stops a runaway loop. The cost cap is near-zero so
+    # the BudgetGuard cost field still has meaning if you swap in a paid model.
+    max_tokens: int = 4_000
+    max_calls: int = 12
+    max_cost_usd: float = 0.50
+    warn_at_pct: float = 0.8
+
+    # --- Rate limit ---
+    # Sliding-window cap. A local 8B model on consumer hardware does not love
+    # being hammered; this also protects a shared dev box.
+    max_calls_per_minute: int = 30
+
+    # --- Tool allowlist ---
+    # The agent may only call tools named here. Anything else is denied and
+    # logged. Keep this tight: it is the difference between a helpful agent
+    # and one that runs `rm -rf` because the model hallucinated a tool.
+    allowed_tools: List[str] = field(default_factory=lambda: ["read_file"])
+
+    # --- Audit log ---
+    audit_log_path: str = "local_first_template_traces.jsonl"
+
+    @classmethod
+    def from_env(cls) -> "AgentPolicy":
+        """Build a policy, letting env vars override the model-server fields.
+
+        AGENTGUARD_LOCAL_BASE_URL and AGENTGUARD_LOCAL_MODEL let you point the
+        same example at a real server without editing code.
+        """
+        return cls(
+            base_url=os.environ.get("AGENTGUARD_LOCAL_BASE_URL", cls.base_url),
+            model=os.environ.get("AGENTGUARD_LOCAL_MODEL", cls.model),
+        )

--- a/examples/local-first-template/config.py
+++ b/examples/local-first-template/config.py
@@ -11,8 +11,8 @@ server on your own machine.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
-from typing import List
+from dataclasses import dataclass
+from typing import Tuple
 
 
 @dataclass(frozen=True)
@@ -43,7 +43,8 @@ class AgentPolicy:
     # The agent may only call tools named here. Anything else is denied and
     # logged. Keep this tight: it is the difference between a helpful agent
     # and one that runs `rm -rf` because the model hallucinated a tool.
-    allowed_tools: List[str] = field(default_factory=lambda: ["read_file"])
+    # A tuple so a frozen policy is genuinely immutable -- no in-place append.
+    allowed_tools: Tuple[str, ...] = ("read_file",)
 
     # --- Audit log ---
     audit_log_path: str = "local_first_template_traces.jsonl"

--- a/examples/local-first-template/sample_task.txt
+++ b/examples/local-first-template/sample_task.txt
@@ -1,0 +1,7 @@
+Local-first agents run their model on hardware you own.
+
+No API key, no per-token bill, no data leaving the machine. The trade-off is
+that nothing external stops a runaway loop -- so the budget cap, rate limit,
+and tool allowlist have to live in your own code. That is what AgentGuard
+provides here: a token/call budget, a sliding-window rate limit, a tool
+allowlist, and a JSONL audit log of every decision the loop made.

--- a/sdk/tests/test_local_first_template.py
+++ b/sdk/tests/test_local_first_template.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_DIR = REPO_ROOT / "examples" / "local-first-template"
@@ -115,3 +116,53 @@ def test_helpers_handle_bad_input_without_crashing() -> None:
         raise AssertionError("traversal should be refused")
     except ToolDenied:
         pass
+
+
+def test_live_reply_estimates_tokens_when_usage_is_missing() -> None:
+    """Live mode must still feed BudgetGuard when local servers omit usage."""
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        from agent import LocalChatClient
+        from config import AgentPolicy
+    finally:
+        sys.path.pop(0)
+
+    class _FakeResponse:
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "choices": [
+                        {"message": {"content": "Local server reply without usage"}}
+                    ]
+                }
+            ).encode("utf-8")
+
+    client = LocalChatClient(AgentPolicy(), offline=False)
+    messages = [{"role": "user", "content": "Summarize this local task"}]
+
+    with patch("agent.urllib.request.urlopen", return_value=_FakeResponse()):
+        reply = client.complete(messages)
+
+    assert reply["content"] == "Local server reply without usage"
+    assert reply["prompt_tokens"] == max(1, len(messages[0]["content"]) // 4)
+    assert reply["completion_tokens"] == max(1, len(reply["content"]) // 4)
+
+
+def test_policy_allowlist_is_tuple_backed() -> None:
+    """A frozen policy should not expose a mutable tool allowlist."""
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        from config import AgentPolicy
+    finally:
+        sys.path.pop(0)
+
+    policy = AgentPolicy()
+
+    assert isinstance(policy.allowed_tools, tuple)
+    assert policy.allowed_tools == ("read_file",)

--- a/sdk/tests/test_local_first_template.py
+++ b/sdk/tests/test_local_first_template.py
@@ -1,0 +1,90 @@
+"""Smoke test for examples/local-first-template/.
+
+Runs the example offline (no model server, no GPU, no network) and asserts
+the AgentGuard wiring -- budget, rate limit, tool allowlist, JSONL audit log
+-- does not drift. Mirrors the subprocess pattern in test_example_starters.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "local-first-template"
+AGENT_PATH = EXAMPLE_DIR / "agent.py"
+
+
+def _env() -> dict:
+    env = os.environ.copy()
+    sdk_path = str(REPO_ROOT / "sdk")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        sdk_path if not existing else os.pathsep.join([sdk_path, existing])
+    )
+    # Default is offline; set it explicitly so the test is unambiguous.
+    env["AGENTGUARD_LOCAL_DEMO"] = "offline"
+    return env
+
+
+def test_example_files_exist_and_compile() -> None:
+    for name in ("agent.py", "config.py"):
+        path = EXAMPLE_DIR / name
+        assert path.exists(), f"Missing example file: {path}"
+        compile(path.read_text(encoding="utf-8"), str(path), "exec")
+    assert (EXAMPLE_DIR / "README.md").exists()
+    assert (EXAMPLE_DIR / "sample_task.txt").exists()
+
+
+def test_agent_runs_offline_and_audits_every_guard() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            result = subprocess.run(
+                [sys.executable, str(AGENT_PATH)],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                env=_env(),
+                check=False,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise AssertionError(
+                "local-first agent timed out.\n"
+                f"STDOUT:\n{exc.stdout or ''}\nSTDERR:\n{exc.stderr or ''}"
+            ) from exc
+
+        assert result.returncode == 0, result.stderr
+        # Core loop wiring is visible in stdout.
+        assert "offline=True" in result.stdout
+        assert "tool DENIED" in result.stdout
+        assert "Final answer:" in result.stdout
+
+        trace_path = Path(tmpdir, "local_first_template_traces.jsonl")
+        assert trace_path.exists(), "audit JSONL was not written"
+
+        names = []
+        with trace_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    names.append(json.loads(line).get("name"))
+
+        # Every guard/loop path the example claims must appear in the log.
+        assert "guard.rate_check" in names
+        assert "guard.tool_denied" in names
+        assert "llm.call" in names
+        assert "tool.call" in names
+        assert "agent.final" in names
+
+
+def test_agent_makes_no_network_call_in_offline_mode() -> None:
+    """Offline mode must never open a socket -- CI has no model server."""
+    source = AGENT_PATH.read_text(encoding="utf-8")
+    # The live path is the only urlopen; it is gated behind the offline flag.
+    assert "_live_reply" in source
+    assert "_offline_reply" in source
+    assert 'os.environ.get("AGENTGUARD_LOCAL_DEMO"' in source

--- a/sdk/tests/test_local_first_template.py
+++ b/sdk/tests/test_local_first_template.py
@@ -88,3 +88,30 @@ def test_agent_makes_no_network_call_in_offline_mode() -> None:
     assert "_live_reply" in source
     assert "_offline_reply" in source
     assert 'os.environ.get("AGENTGUARD_LOCAL_DEMO"' in source
+
+
+def test_helpers_handle_bad_input_without_crashing() -> None:
+    """parse_tool_call and read_file_tool degrade gracefully on bad input."""
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        from agent import ToolDenied, parse_tool_call, read_file_tool
+    finally:
+        sys.path.pop(0)
+
+    # Not a tool call -> None.
+    assert parse_tool_call("just an answer") is None
+    # Malformed JSON args -> flagged invalid, not a crash.
+    bad = parse_tool_call("TOOL_CALL: read_file {bad json")
+    assert bad is not None and bad["valid_args"] is False
+    # Empty path is refused, not read as a directory.
+    try:
+        read_file_tool("", base_dir=EXAMPLE_DIR)
+        raise AssertionError("empty path should be refused")
+    except ToolDenied:
+        pass
+    # Path traversal is refused.
+    try:
+        read_file_tool("../../../etc/passwd", base_dir=EXAMPLE_DIR)
+        raise AssertionError("traversal should be refused")
+    except ToolDenied:
+        pass


### PR DESCRIPTION
## Summary
- Adds `examples/local-first-template/` — a framework-free agent loop that calls a **local** OpenAI-compatible model server (llama.cpp `llama-server`, Ollama, LM Studio) while AgentGuard enforces a budget cap, a rate limit, and a tool allowlist.
- Every model call, tool call, and guard decision is written to a JSONL audit log via `JsonlFileSink`.
- Defaults to **offline mode** (canned model reply) so it runs in CI with no model server, no GPU, and no network. Set `AGENTGUARD_LOCAL_DEMO=live` to point at a real server.

**New-repo decision:** the originating task considered a standalone `agentguard-local-template` repo. Per the processed decision request, this was narrowed to an **in-repo example** — no new repository, package, dependency, or service.

## Test plan
- [x] `python examples/local-first-template/agent.py` runs offline, exits 0, no network
- [x] Output shows budget tracking, a rate-limit check, and a tool-allowlist denial
- [x] JSONL audit log contains `guard.rate_check`, `guard.tool_denied`, `llm.call`, `tool.call`, `agent.final`
- [x] `sdk/tests/test_local_first_template.py` — 3 tests pass (0.30s), no GPU
- [x] No regression: `test_example_starters.py` + `test_architecture.py` (18) still pass
- [x] `ruff check` clean

## Artifacts
WORK_PLAN, RESEARCH, and QA_REPORT were produced by the queue worker; QA verdict was ✅ (no secrets, no denylist paths, no coverage regression). Available on request.

## Risk
Low. Additive only — one new example directory, one new test, one table row in `examples/README.md`. No production code, no dependencies, no denylist paths touched.
