### PR TITLE
agent: harden LangChain callback span bookkeeping

### DIFF
--- a/sdk/agentguard/integrations/langchain.py
+++ b/sdk/agentguard/integrations/langchain.py
@@ -76,10 +76,10 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
     ) -> None:
         with self._lock:
             ctx = self._pop_span(run_id)
-        if ctx is None:
-            return
-        ctx.event("chain.outputs", data={"outputs": _safe_dict(outputs)})
-        self._exit_span(ctx, None, None, None)
+            if ctx is None:
+                return
+            ctx.event("chain.outputs", data={"outputs": _safe_dict(outputs)})
+            self._exit_span(ctx, None, None, None)
 
     def on_chain_error(
         self,
@@ -90,9 +90,9 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
     ) -> None:
         with self._lock:
             ctx = self._pop_span(run_id)
-        if ctx is None:
-            return
-        self._exit_span(ctx, type(error), error, error.__traceback__)
+            if ctx is None:
+                return
+            self._exit_span(ctx, type(error), error, error.__traceback__)
 
     # -- llm ------------------------------------------------------------------
 
@@ -121,8 +121,8 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
     ) -> None:
         with self._lock:
             ctx = self._pop_span(run_id)
-        if ctx is None:
-            return
+            if ctx is None:
+                return
         usage = _extract_token_usage(response)
         model_name = _extract_model_name(response)
         provider = infer_provider(model_name)
@@ -148,18 +148,20 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
                         consume_kwargs["cost_usd"] = payload["cost_usd"]
                     self._budget_guard.consume(**consume_kwargs)
                 except BudgetExceeded as e:
-                    ctx.event("guard.budget_exceeded", data={
-                        "tokens_used": self._budget_guard.state.tokens_used,
-                        "tokens_limit": self._budget_guard.max_tokens,
-                        "calls_used": self._budget_guard.state.calls_used,
-                        "calls_limit": self._budget_guard.max_calls,
-                        "error": str(e),
-                    })
-                    ctx.event("llm.end", data=payload)
-                    self._exit_span(ctx, None, None, None)
+                    with self._lock:
+                        ctx.event("guard.budget_exceeded", data={
+                            "tokens_used": self._budget_guard.state.tokens_used,
+                            "tokens_limit": self._budget_guard.max_tokens,
+                            "calls_used": self._budget_guard.state.calls_used,
+                            "calls_limit": self._budget_guard.max_calls,
+                            "error": str(e),
+                        })
+                        ctx.event("llm.end", data=payload)
+                        self._exit_span(ctx, None, None, None)
                     raise
-        ctx.event("llm.end", data=payload)
-        self._exit_span(ctx, None, None, None)
+        with self._lock:
+            ctx.event("llm.end", data=payload)
+            self._exit_span(ctx, None, None, None)
 
     def on_llm_error(
         self,
@@ -170,9 +172,9 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
     ) -> None:
         with self._lock:
             ctx = self._pop_span(run_id)
-        if ctx is None:
-            return
-        self._exit_span(ctx, type(error), error, error.__traceback__)
+            if ctx is None:
+                return
+            self._exit_span(ctx, type(error), error, error.__traceback__)
 
     # -- tools ----------------------------------------------------------------
 
@@ -187,31 +189,33 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         tool_name = serialized.get("name") or serialized.get("id", "tool")
         if isinstance(tool_name, list):
             tool_name = tool_name[-1]
-        with self._lock:
-            current_ctx = self._span_stack[-1] if self._span_stack else None
         if self._loop_guard:
             try:
                 self._loop_guard.check(tool_name=tool_name, tool_args={"input": input_str})
             except LoopDetected as e:
-                if current_ctx:
-                    current_ctx.event("guard.loop_detected", data={
-                        "tool_name": tool_name,
-                        "repeat_count": self._loop_guard.max_repeats,
-                        "error": str(e),
-                    })
+                with self._lock:
+                    current_ctx = self._span_stack[-1] if self._span_stack else None
+                    if current_ctx:
+                        current_ctx.event("guard.loop_detected", data={
+                            "tool_name": tool_name,
+                            "repeat_count": self._loop_guard.max_repeats,
+                            "error": str(e),
+                        })
                 raise
         if self._budget_guard:
             try:
                 self._budget_guard.consume(calls=1)
             except BudgetExceeded as e:
-                if current_ctx:
-                    current_ctx.event("guard.budget_exceeded", data={
-                        "tokens_used": self._budget_guard.state.tokens_used,
-                        "tokens_limit": self._budget_guard.max_tokens,
-                        "calls_used": self._budget_guard.state.calls_used,
-                        "calls_limit": self._budget_guard.max_calls,
-                        "error": str(e),
-                    })
+                with self._lock:
+                    current_ctx = self._span_stack[-1] if self._span_stack else None
+                    if current_ctx:
+                        current_ctx.event("guard.budget_exceeded", data={
+                            "tokens_used": self._budget_guard.state.tokens_used,
+                            "tokens_limit": self._budget_guard.max_tokens,
+                            "calls_used": self._budget_guard.state.calls_used,
+                            "calls_limit": self._budget_guard.max_calls,
+                            "error": str(e),
+                        })
                 raise
         with self._lock:
             parent = self._span_stack[-1] if self._span_stack else None
@@ -230,10 +234,10 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
     ) -> None:
         with self._lock:
             ctx = self._pop_span(run_id)
-        if ctx is None:
-            return
-        ctx.event("tool.result", data={"output": str(output)})
-        self._exit_span(ctx, None, None, None)
+            if ctx is None:
+                return
+            ctx.event("tool.result", data={"output": str(output)})
+            self._exit_span(ctx, None, None, None)
 
     def on_tool_error(
         self,
@@ -244,9 +248,9 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
     ) -> None:
         with self._lock:
             ctx = self._pop_span(run_id)
-        if ctx is None:
-            return
-        self._exit_span(ctx, type(error), error, error.__traceback__)
+            if ctx is None:
+                return
+            self._exit_span(ctx, type(error), error, error.__traceback__)
 
     # -- helpers --------------------------------------------------------------
 
@@ -263,7 +267,9 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         return ctx
 
     def _pop_span(self, run_id: Optional[uuid.UUID]) -> Optional[TraceContext]:
-        if run_id and str(run_id) in self._run_to_span:
+        if run_id and str(run_id) not in self._run_to_span:
+            return None
+        if run_id:
             ctx = self._run_to_span.pop(str(run_id))
             if ctx in self._span_stack:
                 while self._span_stack and self._span_stack[-1] is not ctx:
@@ -279,10 +285,11 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         return None
 
     def _exit_span(self, ctx: TraceContext, exc_type: Any, exc: Any, tb: Any) -> None:
-        ctx_mgr = self._span_contexts.pop(id(ctx), ctx)
-        ctx_mgr.__exit__(exc_type, exc, tb)
-        if not self._span_stack:
-            self._root_ctx = None
+        with self._lock:
+            ctx_mgr = self._span_contexts.pop(id(ctx), ctx)
+            ctx_mgr.__exit__(exc_type, exc, tb)
+            if not self._span_stack:
+                self._root_ctx = None
 
     def _forget_run_for_span(self, ctx: TraceContext) -> None:
         for run_key, mapped_ctx in list(self._run_to_span.items()):

--- a/sdk/agentguard/integrations/langchain.py
+++ b/sdk/agentguard/integrations/langchain.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import threading
 import uuid
+from contextlib import AbstractContextManager
 from typing import Any, Dict, List, Optional
 
 from agentguard.guards import BudgetExceeded, BudgetGuard, LoopDetected, LoopGuard
@@ -41,6 +43,8 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         self._root_ctx: Optional[Any] = None
         self._span_stack: List[TraceContext] = []
         self._run_to_span: Dict[str, TraceContext] = {}
+        self._span_contexts: Dict[int, AbstractContextManager[Any]] = {}
+        self._lock = threading.RLock()
 
     # -- chains ---------------------------------------------------------------
 
@@ -52,19 +56,16 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        name = serialized.get("name") or serialized.get("id", ["chain"])[-1] if isinstance(serialized.get("id"), list) else serialized.get("name") or "chain"
-        if not self._span_stack:
-            ctx_mgr = self._tracer.trace(f"chain.{name}", data={"inputs": _safe_dict(inputs)})
-            ctx = ctx_mgr.__enter__()
-            self._root_ctx = ctx_mgr
-            self._span_stack.append(ctx)
-        else:
-            parent = self._span_stack[-1]
-            ctx = parent.span(f"chain.{name}", data={"inputs": _safe_dict(inputs)})
-            ctx.__enter__()
-            self._span_stack.append(ctx)
-        if run_id:
-            self._run_to_span[str(run_id)] = ctx
+        name = _chain_name(serialized)
+        with self._lock:
+            if not self._span_stack:
+                ctx_mgr = self._tracer.trace(f"chain.{name}", data={"inputs": _safe_dict(inputs)})
+                self._enter_span(ctx_mgr, run_id)
+                self._root_ctx = ctx_mgr
+            else:
+                parent = self._span_stack[-1]
+                ctx_mgr = parent.span(f"chain.{name}", data={"inputs": _safe_dict(inputs)})
+                self._enter_span(ctx_mgr, run_id)
 
     def on_chain_end(
         self,
@@ -73,11 +74,12 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        ctx = self._pop_span(run_id)
+        with self._lock:
+            ctx = self._pop_span(run_id)
         if ctx is None:
             return
         ctx.event("chain.outputs", data={"outputs": _safe_dict(outputs)})
-        ctx.__exit__(None, None, None)
+        self._exit_span(ctx, None, None, None)
 
     def on_chain_error(
         self,
@@ -86,10 +88,11 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        ctx = self._pop_span(run_id)
+        with self._lock:
+            ctx = self._pop_span(run_id)
         if ctx is None:
             return
-        ctx.__exit__(type(error), error, error.__traceback__)
+        self._exit_span(ctx, type(error), error, error.__traceback__)
 
     # -- llm ------------------------------------------------------------------
 
@@ -101,15 +104,13 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        parent = self._span_stack[-1] if self._span_stack else None
-        if parent is None:
-            self.on_chain_start({"name": "llm"}, {"prompts": prompts}, run_id=run_id)
-            return
-        ctx = parent.span("llm.call", data={"prompts": prompts})
-        ctx.__enter__()
-        self._span_stack.append(ctx)
-        if run_id:
-            self._run_to_span[str(run_id)] = ctx
+        with self._lock:
+            parent = self._span_stack[-1] if self._span_stack else None
+            if parent is None:
+                self.on_chain_start({"name": "llm"}, {"prompts": prompts}, run_id=run_id)
+                return
+            ctx_mgr = parent.span("llm.call", data={"prompts": prompts})
+            self._enter_span(ctx_mgr, run_id)
 
     def on_llm_end(
         self,
@@ -118,7 +119,8 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        ctx = self._pop_span(run_id)
+        with self._lock:
+            ctx = self._pop_span(run_id)
         if ctx is None:
             return
         usage = _extract_token_usage(response)
@@ -154,10 +156,10 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
                         "error": str(e),
                     })
                     ctx.event("llm.end", data=payload)
-                    ctx.__exit__(None, None, None)
+                    self._exit_span(ctx, None, None, None)
                     raise
         ctx.event("llm.end", data=payload)
-        ctx.__exit__(None, None, None)
+        self._exit_span(ctx, None, None, None)
 
     def on_llm_error(
         self,
@@ -166,10 +168,11 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        ctx = self._pop_span(run_id)
+        with self._lock:
+            ctx = self._pop_span(run_id)
         if ctx is None:
             return
-        ctx.__exit__(type(error), error, error.__traceback__)
+        self._exit_span(ctx, type(error), error, error.__traceback__)
 
     # -- tools ----------------------------------------------------------------
 
@@ -184,13 +187,14 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         tool_name = serialized.get("name") or serialized.get("id", "tool")
         if isinstance(tool_name, list):
             tool_name = tool_name[-1]
+        with self._lock:
+            current_ctx = self._span_stack[-1] if self._span_stack else None
         if self._loop_guard:
             try:
                 self._loop_guard.check(tool_name=tool_name, tool_args={"input": input_str})
             except LoopDetected as e:
-                ctx = self._span_stack[-1] if self._span_stack else None
-                if ctx:
-                    ctx.event("guard.loop_detected", data={
+                if current_ctx:
+                    current_ctx.event("guard.loop_detected", data={
                         "tool_name": tool_name,
                         "repeat_count": self._loop_guard.max_repeats,
                         "error": str(e),
@@ -200,9 +204,8 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
             try:
                 self._budget_guard.consume(calls=1)
             except BudgetExceeded as e:
-                ctx = self._span_stack[-1] if self._span_stack else None
-                if ctx:
-                    ctx.event("guard.budget_exceeded", data={
+                if current_ctx:
+                    current_ctx.event("guard.budget_exceeded", data={
                         "tokens_used": self._budget_guard.state.tokens_used,
                         "tokens_limit": self._budget_guard.max_tokens,
                         "calls_used": self._budget_guard.state.calls_used,
@@ -210,15 +213,13 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
                         "error": str(e),
                     })
                 raise
-        parent = self._span_stack[-1] if self._span_stack else None
-        if parent is None:
-            self.on_chain_start({"name": "tool"}, {"input": input_str}, run_id=run_id)
-            return
-        ctx = parent.span(f"tool.{tool_name}", data={"input": input_str})
-        ctx.__enter__()
-        self._span_stack.append(ctx)
-        if run_id:
-            self._run_to_span[str(run_id)] = ctx
+        with self._lock:
+            parent = self._span_stack[-1] if self._span_stack else None
+            if parent is None:
+                self.on_chain_start({"name": "tool"}, {"input": input_str}, run_id=run_id)
+                return
+            ctx_mgr = parent.span(f"tool.{tool_name}", data={"input": input_str})
+            self._enter_span(ctx_mgr, run_id)
 
     def on_tool_end(
         self,
@@ -227,11 +228,12 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        ctx = self._pop_span(run_id)
+        with self._lock:
+            ctx = self._pop_span(run_id)
         if ctx is None:
             return
         ctx.event("tool.result", data={"output": str(output)})
-        ctx.__exit__(None, None, None)
+        self._exit_span(ctx, None, None, None)
 
     def on_tool_error(
         self,
@@ -240,22 +242,52 @@ class AgentGuardCallbackHandler(_Base):  # type: ignore[misc]
         run_id: Optional[uuid.UUID] = None,
         **kwargs: Any,
     ) -> None:
-        ctx = self._pop_span(run_id)
+        with self._lock:
+            ctx = self._pop_span(run_id)
         if ctx is None:
             return
-        ctx.__exit__(type(error), error, error.__traceback__)
+        self._exit_span(ctx, type(error), error, error.__traceback__)
 
     # -- helpers --------------------------------------------------------------
+
+    def _enter_span(
+        self,
+        ctx_mgr: AbstractContextManager[TraceContext],
+        run_id: Optional[uuid.UUID],
+    ) -> TraceContext:
+        ctx = ctx_mgr.__enter__()
+        self._span_stack.append(ctx)
+        self._span_contexts[id(ctx)] = ctx_mgr
+        if run_id:
+            self._run_to_span[str(run_id)] = ctx
+        return ctx
 
     def _pop_span(self, run_id: Optional[uuid.UUID]) -> Optional[TraceContext]:
         if run_id and str(run_id) in self._run_to_span:
             ctx = self._run_to_span.pop(str(run_id))
             if ctx in self._span_stack:
-                self._span_stack.remove(ctx)
+                while self._span_stack and self._span_stack[-1] is not ctx:
+                    leaked = self._span_stack.pop()
+                    self._forget_run_for_span(leaked)
+                    self._exit_span(leaked, None, None, None)
+                self._span_stack.pop()
             return ctx
         if self._span_stack:
-            return self._span_stack.pop()
+            ctx = self._span_stack.pop()
+            self._forget_run_for_span(ctx)
+            return ctx
         return None
+
+    def _exit_span(self, ctx: TraceContext, exc_type: Any, exc: Any, tb: Any) -> None:
+        ctx_mgr = self._span_contexts.pop(id(ctx), ctx)
+        ctx_mgr.__exit__(exc_type, exc, tb)
+        if not self._span_stack:
+            self._root_ctx = None
+
+    def _forget_run_for_span(self, ctx: TraceContext) -> None:
+        for run_key, mapped_ctx in list(self._run_to_span.items()):
+            if mapped_ctx is ctx:
+                self._run_to_span.pop(run_key, None)
 
 
 # -- utility functions --------------------------------------------------------
@@ -265,6 +297,18 @@ def _safe_dict(d: Any) -> Dict[str, Any]:
     if isinstance(d, dict):
         return d
     return {"value": repr(d)}
+
+
+def _chain_name(serialized: Dict[str, Any]) -> str:
+    name = serialized.get("name")
+    if name:
+        return str(name)
+    identifier = serialized.get("id")
+    if isinstance(identifier, list) and identifier:
+        return str(identifier[-1])
+    if identifier:
+        return str(identifier)
+    return "chain"
 
 
 def _safe_response(response: Any) -> Dict[str, Any]:

--- a/sdk/tests/test_langchain_integration.py
+++ b/sdk/tests/test_langchain_integration.py
@@ -51,6 +51,26 @@ class TestLangChainIntegration(unittest.TestCase):
         self.assertEqual(handler._run_to_span, {})
         self.assertIsNone(handler._root_ctx)
 
+    def test_stale_child_end_does_not_close_new_active_run(self):
+        handler = AgentGuardCallbackHandler(tracer=self.tracer)
+        chain_id = uuid.uuid4()
+        llm_id = uuid.uuid4()
+
+        handler.on_chain_start({"name": "agent"}, {}, run_id=chain_id)
+        handler.on_llm_start({}, ["prompt"], run_id=llm_id)
+        handler.on_chain_end({"output": "done"}, run_id=chain_id)
+
+        next_chain_id = uuid.uuid4()
+        handler.on_chain_start({"name": "next"}, {}, run_id=next_chain_id)
+        handler.on_llm_end(_MockResponse(), run_id=llm_id)
+
+        self.assertEqual(len(handler._span_stack), 1)
+        self.assertIn(str(next_chain_id), handler._run_to_span)
+        handler.on_chain_end({"output": "done"}, run_id=next_chain_id)
+        self.assertEqual(handler._span_stack, [])
+        self.assertEqual(handler._run_to_span, {})
+        self.assertIsNone(handler._root_ctx)
+
     def test_concurrent_callback_lifecycles_do_not_corrupt_state(self):
         handler = AgentGuardCallbackHandler(tracer=self.tracer)
 

--- a/sdk/tests/test_langchain_integration.py
+++ b/sdk/tests/test_langchain_integration.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import threading
 import unittest
 import uuid
 
@@ -33,6 +34,40 @@ class TestLangChainIntegration(unittest.TestCase):
         kinds = [e["kind"] for e in events]
         self.assertIn("span", kinds)
         self.assertIn("event", kinds)
+        self.assertEqual(handler._span_stack, [])
+        self.assertEqual(handler._run_to_span, {})
+        self.assertIsNone(handler._root_ctx)
+
+    def test_parent_end_closes_never_ended_child_run(self):
+        handler = AgentGuardCallbackHandler(tracer=self.tracer)
+        chain_id = uuid.uuid4()
+        llm_id = uuid.uuid4()
+
+        handler.on_chain_start({"name": "agent"}, {}, run_id=chain_id)
+        handler.on_llm_start({}, ["prompt"], run_id=llm_id)
+        handler.on_chain_end({"output": "done"}, run_id=chain_id)
+
+        self.assertEqual(handler._span_stack, [])
+        self.assertEqual(handler._run_to_span, {})
+        self.assertIsNone(handler._root_ctx)
+
+    def test_concurrent_callback_lifecycles_do_not_corrupt_state(self):
+        handler = AgentGuardCallbackHandler(tracer=self.tracer)
+
+        def run_lifecycle(index: int) -> None:
+            run_id = uuid.uuid4()
+            handler.on_chain_start({"name": f"agent-{index}"}, {"input": index}, run_id=run_id)
+            handler.on_chain_end({"output": index}, run_id=run_id)
+
+        threads = [threading.Thread(target=run_lifecycle, args=(index,)) for index in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(handler._span_stack, [])
+        self.assertEqual(handler._run_to_span, {})
+        self.assertIsNone(handler._root_ctx)
 
     def test_nested_llm_creates_span(self):
         handler = AgentGuardCallbackHandler(tracer=self.tracer)


### PR DESCRIPTION
## Summary
- add locked span/run bookkeeping to `AgentGuardCallbackHandler`
- close owned context managers instead of leaving root trace managers behind
- close leaked child spans when a parent run ends without child end callbacks
- replace nested chain-name ternary with a readable helper
- add cleanup and concurrent lifecycle tests

## Bug class killed
LangChain callback runs no longer leak root contexts or orphan child spans when callback end events are missing or arrive out of normal order.

## Failing-then-passing proof
- Before fix: `test_chain_lifecycle` failed because `_root_ctx` remained set after chain end.
- Before fix: `test_parent_end_closes_never_ended_child_run` failed because the child LLM span remained in `_span_stack`.
- After fix: full LangChain integration suite passes.

## Validation
- `python -m pytest tests/test_langchain_integration.py -q`
- `python -m ruff check sdk\agentguard\integrations\langchain.py sdk\tests\test_langchain_integration.py`

## Notes
`make` is not available in this Windows shell, so I ran direct targeted equivalents for this branch.