### PR TITLE
Clarify doctor first-run proof path

### DIFF
--- a/sdk/agentguard/demo.py
+++ b/sdk/agentguard/demo.py
@@ -4,6 +4,7 @@ import os
 import sys
 from typing import Optional, TextIO
 
+from agentguard.first_run import local_proof_commands
 from agentguard.guards import (
     BudgetExceeded,
     BudgetGuard,
@@ -68,11 +69,7 @@ def run_offline_demo(
     _print(out, f"View incident report: agentguard incident {rendered_trace_path}")
     _print(out, "")
     _print(out, "Next: add AgentGuard to a repo")
-    next_commands = [
-        "agentguard quickstart --framework raw --write",
-        "python agentguard_raw_quickstart.py",
-        "agentguard report .agentguard/traces.jsonl",
-    ]
+    next_commands = local_proof_commands()
     for command in next_commands:
         _print(out, f"  {command}")
     _print(out, "")

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any, Dict, List, Optional, TextIO, Tuple
 
 from agentguard.evaluation import _load_events
+from agentguard.first_run import local_proof_commands
 from agentguard.repo_config import load_repo_config_safely
 from agentguard.setup import get_tracer, init, shutdown
 
@@ -92,10 +93,7 @@ def _run_checks(trace_path: str) -> Dict[str, Any]:
         "detected_integrations": detected,
         "integration_hints": hints,
         "next_commands": [
-            "agentguard demo",
-            "agentguard quickstart --framework raw --write",
-            "python agentguard_raw_quickstart.py",
-            "agentguard report .agentguard/traces.jsonl",
+            *local_proof_commands(include_demo=True),
             f"agentguard report {_shell_quote_path(normalized_path)}",
         ],
         "recommended_repo_config": _recommended_repo_config(),

--- a/sdk/agentguard/doctor.py
+++ b/sdk/agentguard/doctor.py
@@ -93,6 +93,9 @@ def _run_checks(trace_path: str) -> Dict[str, Any]:
         "integration_hints": hints,
         "next_commands": [
             "agentguard demo",
+            "agentguard quickstart --framework raw --write",
+            "python agentguard_raw_quickstart.py",
+            "agentguard report .agentguard/traces.jsonl",
             f"agentguard report {_shell_quote_path(normalized_path)}",
         ],
         "recommended_repo_config": _recommended_repo_config(),

--- a/sdk/agentguard/first_run.py
+++ b/sdk/agentguard/first_run.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import List
+
+LOCAL_TRACE_FILE = ".agentguard/traces.jsonl"
+RAW_QUICKSTART_FILE = "agentguard_raw_quickstart.py"
+RAW_QUICKSTART_COMMAND = "agentguard quickstart --framework raw --write"
+
+
+def local_proof_commands(*, include_demo: bool = False) -> List[str]:
+    """Return the local-first proof path shown by first-run CLI commands."""
+    commands = [
+        RAW_QUICKSTART_COMMAND,
+        f"python {RAW_QUICKSTART_FILE}",
+        f"agentguard report {LOCAL_TRACE_FILE}",
+    ]
+    if include_demo:
+        return ["agentguard demo", *commands]
+    return commands

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -26,8 +26,13 @@ class TestDoctor(unittest.TestCase):
             self.assertIn("Suggested next step:", output)
             self.assertIn("local_only=True", output)
             self.assertIn("agentguard demo", output)
+            self.assertIn("agentguard quickstart --framework raw --write", output)
+            self.assertIn("python agentguard_raw_quickstart.py", output)
+            self.assertIn("agentguard report .agentguard/traces.jsonl", output)
             self.assertIn("If 'agentguard' is not on PATH:", output)
             self.assertIn("python -m agentguard.cli demo", output)
+            self.assertIn("python -m agentguard.cli quickstart --framework raw --write", output)
+            self.assertIn("python -m agentguard.cli report .agentguard/traces.jsonl", output)
             self.assertIn(f"python -m agentguard.cli report {trace_path}", output)
 
     def test_run_doctor_json_output_is_parseable(self) -> None:
@@ -42,6 +47,15 @@ class TestDoctor(unittest.TestCase):
             self.assertEqual(payload["status"], "ok")
             self.assertEqual(payload["trace_file"], trace_path)
             self.assertGreaterEqual(payload["events_written"], 4)
+            self.assertEqual(
+                payload["next_commands"][:4],
+                [
+                    "agentguard demo",
+                    "agentguard quickstart --framework raw --write",
+                    "python agentguard_raw_quickstart.py",
+                    "agentguard report .agentguard/traces.jsonl",
+                ],
+            )
             self.assertIn("recommended_snippet", payload)
             self.assertEqual(payload["recommended_repo_config"]["profile"], "coding-agent")
 

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import agentguard
 from agentguard.cli import _doctor
 from agentguard.doctor import run_doctor
+from agentguard.first_run import local_proof_commands
 
 
 class TestDoctor(unittest.TestCase):
@@ -47,15 +48,7 @@ class TestDoctor(unittest.TestCase):
             self.assertEqual(payload["status"], "ok")
             self.assertEqual(payload["trace_file"], trace_path)
             self.assertGreaterEqual(payload["events_written"], 4)
-            self.assertEqual(
-                payload["next_commands"][:4],
-                [
-                    "agentguard demo",
-                    "agentguard quickstart --framework raw --write",
-                    "python agentguard_raw_quickstart.py",
-                    "agentguard report .agentguard/traces.jsonl",
-                ],
-            )
+            self.assertEqual(payload["next_commands"][:4], local_proof_commands(include_demo=True))
             self.assertIn("recommended_snippet", payload)
             self.assertEqual(payload["recommended_repo_config"]["profile"], "coding-agent")
 


### PR DESCRIPTION
## Summary
- make `agentguard doctor` print the complete local first-run proof path after install
- centralize the raw local proof command list so `doctor` and `demo` cannot drift
- include `demo`, raw quickstart write/run, and local report commands in doctor JSON/text output
- add regression coverage so the doctor next-step contract stays aligned with the README/PyPI first-run proof

## What broke or confused first-run users
- The SDK flow itself worked from a clean venv, but `doctor` only pointed to `agentguard demo` and reporting the doctor trace. A new user had to infer the rest of the 60-second proof path from README or `demo` output.
- Copilot review also flagged command drift risk between `doctor` and `demo`; fixed by adding `agentguard.first_run.local_proof_commands()` and using it from both surfaces.

## Proof
- `python -m pytest K:\agent47\sdk\tests\test_doctor.py -v --rootdir K:\agent47` -> 9 passed
- `python -m pytest K:\agent47\sdk\tests\test_doctor.py K:\agent47\sdk\tests\test_demo.py K:\agent47\sdk\tests\test_quickstart.py K:\agent47\sdk\tests\test_cli_report.py K:\agent47\sdk\tests\test_pypi_readme_sync.py -v --rootdir K:\agent47` -> 40 passed
- Clean venv editable install proof: `agentguard.__file__=K:\agent47\sdk\agentguard\__init__.py`
- Clean venv ran: `agentguard doctor`, `agentguard demo`, `agentguard quickstart --framework raw --write`, `python agentguard_raw_quickstart.py`, `agentguard report .agentguard\traces.jsonl`
- Clean venv report showed `Total events: 14`, `Estimated cost: $5.0200`, `guard.budget_exceeded: 1`, `guard.loop_detected: 1`
- Makefile equivalents because `make` is unavailable in this shell:
  - `python scripts/ci_tools_requirements_guard.py` -> passed
  - `python -m ruff check sdk\agentguard scripts\generate_pypi_readme.py scripts\sdk_preflight.py scripts\sdk_release_guard.py scripts\ci_tools_requirements_guard.py` -> passed
  - `python -m pytest sdk\tests -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 748 passed, coverage 93.16%
  - `npm --prefix mcp-server test` -> 6 passed
  - `python -m pytest sdk\tests\test_architecture.py -v` -> 9 passed
  - `python -m bandit -r sdk\agentguard -s B101,B110,B112,B311 -q` -> passed
  - `python scripts\sdk_release_guard.py` -> Release guard passed
  - `python scripts\sdk_preflight.py` -> passed
- GitHub PR checks after follow-up commit -> all passing, including lint, CI Python 3.9/3.10/3.11/3.12, mcp, mcp-budget, and CodeQL

## Review loop
- Addressed Copilot thread about duplicated first-run command lists.
- Replied to and resolved the review thread after pushing `8339aeb`.
- Waited for delayed review comments after the second CI run; no unresolved review threads remain.

## Scope
SDK only. No dashboard, MCP runtime code, registry, Glama, or marketing surface changes.