### PR TITLE
agent: make MCP budget recording atomic

### DIFF
--- a/agentguard-mcp/agentguard_mcp/storage.py
+++ b/agentguard-mcp/agentguard_mcp/storage.py
@@ -201,19 +201,31 @@ class BudgetStore:
 
         current = now or utc_now()
         scopes = matching_scopes(server, tool, session_id)
-        configured = [budget for budget in self._get_budgets(scopes) if budget is not None]
-        kill_reasons = [
-            f"{budget.scope} is blocked by kill_switch" for budget in configured if budget.kill_switch
-        ]
-        if kill_reasons:
-            return {"allowed": False, "reasons": kill_reasons, "scopes_checked": scopes}
-
-        reasons = self._budget_exceeded_reasons(configured, tokens_in + tokens_out, cost_usd, current)
-        if reasons:
-            return {"allowed": False, "reasons": reasons, "scopes_checked": scopes}
-
         timestamp = format_utc(current)
+
         with self._lock, self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            configured = [
+                budget for budget in self._get_budgets_for_conn(conn, scopes) if budget is not None
+            ]
+            kill_reasons = [
+                f"{budget.scope} is blocked by kill_switch"
+                for budget in configured
+                if budget.kill_switch
+            ]
+            if kill_reasons:
+                return {"allowed": False, "reasons": kill_reasons, "scopes_checked": scopes}
+
+            reasons = self._budget_exceeded_reasons(
+                conn,
+                configured,
+                tokens_in + tokens_out,
+                cost_usd,
+                current,
+            )
+            if reasons:
+                return {"allowed": False, "reasons": reasons, "scopes_checked": scopes}
+
             conn.executemany(
                 """
                     INSERT INTO usage_events (
@@ -231,6 +243,7 @@ class BudgetStore:
 
     def _budget_exceeded_reasons(
         self,
+        conn: sqlite3.Connection,
         budgets: list[Budget],
         added_tokens: int,
         added_cost_usd: float,
@@ -238,7 +251,7 @@ class BudgetStore:
     ) -> list[str]:
         reasons: list[str] = []
         for budget in budgets:
-            snapshot = self.check_remaining(budget.scope, now)
+            snapshot = self._snapshot_for_conn(conn, budget.scope, budget, now)
             projected_tokens = snapshot["tokens_used"] + added_tokens
             projected_usd = snapshot["usd_used"] + added_cost_usd
             if snapshot["tokens_limit"] is not None and projected_tokens > snapshot["tokens_limit"]:
@@ -290,8 +303,10 @@ class BudgetStore:
             )
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
         return conn
 
     @contextmanager
@@ -305,10 +320,13 @@ class BudgetStore:
 
     def _get_budget(self, scope: str) -> Budget | None:
         with self._connection() as conn:
-            row = conn.execute(
-                "SELECT scope, limit_tokens, limit_usd, period, kill_switch FROM budgets WHERE scope = ?",
-                (scope,),
-            ).fetchone()
+            return self._get_budget_for_conn(conn, scope)
+
+    def _get_budget_for_conn(self, conn: sqlite3.Connection, scope: str) -> Budget | None:
+        row = conn.execute(
+            "SELECT scope, limit_tokens, limit_usd, period, kill_switch FROM budgets WHERE scope = ?",
+            (scope,),
+        ).fetchone()
         if row is None:
             return None
         return Budget(
@@ -322,20 +340,56 @@ class BudgetStore:
     def _get_budgets(self, scopes: list[str]) -> list[Budget | None]:
         return [self._get_budget(scope) for scope in scopes]
 
+    def _get_budgets_for_conn(
+        self,
+        conn: sqlite3.Connection,
+        scopes: list[str],
+    ) -> list[Budget | None]:
+        return [self._get_budget_for_conn(conn, scope) for scope in scopes]
+
     def _usage_for(self, scope: str, period: Period, now: datetime) -> tuple[int, float]:
-        since = format_utc(period_start(period, now))
         with self._connection() as conn:
-            row = conn.execute(
-                """
-                SELECT
-                    COALESCE(SUM(tokens_in + tokens_out), 0) AS tokens_used,
-                    COALESCE(SUM(cost_usd), 0.0) AS usd_used
-                FROM usage_events
-                WHERE scope = ? AND ts >= ?
-                """,
-                (scope, since),
-            ).fetchone()
+            return self._usage_for_conn(conn, scope, period, now)
+
+    def _usage_for_conn(
+        self,
+        conn: sqlite3.Connection,
+        scope: str,
+        period: Period,
+        now: datetime,
+    ) -> tuple[int, float]:
+        since = format_utc(period_start(period, now))
+        row = conn.execute(
+            """
+            SELECT
+                COALESCE(SUM(tokens_in + tokens_out), 0) AS tokens_used,
+                COALESCE(SUM(cost_usd), 0.0) AS usd_used
+            FROM usage_events
+            WHERE scope = ? AND ts >= ?
+            """,
+            (scope, since),
+        ).fetchone()
         return int(row["tokens_used"]), float(row["usd_used"])
+
+    def _snapshot_for_conn(
+        self,
+        conn: sqlite3.Connection,
+        scope: str,
+        budget: Budget,
+        now: datetime,
+    ) -> BudgetSnapshot:
+        tokens_used, usd_used = self._usage_for_conn(conn, scope, budget.period, now)
+        reset = period_reset(budget.period, now)
+        return {
+            "scope": scope,
+            "tokens_used": tokens_used,
+            "tokens_limit": budget.limit_tokens,
+            "usd_used": usd_used,
+            "usd_limit": budget.limit_usd,
+            "period": budget.period,
+            "period_resets_at": format_utc(reset) if reset is not None else None,
+            "kill_switch": budget.kill_switch,
+        }
 
 
 def normalize_scope(scope: str) -> str:

--- a/agentguard-mcp/tests/test_storage.py
+++ b/agentguard-mcp/tests/test_storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 import pytest
@@ -68,6 +70,26 @@ def test_record_call_allows_exact_limit_and_persists(tmp_path):
 
     assert result["allowed"] is True
     assert store.check_remaining("global")["tokens_used"] == 10
+
+
+def test_concurrent_record_call_never_exceeds_budget(tmp_path):
+    store = BudgetStore(tmp_path / "state.db")
+    store.set_budget("global", 1, None, "day")
+    started = threading.Barrier(16)
+
+    def record_once():
+        started.wait()
+        return store.record_call("github", "create_issue", 1, 0, 0.0, None)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        results = list(pool.map(lambda _: record_once(), range(16)))
+
+    allowed = [result for result in results if result["allowed"]]
+    blocked = [result for result in results if not result["allowed"]]
+
+    assert len(allowed) == 1
+    assert len(blocked) == 15
+    assert store.check_remaining("global")["tokens_used"] == 1
 
 
 def test_set_budget_rejects_empty_limits(tmp_path):


### PR DESCRIPTION
## Summary
- move local-budget MCP `record_call()` read/check/insert into one locked SQLite write transaction
- enable WAL mode and a busy timeout on SQLite connections
- add a concurrent regression proving usage cannot exceed budget under threaded calls

## Bug class killed
The local-budget MCP store no longer has a TOCTOU budget race where concurrent calls can all pass the pre-insert check and overshoot the configured budget.

## Failing-then-passing proof
- Before fix: `python -m pytest tests/test_storage.py::test_concurrent_record_call_never_exceeds_budget -q` failed with 8 allowed calls against a global budget of 1.
- After fix: same command passes and persisted usage remains 1.

## Validation
- `python -m pytest tests/test_storage.py::test_concurrent_record_call_never_exceeds_budget -q`
- `python -m pytest -q`
- `python -m ruff check agentguard_mcp tests`

## Notes
`make` is not available in this Windows shell, so I ran direct package-level equivalents for this P0 branch.