### PR TITLE
docs: refresh ARCHITECTURE.md to match current repo layout

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## 1. System Overview
 
-AgentGuard is the public SDK wedge in the BMD PAT LLC portfolio: a zero-dependency Python runtime-safety SDK plus a small TypeScript MCP server and static public site. This repo exists to make coding-agent safety easy to adopt, easy to trust, and easy to prove locally. The hosted dashboard/control plane is a separate private repo; this repo's job is to ship the free MIT SDK, the MCP bridge, and the public docs/examples that drive distribution.
+AgentGuard is the public SDK wedge in the BMD PAT LLC portfolio: a zero-dependency Python runtime-safety SDK (`agentguard47`), two MCP server surfaces, and a static public site. This repo exists to make coding-agent safety easy to adopt, easy to trust, and easy to prove locally. The hosted dashboard/control plane is a separate private repo; this repo's job is to ship the free MIT SDK, the MCP bridges, and the public docs/examples that drive distribution.
 
 ## 2. Core Principles
 
@@ -14,21 +14,37 @@ AgentGuard is the public SDK wedge in the BMD PAT LLC portfolio: a zero-dependen
 
 ## 3. Directory Map
 
-- [`sdk/`](sdk/): Python package source, tests, packaging metadata, and generated PyPI README snapshot.
-- [`sdk/agentguard/`](sdk/agentguard/): core SDK modules, CLI helpers, integrations, and sinks.
+### Python SDK
+- [`sdk/`](sdk/): Python package source, tests, packaging metadata (`pyproject.toml`), the generated PyPI README snapshot ([`sdk/PYPI_README.md`](sdk/PYPI_README.md)), and `sdk/examples/`.
+- [`sdk/agentguard/`](sdk/agentguard/): core SDK modules. Highlights:
+  - `tracing.py` / `atracing.py`: `Tracer` / `AsyncTracer`, `TraceContext` / `AsyncTraceContext`, plus the core `JsonlFileSink`, `StdoutSink`, and `TraceSink` base.
+  - `guards.py`: the guard family and their exceptions.
+  - `setup.py`: `init()` / `get_tracer()` / `get_budget_guard()` / `shutdown()` convenience entrypoints.
+  - `instrument.py`, `decision.py`, `evaluation.py`, `cost.py`, `usage.py`, `savings.py`, `escalation.py`, `schemas.py`, `profiles.py`, `repo_config.py`, `reporting.py`, `export.py`: instrumentation, decision tracing, eval, cost/usage accounting, and report surfaces.
+  - `cli.py`, `doctor.py`, `demo.py`, `quickstart.py`, `skillpack.py`: the CLI and local proof surfaces.
+  - [`sdk/agentguard/integrations/`](sdk/agentguard/integrations/): optional, guarded-import framework adapters (`crewai.py`, `langchain.py`, `langgraph.py`).
+  - [`sdk/agentguard/sinks/`](sdk/agentguard/sinks/): non-core sinks (`http.py` -> `HttpSink`, `otel.py` -> `OtelTraceSink`).
 - [`sdk/tests/`](sdk/tests/): behavioral, structural, hardening, DX, and integration-style tests for the SDK.
-- [`mcp-server/`](mcp-server/): published read-only MCP server that exposes AgentGuard traces, decision events, alerts, usage, and cost data through MCP.
-- [`examples/`](examples/): runnable local examples, checked-in starter files, notebooks, and proof-oriented onboarding paths.
-- [`docs/`](docs/): public guides for getting started, coding-agent onboarding, smoke tests, incident/report flows, and decision/session patterns.
-- [`site/`](site/): static public landing/docs pages that describe the public SDK surface only; not the source of truth for private dashboard behavior.
-- [`memory/`](memory/): SDK-only ground truth for current state, blockers, decisions, and distribution priorities.
-- [`ops/`](ops/): operating docs, north star, roadmap, definition of done, and secondary architecture notes.
+
+### MCP servers (two distinct surfaces)
+- [`mcp-server/`](mcp-server/): the published **read-only** TypeScript MCP server (`@agentguard47/mcp-server`). Exposes AgentGuard traces, decision events, alerts, usage, cost, and budget health from the hosted dashboard to MCP clients.
+- [`agentguard-mcp/`](agentguard-mcp/): a newer **local-budget** Python MCP server (`agentguard_mcp`). Lets MCP clients record tool calls and enforce per-tool / per-server / per-session / per-day budgets. State lives in local SQLite (`~/.agentguard/state.db`); no account, no telemetry unless `AGENTGUARD_SYNC_URL` is opted into. Modules: `server.py`, `storage.py`, `sync.py`, `__main__.py`. Not yet published to PyPI/npm.
+- [`npm/`](npm/): `npm/agentguard-mcp/` is a thin npm shim that lets `npx`/Node users launch the Python `agentguard-mcp` server.
+
+### Distribution, docs, and tooling
+- [`skills/`](skills/): distributable agent skill packs. `skills/agentguard/SKILL.md` is the AgentGuard skill, also surfaced through the SDK `skillpack` CLI command.
+- [`examples/`](examples/): runnable local examples, checked-in starter files, notebooks, and proof-oriented onboarding paths (plus `examples/agentguard-mcp/`).
+- [`docs/`](docs/): public guides, integration docs, cookbooks, incident/report flows, and community/launch material.
+- [`site/`](site/): static public landing/docs pages describing the public SDK surface only; not the source of truth for private dashboard behavior.
+- [`memory/`](memory/): SDK-only ground truth for current state, blockers, decisions, and distribution priorities. Per `CLAUDE.md`, `memory/` wins over older repo docs on conflict.
+- [`ops/`](ops/): operating docs — north star, SDK scope, roadmap, definition of done, and a secondary architecture note (`ops/02-ARCHITECTURE.md`).
 - [`scripts/`](scripts/): release guards, preflight logic, generated-readme tooling, and maintenance automation.
 - [`proof/`](proof/): saved artifacts that demonstrate local proof for specific PRs or flows.
-- [`inbox/`](inbox/): short SDK-only cofounder handoff log after merged PRs.
+- [`inbox/`](inbox/): short SDK-only cofounder handoff log appended after merged PRs.
 
 ## 4. Data Flow
 
+### Runtime SDK path (`agentguard47`)
 ```mermaid
 flowchart TD
     U["User code or coding agent"] --> S["agentguard.init() / Tracer / AsyncTracer"]
@@ -37,19 +53,31 @@ flowchart TD
     G -->|allowed| T["TraceContext emits JSON-safe span/event records"]
     T --> L["Local sinks: JsonlFileSink / StdoutSink"]
     T --> H["HttpSink to private dashboard ingest"]
-    L --> R["CLI proof surfaces: doctor / demo / report / incident / decisions / eval"]
+    T --> O["OtelTraceSink to OpenTelemetry collectors"]
+    L --> R["CLI proof surfaces: doctor / demo / quickstart / report / incident / decisions / eval / summarize / skillpack"]
     H --> D["Private dashboard repo and hosted API"]
-    D --> M["MCP server reads hosted traces, decisions, alerts, usage, costs, and budget health"]
-    M --> C["Codex / Claude Code / Cursor / other MCP clients"]
 ```
+
+### MCP surfaces
+```mermaid
+flowchart TD
+    D["Private dashboard repo and hosted API"] --> M1["mcp-server/ (TypeScript, read-only)\nreads hosted traces, decisions, alerts, usage, costs, budget health"]
+    M1 --> C1["Codex / Claude Code / Cursor / other MCP clients"]
+    C2["MCP-compatible tools"] --> M2["agentguard-mcp/ (Python, local budgets)\nrecords tool calls, enforces per-tool/server/session/day budgets"]
+    M2 --> SQL["Local SQLite state (~/.agentguard/state.db)"]
+    N["npm/agentguard-mcp shim"] -.launches.-> M2
+```
+
+The two MCP servers are independent: `mcp-server/` is a read-only window onto hosted data; `agentguard-mcp/` is a local-first enforcement server with no hosted dependency.
 
 ## 5. Key Abstractions
 
 - `Tracer` / `AsyncTracer`: the runtime event spine. They create traces, propagate span context, run guards on events, and emit records into sinks.
 - `TraceContext` / `AsyncTraceContext`: the scoped unit of work inside a trace. Most runtime instrumentation, decision tracing, and examples build on these.
-- Guards: `LoopGuard`, `FuzzyLoopGuard`, `BudgetGuard`, `TimeoutGuard`, `RateLimitGuard`, and `RetryGuard`. Guards raise exceptions instead of returning booleans.
-- Sinks: `JsonlFileSink`, `StdoutSink`, `HttpSink`, and `OtelTraceSink`. This is the boundary between runtime evidence and its destination.
-- Local proof surfaces: `doctor`, `demo`, `quickstart`, checked-in starters, `report`, `incident`, `decisions`, and `EvalSuite`. These are part of the product, not just internal tooling.
+- Guards (`guards.py`): `LoopGuard`, `FuzzyLoopGuard`, `BudgetGuard`, `TimeoutGuard`, `RateLimitGuard`, `RetryGuard`. Guards raise exceptions (`LoopDetected`, `BudgetExceeded`, `BudgetWarning`, `TimeoutExceeded`, `RetryLimitExceeded`, all under `AgentGuardError`) instead of returning booleans.
+- Sinks: `JsonlFileSink` and `StdoutSink` (core, in `tracing.py`); `HttpSink` and `OtelTraceSink` (non-core, in `sinks/`). The `TraceSink` base is the boundary between runtime evidence and its destination.
+- Local proof surfaces: the `agentguard` CLI subcommands `doctor`, `demo`, `quickstart`, `report`, `incident`, `decisions`, `eval`, `summarize`, and `skillpack`, plus `EvalSuite` and checked-in starters. These are part of the product, not just internal tooling.
+- MCP surfaces: the read-only TypeScript `mcp-server/` and the local-budget Python `agentguard-mcp/` are first-class adoption surfaces alongside the SDK.
 
 ## 6. Boundaries
 
@@ -63,7 +91,7 @@ flowchart TD
 
 1. Does the change respect zero-dependency core rules and one-way import direction?
 2. Is it clearly inside the public SDK/MCP/site boundary, or is it actually dashboard work?
-3. Which layer does it belong in: core SDK, optional integration, CLI/proof surface, MCP server, docs/examples, or release tooling?
+3. Which layer does it belong in: core SDK, optional integration, sink, CLI/proof surface, the read-only `mcp-server/`, the local `agentguard-mcp/`, docs/examples, skill pack, or release tooling?
 4. Can it reuse existing patterns like `TraceSink`, guard exceptions, repo-local `.agentguard.json`, or CLI proof flows instead of inventing a parallel path?
 5. What proof is required?
    - SDK code: targeted tests plus `sdk_preflight.py`
@@ -73,12 +101,14 @@ flowchart TD
 
 ## 8. Known Technical Debt
 
-- Architecture knowledge is currently split between this new root doc and [`ops/02-ARCHITECTURE.md`](ops/02-ARCHITECTURE.md). They are close, but duplication can drift if only one gets updated.
+- Architecture knowledge is still split between this root doc and [`ops/02-ARCHITECTURE.md`](ops/02-ARCHITECTURE.md). They can drift if only one gets updated; treat this root doc as the law.
 - The public repo still contains [`site/`](site/), which creates recurring boundary confusion because the private dashboard repo also owns hosted product surfaces.
+- Two MCP packages now coexist (`mcp-server/` TypeScript read-only, `agentguard-mcp/` Python local-budget) plus the `npm/` shim. Their naming overlaps and release/distribution story still needs consolidating; `agentguard-mcp` is not yet published.
 - Some tests still intentionally import private tracing helpers for hardening coverage, so internal refactors need compatibility shims or test cleanup rather than assuming internals are free to disappear.
-- The MCP server is a separate package with its own tool/runtime contract, but release and architecture understanding still skews heavily toward the Python SDK.
+- Generated/scratch artifacts (`output/`, root-level `*.jsonl` trace files) accumulate at the repo root and are easy to mistake for first-class modules.
 - Local PR proof is strong, but some supporting repo tooling around GitHub review/check inspection is fragile on Windows shells and depends on manual `gh` fallbacks.
 
 ## 9. Change Log
 
 - 2026-04-09: Created root `ARCHITECTURE.md` as the repo-level architecture law for future nightshift and PR work.
+- 2026-05-17: Refreshed directory map, data flow, and abstractions to match the repo as of 2026-05-17 — added the Python `agentguard-mcp/` local-budget server, the `npm/` shim, and `skills/`; documented the two distinct MCP surfaces and the current `sdk/agentguard/` module layout.


### PR DESCRIPTION
## Summary
- `ARCHITECTURE.md` was last updated 2026-04-09 with ~86 commits since; the directory map and data flow no longer matched the repo.
- Refreshed the directory map, data flow, key abstractions, and tech-debt sections to describe the repo as of 2026-05-17.
- Notably documents the two distinct MCP surfaces: the read-only TypeScript `mcp-server/` and the newer local-budget Python `agentguard-mcp/` (plus the `npm/` shim and `skills/`).

## Test plan
- [x] Docs-only change — no code touched
- [x] Every directory and file path referenced in the doc verified to exist in the tree
- [x] Module/guard/sink names cross-checked against `sdk/agentguard/__init__.py` and `guards.py`

## Risk
Low — documentation only, no behavior change, no new dependencies.