### PR TITLE
agent: fail clearly for async decorator tracer mismatch

### DIFF
--- a/sdk/agentguard/instrument.py
+++ b/sdk/agentguard/instrument.py
@@ -323,6 +323,10 @@ def unpatch_anthropic() -> None:
 def async_trace_agent(tracer: Any, name: Optional[str] = None) -> Callable[[F], F]:
     """Decorator that wraps an async function in a top-level trace span.
 
+    Requires an ``AsyncTracer`` or tracer-compatible object whose ``trace()``
+    method returns an async context manager. Use ``trace_agent`` with the sync
+    ``Tracer``.
+
     Usage::
 
         @async_trace_agent(tracer)
@@ -335,7 +339,7 @@ def async_trace_agent(tracer: Any, name: Optional[str] = None) -> Callable[[F], 
 
         @functools.wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            async with tracer.trace(span_name) as ctx:
+            async with _async_trace_context(tracer, span_name, "async_trace_agent") as ctx:
                 kwargs["_trace_ctx"] = ctx
                 try:
                     return await fn(*args, **kwargs)
@@ -346,7 +350,7 @@ def async_trace_agent(tracer: Any, name: Optional[str] = None) -> Callable[[F], 
 
         @functools.wraps(fn)
         async def simple_wrapper(*args: Any, **kwargs: Any) -> Any:
-            async with tracer.trace(span_name):
+            async with _async_trace_context(tracer, span_name, "async_trace_agent"):
                 return await fn(*args, **kwargs)
 
         import inspect
@@ -368,6 +372,10 @@ def async_trace_agent(tracer: Any, name: Optional[str] = None) -> Callable[[F], 
 def async_trace_tool(tracer: Any, name: Optional[str] = None) -> Callable[[F], F]:
     """Decorator that wraps an async function in a tool span.
 
+    Requires an ``AsyncTracer`` or tracer-compatible object whose ``trace()``
+    method returns an async context manager. Use ``trace_tool`` with the sync
+    ``Tracer``.
+
     Usage::
 
         @async_trace_tool(tracer)
@@ -381,7 +389,7 @@ def async_trace_tool(tracer: Any, name: Optional[str] = None) -> Callable[[F], F
 
         @functools.wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            async with tracer.trace(span_name) as ctx:
+            async with _async_trace_context(tracer, span_name, "async_trace_tool") as ctx:
                 try:
                     result = await fn(*args, **kwargs)
                 except Exception as exc:
@@ -403,6 +411,27 @@ def async_trace_tool(tracer: Any, name: Optional[str] = None) -> Callable[[F], F
         return wrapper  # type: ignore[return-value]
 
     return decorator
+
+
+def _async_trace_context(tracer: Any, span_name: str, decorator_name: str) -> Any:
+    """Return an async trace context or raise a clear tracer-mismatch error."""
+    trace = getattr(tracer, "trace", None)
+    if not callable(trace):
+        raise TypeError(
+            f"{decorator_name} requires an AsyncTracer-compatible tracer with trace(). "
+            "Use AsyncTracer with async decorators, or use the sync decorator with Tracer."
+        )
+    context_manager = trace(span_name)
+    if not (
+        hasattr(context_manager, "__aenter__")
+        and hasattr(context_manager, "__aexit__")
+    ):
+        raise TypeError(
+            f"{decorator_name} requires AsyncTracer; got "
+            f"{type(tracer).__name__}. Use AsyncTracer with async decorators, "
+            "or use the sync decorator with Tracer."
+        )
+    return context_manager
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/tests/test_atracing.py
+++ b/sdk/tests/test_atracing.py
@@ -13,6 +13,7 @@ from agentguard import (
     JsonlFileSink,
     LoopDetected,
     LoopGuard,
+    Tracer,
 )
 from agentguard.instrument import (
     _originals,
@@ -206,6 +207,16 @@ class TestAsyncTraceAgent(unittest.TestCase):
         with self.assertRaises(ValueError):
             asyncio.run(failing())
 
+    def test_sync_tracer_misuse_raises_clear_error(self):
+        tracer = Tracer(sink=JsonlFileSink(self.path), service="test")
+
+        @async_trace_agent(tracer)
+        async def my_agent():
+            return "done"
+
+        with self.assertRaisesRegex(TypeError, "AsyncTracer"):
+            asyncio.run(my_agent())
+
 
 class TestAsyncTraceTool(unittest.TestCase):
     def setUp(self):
@@ -260,6 +271,16 @@ class TestAsyncTraceTool(unittest.TestCase):
         error_events = [e for e in events if e.get("name") == "tool.error"]
         self.assertTrue(len(error_events) > 0)
         self.assertEqual(error_events[0]["data"]["tool_name"], "flaky")
+
+    def test_sync_tracer_misuse_raises_clear_error(self):
+        tracer = Tracer(sink=JsonlFileSink(self.path), service="test")
+
+        @async_trace_tool(tracer)
+        async def search():
+            return "result"
+
+        with self.assertRaisesRegex(TypeError, "AsyncTracer"):
+            asyncio.run(search())
 
 
 class TestPatchOpenAIAsync(unittest.TestCase):


### PR DESCRIPTION
## Summary
- make `async_trace_agent` and `async_trace_tool` reject sync `Tracer` misuse with an actionable `TypeError`
- document that async decorators require `AsyncTracer` or an async-context-compatible tracer
- add regressions for sync `Tracer` misuse on both async decorators

## Bug class killed
Public async decorators no longer crash with Python's cryptic `_GeneratorContextManager` async context-manager error when a user passes the sync tracer.

## Failing-then-passing proof
- Before fix: `python -m pytest tests/test_atracing.py::TestAsyncTraceAgent::test_sync_tracer_misuse_raises_clear_error tests/test_atracing.py::TestAsyncTraceTool::test_sync_tracer_misuse_raises_clear_error -q` failed because the error did not mention `AsyncTracer`.
- After fix: same command passes.

## Validation
- `python -m pytest tests/test_atracing.py::TestAsyncTraceAgent::test_sync_tracer_misuse_raises_clear_error tests/test_atracing.py::TestAsyncTraceTool::test_sync_tracer_misuse_raises_clear_error -q`
- `python -m pytest tests/test_atracing.py tests/test_instrument.py -q`
- `python -m ruff check sdk\agentguard\instrument.py sdk\tests\test_atracing.py`

## Notes
`make` is not available in this Windows shell, so I ran direct targeted equivalents for this P0 branch.