### PR TITLE
agent: share trace event sanitization with async tracer

### DIFF
--- a/sdk/agentguard/atracing.py
+++ b/sdk/agentguard/atracing.py
@@ -24,7 +24,7 @@ import time
 import uuid
 
 from agentguard._trace_naming import normalize_session_id, truncate_name
-from agentguard.tracing import StdoutSink, TraceSink
+from agentguard.tracing import StdoutSink, TraceSink, _build_trace_event
 
 
 @dataclass
@@ -217,23 +217,20 @@ class AsyncTracer:
         cost_usd: Optional[float] = None,
     ) -> None:
         """Internal: build and emit a trace event (sync)."""
-        event: Dict[str, Any] = {
-            "service": self._service,
-            "kind": kind,
-            "phase": phase,
-            "trace_id": trace_id,
-            "span_id": span_id,
-            "parent_id": parent_id,
-            "name": name,
-            "ts": time.time(),
-            "duration_ms": duration_ms,
-            "data": data or {},
-            "error": error,
-        }
-        if self._session_id is not None:
-            event["session_id"] = self._session_id
-        if cost_usd is not None:
-            event["cost_usd"] = cost_usd
+        event, safe_data = _build_trace_event(
+            service=self._service,
+            session_id=self._session_id,
+            kind=kind,
+            phase=phase,
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_id=parent_id,
+            name=name,
+            data=data,
+            duration_ms=duration_ms,
+            error=error,
+            cost_usd=cost_usd,
+        )
         self._sink.emit(event)
 
         # Auto-check guards
@@ -241,10 +238,10 @@ class AsyncTracer:
             if kind != "event":
                 continue
             if hasattr(guard, "auto_check"):
-                guard.auto_check(name, data)
+                guard.auto_check(name, safe_data)
             elif hasattr(guard, "check"):
                 try:
-                    guard.check(name, data)
+                    guard.check(name, safe_data)
                 except TypeError:
                     try:
                         guard.check()

--- a/sdk/agentguard/tracing.py
+++ b/sdk/agentguard/tracing.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from agentguard.cost import CostTracker
@@ -188,6 +188,46 @@ def _sanitize_data(data: Optional[Any]) -> Optional[Dict[str, Any]]:
         )
         return _fit_mapping_data(safe_data, _MAX_EVENT_DATA_BYTES)
     return safe_data
+
+
+def _build_trace_event(
+    *,
+    service: str,
+    session_id: Optional[str],
+    kind: str,
+    phase: str,
+    trace_id: str,
+    span_id: str,
+    parent_id: Optional[str],
+    name: str,
+    data: Optional[Dict[str, Any]] = None,
+    duration_ms: Optional[float] = None,
+    error: Optional[Dict[str, Any]] = None,
+    cost_usd: Optional[float] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Build one JSON-safe trace event for sync and async tracers."""
+    safe_data = _sanitize_data(data)
+    event: Dict[str, Any] = {
+        "service": service,
+        "kind": kind,
+        "phase": phase,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_id": parent_id,
+        "name": name,
+        "ts": time.time(),
+        "duration_ms": duration_ms,
+        "data": safe_data or {},
+        "error": error,
+    }
+    if session_id is not None:
+        event["session_id"] = session_id
+    if cost_usd is not None:
+        event["cost_usd"] = cost_usd
+    if metadata:
+        event["metadata"] = metadata
+    return event, safe_data
 
 
 @dataclass
@@ -423,26 +463,21 @@ class Tracer:
         Note: sampling is handled by TraceContext — if this method is
         called, the event should be emitted.
         """
-        safe_data = _sanitize_data(data)
-        event: Dict[str, Any] = {
-            "service": self._service,
-            "kind": kind,
-            "phase": phase,
-            "trace_id": trace_id,
-            "span_id": span_id,
-            "parent_id": parent_id,
-            "name": name,
-            "ts": time.time(),
-            "duration_ms": duration_ms,
-            "data": safe_data or {},
-            "error": error,
-        }
-        if self._session_id is not None:
-            event["session_id"] = self._session_id
-        if cost_usd is not None:
-            event["cost_usd"] = cost_usd
-        if self._metadata:
-            event["metadata"] = self._metadata
+        event, safe_data = _build_trace_event(
+            service=self._service,
+            session_id=self._session_id,
+            kind=kind,
+            phase=phase,
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_id=parent_id,
+            name=name,
+            data=data,
+            duration_ms=duration_ms,
+            error=error,
+            cost_usd=cost_usd,
+            metadata=self._metadata,
+        )
         if self._watermark and not self._watermark_emitted:
             self._watermark_emitted = True
             wm: Dict[str, Any] = {

--- a/sdk/tests/test_atracing.py
+++ b/sdk/tests/test_atracing.py
@@ -140,6 +140,20 @@ class TestAsyncTracer(unittest.TestCase):
         self.assertTrue(trace_events)
         self.assertTrue(all(event["session_id"] == "session-123" for event in trace_events))
 
+    def test_event_data_is_truncated_like_sync_tracer(self):
+        async def run():
+            tracer = AsyncTracer(sink=JsonlFileSink(self.path), service="test")
+            async with tracer.trace("agent.run") as span:
+                span.event("oversized", data={"blob": "x" * 70_000})
+
+        asyncio.run(run())
+
+        with open(self.path) as f:
+            events = [json.loads(line) for line in f if line.strip()]
+        oversized = next(event for event in events if event["name"] == "oversized")
+        self.assertTrue(oversized["data"]["blob"].endswith("...[truncated]"))
+        self.assertLess(len(json.dumps(oversized["data"]).encode("utf-8")), 70_000)
+
 
 class TestAsyncTracerRepr(unittest.TestCase):
     def test_repr(self):


### PR DESCRIPTION
## Summary
- add one shared trace event builder for sync and async tracer emission
- route `AsyncTracer._emit()` through the sync sanitizer so async payloads get JSON coercion and 64KB truncation
- add an oversized async event regression

## Bug class killed
Async traces no longer bypass the sync tracer's JSON-safe event data limits and write unbounded event payloads.

## Failing-then-passing proof
- Before fix: `python -m pytest tests/test_atracing.py::TestAsyncTracer::test_event_data_is_truncated_like_sync_tracer -q` failed because the async event data was not truncated.
- After fix: same command passes.

## Validation
- `python -m pytest tests/test_atracing.py::TestAsyncTracer::test_event_data_is_truncated_like_sync_tracer -q`
- `python -m pytest tests/test_atracing.py tests/test_tracing.py -q`
- `python -m ruff check sdk\agentguard\tracing.py sdk\agentguard\atracing.py sdk\tests\test_atracing.py`

## Notes
`make` is not available in this Windows shell, so I ran direct targeted equivalents for this P0 branch.