### PR TITLE
agent: fail loudly on guard bugs and refresh pricing trust

### DIFF
--- a/sdk/agentguard/atracing.py
+++ b/sdk/agentguard/atracing.py
@@ -24,7 +24,7 @@ import time
 import uuid
 
 from agentguard._trace_naming import normalize_session_id, truncate_name
-from agentguard.tracing import StdoutSink, TraceSink, _build_trace_event
+from agentguard.tracing import StdoutSink, TraceSink, _build_trace_event, _check_guard
 
 
 @dataclass
@@ -237,16 +237,7 @@ class AsyncTracer:
         for guard in self._guards:
             if kind != "event":
                 continue
-            if hasattr(guard, "auto_check"):
-                guard.auto_check(name, safe_data)
-            elif hasattr(guard, "check"):
-                try:
-                    guard.check(name, safe_data)
-                except TypeError:
-                    try:
-                        guard.check()
-                    except TypeError:
-                        pass
+            _check_guard(guard, name, safe_data)
 
     def __repr__(self) -> str:
         session_part = ""

--- a/sdk/agentguard/cost.py
+++ b/sdk/agentguard/cost.py
@@ -4,9 +4,12 @@ Hardcoded pricing dict — no network calls, no dependencies.
 """
 from __future__ import annotations
 
+import logging
 import threading
 import warnings
 from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("agentguard.cost")
 
 
 class UnknownModelWarning(UserWarning):
@@ -15,12 +18,17 @@ class UnknownModelWarning(UserWarning):
 
 
 # Prices per 1K tokens: (input_price, output_price)
-# Last updated: 2026-03-26
-# Verified directly against current Anthropic and Google pricing pages.
-# OpenAI entries were retained from the prior table because the official
-# pricing page was not fetchable from this environment due to Cloudflare.
+# Last updated: 2026-05-19
+# Verified against official OpenAI, Anthropic, and Google pricing pages.
 _PRICES: Dict[Tuple[str, str], Tuple[float, float]] = {
     # OpenAI
+    ("openai", "gpt-5.5"): (0.005, 0.030),
+    ("openai", "gpt-5.5-pro"): (0.030, 0.180),
+    ("openai", "gpt-5.4"): (0.0025, 0.015),
+    ("openai", "gpt-5.4-mini"): (0.00075, 0.0045),
+    ("openai", "gpt-5.4-nano"): (0.0002, 0.00125),
+    ("openai", "gpt-5.4-pro"): (0.030, 0.180),
+    ("openai", "gpt-5.3-codex"): (0.00175, 0.014),
     ("openai", "gpt-4o"): (0.0025, 0.010),
     ("openai", "gpt-4o-mini"): (0.00015, 0.0006),
     ("openai", "gpt-4-turbo"): (0.01, 0.03),
@@ -30,6 +38,10 @@ _PRICES: Dict[Tuple[str, str], Tuple[float, float]] = {
     ("openai", "o1-mini"): (0.003, 0.012),
     ("openai", "o3-mini"): (0.0011, 0.0044),
     # Anthropic
+    ("anthropic", "claude-opus-4-7"): (0.005, 0.025),
+    ("anthropic", "claude-opus-4-5"): (0.005, 0.025),
+    ("anthropic", "claude-sonnet-4-6"): (0.003, 0.015),
+    ("anthropic", "claude-sonnet-4-5"): (0.003, 0.015),
     ("anthropic", "claude-3-5-sonnet-20241022"): (0.003, 0.015),
     ("anthropic", "claude-3-5-haiku-20241022"): (0.0008, 0.004),
     ("anthropic", "claude-3-opus-20240229"): (0.015, 0.075),
@@ -39,6 +51,9 @@ _PRICES: Dict[Tuple[str, str], Tuple[float, float]] = {
     ("anthropic", "claude-opus-4-20250515"): (0.015, 0.075),
     ("anthropic", "claude-opus-4-6"): (0.005, 0.025),
     # Google
+    ("google", "gemini-2.5-pro"): (0.00125, 0.010),
+    ("google", "gemini-2.5-flash"): (0.00030, 0.00250),
+    ("google", "gemini-2.5-flash-lite"): (0.00010, 0.00040),
     ("google", "gemini-1.5-pro"): (0.00125, 0.005),
     ("google", "gemini-1.5-flash"): (0.000075, 0.0003),
     ("google", "gemini-2.0-flash"): (0.0001, 0.0004),
@@ -49,7 +64,7 @@ _PRICES: Dict[Tuple[str, str], Tuple[float, float]] = {
     ("meta", "llama-3.1-70b"): (0.00035, 0.0004),
 }
 
-LAST_UPDATED = "2026-03-26"
+LAST_UPDATED = "2026-05-19"
 
 
 def estimate_cost(
@@ -79,12 +94,12 @@ def estimate_cost(
         for (_p, m), prices in _PRICES.items():
             if m == model:
                 return (input_tokens * prices[0] + output_tokens * prices[1]) / 1000.0
-    warnings.warn(
+    message = (
         f"Unknown model '{model}'. Pricing data last updated {LAST_UPDATED}. "
-        f"Cost estimate is $0.00.",
-        UnknownModelWarning,
-        stacklevel=2,
+        "Cost estimate is $0.00."
     )
+    logger.warning(message)
+    warnings.warn(message, UnknownModelWarning, stacklevel=2)
     return 0.0
 
 

--- a/sdk/agentguard/cost.py
+++ b/sdk/agentguard/cost.py
@@ -67,6 +67,17 @@ _PRICES: Dict[Tuple[str, str], Tuple[float, float]] = {
 LAST_UPDATED = "2026-05-19"
 
 
+def _resolve_prices(provider: str, model: str, input_tokens: int) -> Optional[Tuple[float, float]]:
+    prices = _PRICES.get((provider, model))
+    if not prices:
+        return None
+    if provider == "openai" and model == "gpt-5.5" and input_tokens > 272_000:
+        return (prices[0] * 2, prices[1] * 1.5)
+    if provider == "google" and model == "gemini-2.5-pro" and input_tokens > 200_000:
+        return (0.0025, 0.015)
+    return prices
+
+
 def estimate_cost(
     model: str,
     input_tokens: int = 0,
@@ -86,13 +97,16 @@ def estimate_cost(
         Estimated cost in USD. Returns 0.0 if model not found.
     """
     if provider:
-        prices = _PRICES.get((provider, model))
+        prices = _resolve_prices(provider, model, input_tokens)
         if prices:
             return (input_tokens * prices[0] + output_tokens * prices[1]) / 1000.0
     else:
         # Try all providers
-        for (_p, m), prices in _PRICES.items():
+        for (_p, m), _prices in _PRICES.items():
             if m == model:
+                prices = _resolve_prices(_p, m, input_tokens)
+                if not prices:
+                    continue
                 return (input_tokens * prices[0] + output_tokens * prices[1]) / 1000.0
     message = (
         f"Unknown model '{model}'. Pricing data last updated {LAST_UPDATED}. "

--- a/sdk/agentguard/tracing.py
+++ b/sdk/agentguard/tracing.py
@@ -14,19 +14,20 @@ Usage::
 """
 from __future__ import annotations
 
+import inspect
+import json
 import logging
+import os
+import random
+import threading
+import time
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from agentguard.cost import CostTracker
-import json
-import os
-import random
-import threading
-import time
-import uuid
 
 from agentguard._trace_naming import normalize_session_id, truncate_name
 
@@ -228,6 +229,49 @@ def _build_trace_event(
     if metadata:
         event["metadata"] = metadata
     return event, safe_data
+
+
+def _callable_accepts_n_positional_args(fn: Any, count: int) -> bool:
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return count == 2
+
+    required = 0
+    positional = 0
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            return required <= count
+        if parameter.kind in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }:
+            positional += 1
+            if parameter.default is inspect.Parameter.empty:
+                required += 1
+    return required <= count <= positional
+
+
+def _check_guard(guard: Any, name: str, data: Optional[Dict[str, Any]] = None) -> None:
+    """Dispatch one guard without swallowing implementation errors."""
+    auto_check = getattr(guard, "auto_check", None)
+    if callable(auto_check):
+        auto_check(name, data)
+        return
+
+    check = getattr(guard, "check", None)
+    if not callable(check):
+        return
+    if _callable_accepts_n_positional_args(check, 2):
+        check(name, data)
+        return
+    if _callable_accepts_n_positional_args(check, 0):
+        check()
+        return
+    raise TypeError(
+        f"Guard {type(guard).__name__}.check must accept either "
+        "(event_name, event_data) or no positional arguments"
+    )
 
 
 @dataclass
@@ -499,17 +543,7 @@ class Tracer:
     def _check_guards(self, name: str, data: Optional[Dict[str, Any]] = None) -> None:
         """Run all attached guards. Called on every event, even sampled-out ones."""
         for guard in self._guards:
-            if hasattr(guard, "auto_check"):
-                guard.auto_check(name, data)
-            elif hasattr(guard, "check"):
-                # Backward compat: try check(name, data), then check()
-                try:
-                    guard.check(name, data)
-                except TypeError:
-                    try:
-                        guard.check()
-                    except TypeError:
-                        pass
+            _check_guard(guard, name, data)
 
     def __repr__(self) -> str:
         session_part = ""

--- a/sdk/tests/test_atracing.py
+++ b/sdk/tests/test_atracing.py
@@ -8,6 +8,8 @@ import types
 import unittest
 from unittest.mock import MagicMock
 
+import pytest
+
 from agentguard import (
     AsyncTracer,
     JsonlFileSink,
@@ -154,6 +156,23 @@ class TestAsyncTracer(unittest.TestCase):
         oversized = next(event for event in events if event["name"] == "oversized")
         self.assertTrue(oversized["data"]["blob"].endswith("...[truncated]"))
         self.assertLess(len(json.dumps(oversized["data"]).encode("utf-8")), 70_000)
+
+    def test_buggy_check_guard_type_error_fails_loudly(self):
+        class BuggyGuard:
+            def check(self, name, data):
+                raise TypeError("async guard implementation bug")
+
+        async def run():
+            tracer = AsyncTracer(
+                sink=JsonlFileSink(self.path),
+                service="test",
+                guards=[BuggyGuard()],
+            )
+            async with tracer.trace("agent.run") as span:
+                span.event("tool.search", data={"query": "docs"})
+
+        with pytest.raises(TypeError, match="async guard implementation bug"):
+            asyncio.run(run())
 
 
 class TestAsyncTracerRepr(unittest.TestCase):

--- a/sdk/tests/test_cost.py
+++ b/sdk/tests/test_cost.py
@@ -44,6 +44,16 @@ class TestEstimateCost(unittest.TestCase):
         # (1000 * 0.005 + 500 * 0.025) / 1000 = 0.005 + 0.0125 = 0.0175
         self.assertAlmostEqual(cost, 0.0175, places=6)
 
+    def test_gpt_55_long_context_uses_full_session_multiplier(self) -> None:
+        cost = estimate_cost("gpt-5.5", input_tokens=300_000, output_tokens=10_000, provider="openai")
+        # >272K input tokens: input is 2x and output is 1.5x for the full session.
+        self.assertAlmostEqual(cost, 3.45, places=6)
+
+    def test_gemini_25_pro_long_context_uses_high_token_tier(self) -> None:
+        cost = estimate_cost("gemini-2.5-pro", input_tokens=250_000, output_tokens=10_000, provider="google")
+        # >200K prompt tokens: $2.50 input / $15 output per 1M tokens.
+        self.assertAlmostEqual(cost, 0.775, places=6)
+
     def test_zero_tokens(self) -> None:
         cost = estimate_cost("gpt-4o", input_tokens=0, output_tokens=0, provider="openai")
         self.assertEqual(cost, 0.0)

--- a/sdk/tests/test_cost.py
+++ b/sdk/tests/test_cost.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import date
 
 from agentguard.cost import LAST_UPDATED, CostTracker, UnknownModelWarning, estimate_cost
 
@@ -17,6 +18,16 @@ class TestEstimateCost(unittest.TestCase):
         with self.assertWarns(UnknownModelWarning):
             cost = estimate_cost("nonexistent-model", input_tokens=1000, output_tokens=500)
         self.assertEqual(cost, 0.0)
+
+    def test_unknown_model_logs_warning(self) -> None:
+        with self.assertWarns(UnknownModelWarning), self.assertLogs(
+            "agentguard.cost",
+            level="WARNING",
+        ) as logs:
+            cost = estimate_cost("nonexistent-model", input_tokens=1000, output_tokens=500)
+
+        self.assertEqual(cost, 0.0)
+        self.assertTrue(any("Unknown model" in message for message in logs.output))
 
     def test_anthropic_model(self) -> None:
         cost = estimate_cost("claude-3-5-sonnet-20241022", input_tokens=1000, output_tokens=500, provider="anthropic")
@@ -85,7 +96,8 @@ class TestCostTracker(unittest.TestCase):
 
 class TestEstimateCostEdgeCases(unittest.TestCase):
     def test_last_updated_marker(self) -> None:
-        self.assertEqual(LAST_UPDATED, "2026-03-26")
+        updated = date.fromisoformat(LAST_UPDATED)
+        self.assertLessEqual((date.today() - updated).days, 90)
 
     def test_very_large_tokens(self) -> None:
         cost = estimate_cost("gpt-4o", input_tokens=1_000_000, output_tokens=1_000_000, provider="openai")

--- a/sdk/tests/test_coverage_gaps.py
+++ b/sdk/tests/test_coverage_gaps.py
@@ -127,14 +127,14 @@ class TestTracerGuardFallback(unittest.TestCase):
             ctx.event("step")
 
     def test_guard_with_incompatible_check(self):
-        """Guard.check() that raises TypeError is silently ignored."""
+        """Guard.check() TypeError fails loudly."""
         class BadGuard:
             def check(self, *args, **kwargs):
                 raise TypeError("bad")
 
         sink = StdoutSink()
         tracer = Tracer(sink=sink, guards=[BadGuard()])
-        with tracer.trace("test") as ctx:
+        with self.assertRaisesRegex(TypeError, "bad"), tracer.trace("test") as ctx:
             ctx.event("step")
 
 
@@ -585,7 +585,7 @@ class TestAsyncTracerGuardFallback(unittest.TestCase):
         asyncio.run(run())
 
     def test_async_guard_with_incompatible_check(self):
-        """Guard.check() that raises TypeError is silently ignored (async)."""
+        """Guard.check() TypeError fails loudly (async)."""
         import asyncio
         from agentguard.atracing import AsyncTracer
 
@@ -600,7 +600,8 @@ class TestAsyncTracerGuardFallback(unittest.TestCase):
             async with tracer.trace("test") as ctx:
                 ctx.event("step")
 
-        asyncio.run(run())
+        with self.assertRaisesRegex(TypeError, "bad"):
+            asyncio.run(run())
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/tests/test_tracing.py
+++ b/sdk/tests/test_tracing.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 import unittest
 
+import pytest
+
 from agentguard.tracing import JsonlFileSink, TraceContext, Tracer, _sanitize_data
 
 
@@ -180,6 +182,36 @@ class TestSessionId(unittest.TestCase):
         trace_events = [event for event in captured if event.get("kind") in {"span", "event"}]
         assert trace_events
         assert all(event["session_id"] == "session-123" for event in trace_events)
+
+
+class TestTracerGuardDispatch(unittest.TestCase):
+    def test_buggy_check_guard_type_error_fails_loudly(self) -> None:
+        class BuggyGuard:
+            def check(self, name, data):
+                raise TypeError("guard implementation bug")
+
+        tracer = Tracer(guards=[BuggyGuard()], watermark=False)
+
+        with pytest.raises(TypeError, match="guard implementation bug"), tracer.trace(
+            "agent.run"
+        ) as span:
+            span.event("tool.search", data={"query": "docs"})
+
+    def test_zero_arg_check_guard_is_still_supported(self) -> None:
+        class ZeroArgGuard:
+            def __init__(self) -> None:
+                self.called = False
+
+            def check(self) -> None:
+                self.called = True
+
+        guard = ZeroArgGuard()
+        tracer = Tracer(guards=[guard], watermark=False)
+
+        with tracer.trace("agent.run") as span:
+            span.event("tool.search")
+
+        self.assertTrue(guard.called)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace fallback `TypeError` swallowing in sync/async guard dispatch with explicit guard protocol detection
- preserve zero-arg `check()` compatibility while surfacing implementation `TypeError`s
- refresh static OpenAI, Anthropic, and Google model pricing entries and update `LAST_UPDATED`
- add a 90-day pricing freshness test and log `WARNING` when unknown models resolve to `$0.00`

## Bug class killed
Buggy custom guards no longer silently stop protecting a run, and unknown/stale pricing no longer disappears into a warnings-only path.

## Failing-then-passing proof
- Before fix: guard dispatch regressions failed because `TypeError` from `check(name, data)` was swallowed.
- Before fix: unknown-model logging regression failed because no `agentguard.cost` warning log was emitted.
- After fix: all targeted regressions pass.

## Official pricing sources used
- OpenAI pricing: https://developers.openai.com/api/docs/pricing
- Anthropic pricing: https://platform.claude.com/docs/en/about-claude/pricing
- Google Gemini pricing: https://ai.google.dev/gemini-api/docs/pricing

## Validation
- `python -m pytest tests/test_tracing.py::TestTracerGuardDispatch tests/test_atracing.py::TestAsyncTracer::test_buggy_check_guard_type_error_fails_loudly tests/test_cost.py::TestEstimateCost::test_unknown_model_logs_warning tests/test_cost.py::TestEstimateCostEdgeCases::test_last_updated_marker -q`
- `python -m pytest tests/test_tracing.py tests/test_atracing.py tests/test_cost.py tests/test_instrument.py tests/test_cost_guardrail.py -q`
- `python -m ruff check sdk\agentguard\tracing.py sdk\agentguard\atracing.py sdk\agentguard\cost.py sdk\tests\test_tracing.py sdk\tests\test_atracing.py sdk\tests\test_cost.py`

## Notes
`make` is not available in this Windows shell, so I ran direct targeted equivalents for this branch.