### PR TITLE
Make coding-agent review loop proof deterministic

### DIFF
--- a/examples/coding_agent_review_loop.py
+++ b/examples/coding_agent_review_loop.py
@@ -10,6 +10,8 @@ No API keys, dashboard, or network calls are required.
 """
 from __future__ import annotations
 
+import os
+
 from agentguard import (
     BudgetExceeded,
     BudgetGuard,
@@ -122,6 +124,9 @@ def _run_retry_storm(tracer: Tracer) -> None:
 
 
 def main() -> int:
+    if os.path.exists(TRACE_FILE):
+        os.remove(TRACE_FILE)
+
     tracer = Tracer(
         sink=JsonlFileSink(TRACE_FILE),
         service="coding-agent-review-loop",

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -230,6 +230,43 @@ def test_coding_agent_review_loop_example_runs_offline() -> None:
         assert "guard.retry_limit_exceeded" in names
 
 
+def test_coding_agent_review_loop_example_resets_trace_on_rerun() -> None:
+    example_path = REPO_ROOT / "examples" / "coding_agent_review_loop.py"
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    sdk_path = str(REPO_ROOT / "sdk")
+    env["PYTHONPATH"] = (
+        sdk_path
+        if not existing_pythonpath
+        else os.pathsep.join([sdk_path, existing_pythonpath])
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for _ in range(2):
+            result = subprocess.run(
+                [sys.executable, str(example_path)],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+                timeout=60,
+            )
+            assert result.returncode == 0, result.stderr
+
+        trace_path = Path(tmpdir, "coding_agent_review_loop_traces.jsonl")
+        names = []
+        with trace_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    names.append(json.loads(line)["name"])
+
+        assert names.count("guard.budget_exceeded") == 1
+        assert names.count("guard.retry_limit_exceeded") == 1
+        assert names.count("review.iteration") == 3
+        assert names.count("tool.retry") == 4
+
+
 def test_coding_agent_review_loop_sample_incident_is_in_sync() -> None:
     example_path = REPO_ROOT / "examples" / "coding_agent_review_loop.py"
     sample_path = REPO_ROOT / "docs" / "examples" / "coding-agent-review-loop-incident.md"

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -263,6 +263,43 @@ def test_coding_agent_review_loop_sample_incident_is_in_sync() -> None:
         assert _normalize_incident_snapshot(actual) == expected
 
 
+def test_coding_agent_review_loop_reruns_do_not_append_stale_trace_events() -> None:
+    example_path = REPO_ROOT / "examples" / "coding_agent_review_loop.py"
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    sdk_path = str(REPO_ROOT / "sdk")
+    env["PYTHONPATH"] = (
+        sdk_path
+        if not existing_pythonpath
+        else os.pathsep.join([sdk_path, existing_pythonpath])
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for _ in range(2):
+            result = subprocess.run(
+                [sys.executable, str(example_path)],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+                timeout=60,
+            )
+            assert result.returncode == 0, result.stderr
+
+        trace_path = Path(tmpdir, "coding_agent_review_loop_traces.jsonl")
+        counts: dict[str, int] = {}
+        with trace_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                name = json.loads(line)["name"]
+                counts[name] = counts.get(name, 0) + 1
+
+        assert counts.get("guard.budget_exceeded") == 1
+        assert counts.get("guard.retry_limit_exceeded") == 1
+
+
 def test_proof_gallery_demo_references_stay_valid() -> None:
     source = PROOF_GALLERY_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
﻿## Summary
- clear the coding-agent review-loop trace before each example run
- add regression coverage proving reruns do not append stale guard events
- keep the dogfood incident report aligned to a single proof run

## Validation
- `python -m pytest sdk/tests/test_example_starters.py -q`
- `python examples/coding_agent_review_loop.py`
- `python examples/coding_agent_review_loop.py`
- `python -m agentguard.cli incident coding_agent_review_loop_traces.jsonl`
- `rg -n "guard\.(budget_exceeded|retry_limit_exceeded)" coding_agent_review_loop_traces.jsonl`
