### PR TITLE
feat: goal-level metering API (guard.goal context manager)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ context/
 # MCP local auth/build artifacts
 mcp-server/.mcpregistry_github_token
 mcp-server/*.tgz
+/sdk/traces.jsonl

--- a/QA_REPORT.md
+++ b/QA_REPORT.md
@@ -1,0 +1,51 @@
+# QA_REPORT
+
+Verdict: ✅
+
+## Scope alignment
+
+The task body's acceptance criteria, each checked against the diff:
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| `Goal` exposes `cost_usd`, `attempts`, `succeeded`, `failure_cost`, `duration_sec`, `calls`, `to_dict()` | ✅ | `sdk/agentguard/goal.py:44-126` |
+| `BudgetGuard.goal(name, verifier)` context manager | ✅ | `sdk/agentguard/guards.py` new method; verified `with guard.goal(...) as g:` works in test suite |
+| Cost accumulates across nested calls via contextvars | ✅ | `_active_goals: ContextVar` + hook in `BudgetGuard.consume` |
+| Verifier runs on exit, populates `succeeded` | ✅ | `_GoalContext.__exit__` |
+| `g.attempt()` explicit | ✅ | `Goal.attempt()` |
+| `failure_cost` = failed-attempt cost | ✅ | `Goal.failure_cost`, tested by `test_three_attempts_then_success_attributes_failure_cost` |
+| Goals nest cleanly, no double-count | ✅ | `test_nested_goals_no_double_count` |
+| Goals do not cross sessions | ✅ | ContextVar scope; goals are local objects, not module-level state |
+| `to_dict()` JSON-serializable | ✅ | `test_to_dict_is_json_serializable` |
+| Happy-path test | ✅ |
+| 3-attempts-then-success test | ✅ |
+| Nested-goals test | ✅ |
+| Failed-goal test | ✅ |
+| README section | ✅ | `sdk/README.md` new "Goal-level metering" section |
+| All existing tests still pass | ✅ | 769 passed, 0 failed |
+| No new external dependencies | ✅ | Only stdlib (`contextvars`, `dataclasses`, `time`) |
+
+## Path note
+
+Task body said `agent47/goal.py`. Actual package layout is `sdk/agentguard/` — so the new file lives at `sdk/agentguard/goal.py`. This matches the rest of the package (`guards.py`, `cost.py`, etc.). The task wording was shorthand; the implementation respects the real layout.
+
+## Security / denylist check
+
+- No changes under `.github/workflows/`, `.env*`, `supabase/migrations/`, `security/`, secrets, or Stripe/Clerk config.
+- No new credentials or API keys.
+- No new external network calls. The verifier is user-supplied; the SDK itself does not invoke external services here.
+
+## Pattern compliance
+
+- `Goal` and `Call` are `@dataclass` like `BudgetState` (`sdk/agentguard/guards.py:176`).
+- `_GoalContext` follows the same context-manager pattern as `TimeoutGuard` (`sdk/agentguard/guards.py:397-405`).
+- Error type for bad verifier is `TypeError`, matching the type-checking patterns elsewhere in `BudgetGuard.consume` (`sdk/agentguard/guards.py:258-269`).
+- Docstrings include `Usage::` example blocks per existing convention.
+
+## Risk
+
+Low. The diff is 79 lines plus a 200-line new module. The only behavior change to existing code is one function-call append inside `BudgetGuard.consume` that is a no-op when no goal is active. All existing tests including `test_concurrency.py`, `test_cost.py`, `test_e2e_pipeline.py` pass unchanged.
+
+## Test coverage regressions
+
+None. Added 8 new tests; no existing test removed or skipped.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,0 +1,47 @@
+# RESEARCH
+
+## API surface assumption verified
+
+The task body said `guard.goal(name, verifier=...)`. The intel concept page (`Knowledge/concepts/cost-per-completed-goal.md`) sketches `from agentguard47 import AgentGuard; guard = AgentGuard(...)`. The actual package exposes `BudgetGuard` (no class named `AgentGuard`). Source: `sdk/agentguard/__init__.py:18-37` lists every public guard class — `AgentGuard` is not there; only `AgentGuardError`.
+
+Decision: add `goal()` as a method on `BudgetGuard`. The "guard" in the concept page sketch is the budget guard — that is where cost state lives, so it is the natural integration point. Adding a `goal()` method is additive (zero breaking change per the task scope rule).
+
+## Cost accumulation hook
+
+`BudgetGuard.consume(...)` is the single place every dollar gets recorded (`sdk/agentguard/guards.py:244-291`). Hooking goal-attribution there means any caller that uses the standard cost path — including auto-patched OpenAI / Anthropic clients, manual `consume` calls, and integration callbacks — gets goal attribution for free, with no other code changes.
+
+The hook calls `agentguard.goal._record_consume(...)` which reads the innermost active goal via a `ContextVar` and appends a `Call`. No-op when no goal is open.
+
+## ContextVar for nesting + async
+
+`contextvars.ContextVar` is the standard library tool the paper (and Python docs) recommend for per-task state that needs to propagate through `asyncio` and `concurrent.futures` worker callsites. No new dependency required. The active-goal stack is a tuple so nested `with` blocks are unambiguous; pop on exit uses `ContextVar.reset(token)`.
+
+## Failure-cost rule
+
+From the concept page: "failure_cost = portion of cost spent on attempts that failed." Implementation:
+
+- If `succeeded is True` and `attempts >= 1`: every call with `attempt_idx < attempts` is failure cost (the final attempt is the winning one).
+- If `succeeded is False`: every direct call is failure cost.
+- Sub-goal failure cost rolls up.
+
+This requires the caller to call `g.attempt()` at the top of each retry so we can stamp each call's `attempt_idx`. The task body explicitly says v1 keeps `attempt()` explicit (no auto-detection).
+
+## Verifier exception semantics
+
+If the `with` block exits via exception, we do NOT call the verifier — succeeded is forced to False. Rationale: the verifier is a success oracle, not an exception handler. Calling it on an in-flight exception risks masking the real error. Verifier exceptions on clean exit propagate (fail loudly per global instructions).
+
+## Files inspected before writing code
+
+- `sdk/agentguard/__init__.py` — public surface
+- `sdk/agentguard/guards.py` — BudgetGuard, BaseGuard
+- `sdk/agentguard/setup.py` — module-level init pattern (not used for this feature)
+- `sdk/tests/test_cost.py`, `tests/test_concurrency.py` — confirmed no test currently asserts that `consume` does NOT call into any other module (so the hook is safe)
+- `Knowledge/concepts/cost-per-completed-goal.md` — design rationale
+- `Queue/agent47/Complete/energy-per-successful-goal-metric.md` — parent task context
+
+## What did NOT make the cut (v1)
+
+- LLM-as-judge verifiers (explicitly deferred per task scope).
+- Persistence / sink wiring (operators serialize and ship).
+- Dashboard wiring (separate follow-up in agent47-dashboard).
+- Module-level `init()` integration. The setup-pattern path could later expose `agentguard.goal(...)` as a convenience that grabs the configured BudgetGuard, but that is additive on top of the v1 method API.

--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -1,0 +1,41 @@
+# WORK_PLAN: goal-level metering API prototype
+
+## Problem
+AgentGuard today only meters per-session via `BudgetGuard`. Operators care about cost-per-completed-goal (per the arXiv:2605.22883 framing). Ship v1 of a `guard.goal(name, verifier=...)` context manager that buckets nested call costs against a named goal, runs a verifier on exit, and exposes a structured ledger.
+
+## Approach
+- New module `sdk/agentguard/goal.py`:
+  - `Call` dataclass — single accounted call (tokens, calls, cost_usd, attempt_idx, ts).
+  - `Goal` dataclass holding name, verifier, calls, sub-goals, attempts counter, start/end ts. Methods: `attempt()`, `_record(call)`, `to_dict()`. Properties: `cost_usd`, `failure_cost`, `duration_sec`, `succeeded` (set on exit).
+  - `_active_goal_stack: ContextVar[tuple[Goal, ...]]` so nested calls inside async/threadpool see the right goal. The stack holds parent + descendants so we can implement nesting cleanly.
+- `BudgetGuard.goal(name, verifier)` returns a context manager. On `__enter__` pushes a new Goal onto the contextvar stack and records start. On `__exit__` pops, runs verifier, sets succeeded, attaches goal to parent (if any) as a sub-goal.
+- Hook into `BudgetGuard.consume(...)` so that, when a goal is active, we also append a `Call` to the innermost goal. This keeps all existing call accounting intact (no breaking change) and adds goal-bucketing as a side effect.
+- `cost_usd` = own calls + sub-goal totals (no double-count: own calls only contain direct `consume` calls; sub-goals' calls live on the sub-goal objects).
+- `failure_cost` = cost of all calls in failed attempts. An attempt is failed if it is not the final attempt of a successful goal. If `not succeeded`, all calls are failure cost.
+- Verifier MUST be a callable returning bool. We do not catch verifier exceptions — they propagate (fail loudly per global instructions).
+
+## Files likely to touch
+- `sdk/agentguard/goal.py` (new)
+- `sdk/agentguard/guards.py` (BudgetGuard.goal method + hook into consume)
+- `sdk/agentguard/__init__.py` (export Goal)
+- `sdk/tests/test_goal.py` (new)
+- `sdk/README.md` (new section)
+- `README.md` at repo root if it mirrors
+
+## Done checklist
+- [ ] `Goal` exposes `cost_usd`, `attempts`, `succeeded`, `failure_cost`, `duration_sec`, `calls`, `to_dict()`.
+- [ ] `BudgetGuard.goal(name, verifier)` works as a context manager.
+- [ ] Nested goals: parent total = own + sub totals, no double count.
+- [ ] Happy path test (1 attempt, succeeds).
+- [ ] 3-attempts-then-success test (failure_cost > 0).
+- [ ] Nested goals test.
+- [ ] Failed goal test (succeeded=False, full cost = failure cost).
+- [ ] README section "Goal-level metering".
+- [ ] All existing tests still pass.
+- [ ] No new external deps.
+
+## Risks / assumptions
+- Hooking into `BudgetGuard.consume` is the right integration point. Alternative would be a separate `record_call` API, but consume is already where every cost lands. The hook is one append; zero behavior change when no goal is active.
+- Contextvars are the right propagation mechanism (async + threadpool safe, as the paper assumes). The standard lib provides this — no new deps.
+- Verifier contract is binary bool in v1 (per task scope). Fuzzy verifiers are v2.
+- Per the concept page sketch, the `guard` in `with guard.goal(...)` is a `BudgetGuard` instance (the only "guard" with cost state). The concept page's reference to `AgentGuard(budget_usd=5.00)` is aspirational naming — current package uses `BudgetGuard(max_cost_usd=...)`. We stay consistent with the existing API.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -141,6 +141,49 @@ rate = RateLimitGuard(max_calls_per_minute=60)
 rate.check()
 ```
 
+## Goal-level metering
+
+Measuring cost per completed goal, not per call.
+
+`BudgetGuard.consume(...)` records token / call / dollar spend. When you wrap
+work inside a `guard.goal(...)` block, every `consume(...)` made inside the
+block (including nested function calls, async tasks, or threadpool workers
+via `contextvars`) is also attributed to that goal. On block exit, the
+verifier you supply runs and the goal's `succeeded` flag is set. Failed
+attempts are billed as `failure_cost` so you can see the "failure tax" line
+item directly.
+
+```python
+from agentguard import BudgetGuard
+
+guard = BudgetGuard(max_cost_usd=5.00)
+
+def refund_verified() -> bool:
+    return stripe.charges.retrieve("ch_abc123").refunded
+
+with guard.goal("refund ch_abc123", verifier=refund_verified) as g:
+    for _ in range(3):
+        g.attempt()
+        try:
+            agent.run_until_done()
+            break
+        except TransientFailure:
+            continue
+
+print(g.cost_usd)      # 0.42  -- total spend across all attempts
+print(g.attempts)      # 3
+print(g.succeeded)     # True
+print(g.failure_cost)  # 0.31  -- cost of attempts 1 and 2
+print(g.duration_sec)  # 47.2
+print(g.to_dict())     # JSON-serializable ledger
+```
+
+Goals nest. A parent goal that spawns sub-goals reports `cost_usd` as own
+direct calls plus sub-goal totals (no double-counting). Goals do not cross
+sessions; serialize and ship the ledger to your dashboard or analytics
+pipeline. v1 requires a binary callable verifier (LLM-as-judge is a future
+extension).
+
 ## Auto-Instrumentation
 
 ```python

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -16,6 +16,7 @@ from .decision import (
     log_decision_proposed,
 )
 from .evaluation import AssertionResult, EvalResult, EvalSuite, summarize_trace
+from .goal import Call, Goal
 from .guards import (
     AgentGuardError,
     BaseGuard,
@@ -80,12 +81,14 @@ __all__ = [
     "BudgetExceeded",
     "BudgetGuard",
     "BudgetWarning",
+    "Call",
     "DecisionTrace",
     "EscalationRequired",
     "EscalationSignal",
     "EvalResult",
     "EvalSuite",
     "FuzzyLoopGuard",
+    "Goal",
     "HttpSink",
     "InitConfig",
     "JsonlFileSink",

--- a/sdk/agentguard/goal.py
+++ b/sdk/agentguard/goal.py
@@ -164,7 +164,7 @@ class _GoalContext:
         if parent is not None:
             parent.sub_goals.append(self._goal)
         self._goal.start_ts = time.time()
-        self._token = _active_goals.set(_active_goals.get() + (self._goal,))
+        self._token = _active_goals.set((*_active_goals.get(), self._goal))
         return self._goal
 
     def __exit__(self, exc_type, exc, tb) -> None:

--- a/sdk/agentguard/goal.py
+++ b/sdk/agentguard/goal.py
@@ -1,0 +1,198 @@
+"""Goal-level metering for AgentGuard.
+
+A ``Goal`` is a user-meaningful outcome (e.g. "refund this charge"). One goal
+may span many model calls, tool calls, retries, and dead ends. Per-call cost
+metering hides that structure; goal-level metering exposes it.
+
+Use ``BudgetGuard.goal(name, verifier=...)`` to open a goal block. Any cost
+consumed via ``BudgetGuard.consume(...)`` inside that block accumulates against
+the goal. On exit, the verifier runs and ``g.succeeded`` is populated. Failed
+attempts (anything before the final attempt of a successful goal, or every
+attempt of a failed goal) accrue ``g.failure_cost``.
+
+See ``concepts/cost-per-completed-goal`` in the knowledge wiki for the design
+rationale.
+"""
+from __future__ import annotations
+
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+@dataclass
+class Call:
+    """A single accounted call inside a goal block."""
+
+    tokens: int
+    calls: int
+    cost_usd: float
+    attempt_idx: int
+    ts: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tokens": self.tokens,
+            "calls": self.calls,
+            "cost_usd": self.cost_usd,
+            "attempt_idx": self.attempt_idx,
+            "ts": self.ts,
+        }
+
+
+@dataclass
+class Goal:
+    """A goal ledger.
+
+    Populated as nested calls execute inside ``BudgetGuard.goal(...)``. The
+    block-exit handler runs the verifier and sets ``succeeded``.
+
+    Attributes:
+        name: Caller-supplied label for the goal.
+        verifier: Zero-arg callable returning bool. Runs on block exit.
+        calls: Direct calls recorded inside this goal (not sub-goals).
+        sub_goals: Child goals opened inside this goal's block.
+        attempts: Number of attempts (incremented by ``attempt()`` from agent code).
+        succeeded: Whether the verifier returned True. ``None`` until exit.
+        start_ts: Wall-clock at block enter.
+        end_ts: Wall-clock at block exit. ``None`` until exit.
+    """
+
+    name: str
+    verifier: Callable[[], bool]
+    calls: List[Call] = field(default_factory=list)
+    sub_goals: List["Goal"] = field(default_factory=list)
+    attempts: int = 0
+    succeeded: Optional[bool] = None
+    start_ts: float = 0.0
+    end_ts: Optional[float] = None
+
+    def attempt(self) -> int:
+        """Mark the start of a new attempt. Returns the new attempt index (1-based).
+
+        Agent code calls this at the top of each retry so failure cost can be
+        attributed correctly. Explicit per task scope (v1 does not auto-detect
+        attempts).
+        """
+        self.attempts += 1
+        return self.attempts
+
+    def _record(self, call: Call) -> None:
+        """Append a Call. Intended for internal use by ``BudgetGuard.consume``."""
+        self.calls.append(call)
+
+    @property
+    def own_cost_usd(self) -> float:
+        """Cost of direct calls, excluding sub-goals."""
+        return sum(c.cost_usd for c in self.calls)
+
+    @property
+    def cost_usd(self) -> float:
+        """Total cost: direct calls + sub-goal totals. No double count."""
+        return self.own_cost_usd + sum(g.cost_usd for g in self.sub_goals)
+
+    @property
+    def failure_cost(self) -> float:
+        """Cost of calls in failed attempts.
+
+        If the goal succeeded and ``attempts >= 1``, calls with
+        ``attempt_idx < attempts`` are failure cost (the final attempt is the
+        winning one). If the goal failed, every direct call is failure cost.
+        Sub-goal failure cost rolls up the same way.
+        """
+        if self.succeeded is False:
+            own = self.own_cost_usd
+        elif self.succeeded is True and self.attempts >= 1:
+            final = self.attempts
+            own = sum(c.cost_usd for c in self.calls if c.attempt_idx < final)
+        else:
+            # succeeded is None (still open) or attempts == 0
+            own = 0.0
+        return own + sum(g.failure_cost for g in self.sub_goals)
+
+    @property
+    def duration_sec(self) -> float:
+        end = self.end_ts if self.end_ts is not None else time.time()
+        return end - self.start_ts
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON."""
+        return {
+            "name": self.name,
+            "cost_usd": self.cost_usd,
+            "own_cost_usd": self.own_cost_usd,
+            "failure_cost": self.failure_cost,
+            "attempts": self.attempts,
+            "succeeded": self.succeeded,
+            "duration_sec": self.duration_sec,
+            "calls": [c.to_dict() for c in self.calls],
+            "sub_goals": [g.to_dict() for g in self.sub_goals],
+        }
+
+
+# Stack of active goals, innermost last. Goals are popped on block exit.
+# ContextVar so async + threadpool callsites see the correct innermost goal.
+_active_goals: ContextVar[Tuple[Goal, ...]] = ContextVar(
+    "agentguard_active_goals", default=()
+)
+
+
+def _current_goal() -> Optional[Goal]:
+    """Return the innermost active goal, or None if no goal block is open."""
+    stack = _active_goals.get()
+    return stack[-1] if stack else None
+
+
+class _GoalContext:
+    """Context manager returned by ``BudgetGuard.goal(...)``.
+
+    Exiting the block runs the verifier and finalizes the goal ledger.
+    Verifier exceptions propagate (fail loudly).
+    """
+
+    def __init__(self, name: str, verifier: Callable[[], bool]) -> None:
+        if not callable(verifier):
+            raise TypeError(
+                f"verifier must be callable, got {type(verifier).__name__}"
+            )
+        self._goal = Goal(name=name, verifier=verifier)
+        self._token = None  # type: ignore[assignment]
+
+    def __enter__(self) -> Goal:
+        parent = _current_goal()
+        if parent is not None:
+            parent.sub_goals.append(self._goal)
+        self._goal.start_ts = time.time()
+        self._token = _active_goals.set(_active_goals.get() + (self._goal,))
+        return self._goal
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._goal.end_ts = time.time()
+        if self._token is not None:
+            _active_goals.reset(self._token)
+        # Only run the verifier if the block exited cleanly. If an exception
+        # is propagating, the goal clearly did not succeed; do not also swallow
+        # by calling the verifier.
+        if exc_type is None:
+            self._goal.succeeded = bool(self._goal.verifier())
+        else:
+            self._goal.succeeded = False
+
+
+def _record_consume(tokens: int, calls: int, cost_usd: float) -> None:
+    """Hook called from ``BudgetGuard.consume`` to attribute the call to the
+    innermost active goal, if any. No-op when no goal is active.
+    """
+    goal = _current_goal()
+    if goal is None:
+        return
+    goal._record(
+        Call(
+            tokens=int(tokens),
+            calls=int(calls),
+            cost_usd=float(cost_usd),
+            attempt_idx=goal.attempts if goal.attempts > 0 else 1,
+            ts=time.time(),
+        )
+    )

--- a/sdk/agentguard/guards.py
+++ b/sdk/agentguard/guards.py
@@ -267,6 +267,11 @@ class BudgetGuard(BaseGuard):
             raise TypeError(
                 f"cost_usd must be a number, got {type(cost_usd).__name__}: {cost_usd!r}"
             )
+        # Attribute the call to any active goal BEFORE budget checks so the
+        # goal ledger includes the call even when this consume call is the one
+        # that trips BudgetExceeded.
+        from .goal import _record_consume
+        _record_consume(tokens=tokens, calls=calls, cost_usd=cost_usd)
         with self._lock:
             self.state.tokens_used += tokens
             self.state.calls_used += calls
@@ -336,6 +341,33 @@ class BudgetGuard(BaseGuard):
         if self._max_cost_usd is not None:
             parts.append(f"max_cost_usd={self._max_cost_usd}")
         return f"BudgetGuard({', '.join(parts)})"
+
+    def goal(self, name: str, verifier: Callable[[], bool]) -> Any:
+        """Open a goal-level metering block.
+
+        Returns a context manager. Inside the block, every ``consume(...)`` call
+        is also recorded against the goal's ledger. On block exit, ``verifier``
+        runs and ``g.succeeded`` is populated.
+
+        Example::
+
+            guard = BudgetGuard(max_cost_usd=5.00)
+            with guard.goal("refund ch_abc123", verifier=refund_ok) as g:
+                g.attempt()
+                agent.run_until_done()
+            print(g.cost_usd, g.attempts, g.succeeded, g.failure_cost)
+
+        See ``agentguard.goal.Goal`` for the full ledger shape.
+
+        Args:
+            name: Caller-supplied label for the goal.
+            verifier: Zero-arg callable returning bool.
+
+        Returns:
+            A context manager that yields a ``Goal`` instance.
+        """
+        from .goal import _GoalContext
+        return _GoalContext(name, verifier)
 
 
 class TimeoutGuard(BaseGuard):

--- a/sdk/tests/test_exports.py
+++ b/sdk/tests/test_exports.py
@@ -139,6 +139,7 @@ class TestTopLevelExports(unittest.TestCase):
             "patch_openai_async", "patch_anthropic_async",
             "unpatch_openai_async", "unpatch_anthropic_async",
             "InitConfig", "RepoConfig", "ProfileDefaults", "SUPPORTED_PROFILES",
+            "Goal", "Call",
         }
         self.assertEqual(set(agentguard.__all__), expected)
 

--- a/sdk/tests/test_goal.py
+++ b/sdk/tests/test_goal.py
@@ -1,0 +1,156 @@
+"""Tests for goal-level metering (BudgetGuard.goal)."""
+from __future__ import annotations
+
+import pytest
+
+from agentguard import BudgetGuard, Goal
+
+
+def test_happy_path_single_attempt_succeeds() -> None:
+    """One attempt, verifier returns True, no failure cost."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+    verified = {"ok": True}
+
+    with guard.goal("simple-goal", verifier=lambda: verified["ok"]) as g:
+        g.attempt()
+        guard.consume(tokens=100, calls=1, cost_usd=0.05)
+        guard.consume(tokens=50, calls=1, cost_usd=0.02)
+
+    assert isinstance(g, Goal)
+    assert g.succeeded is True
+    assert g.attempts == 1
+    assert g.cost_usd == pytest.approx(0.07)
+    assert g.failure_cost == pytest.approx(0.0)
+    assert len(g.calls) == 2
+    assert g.duration_sec >= 0
+
+
+def test_three_attempts_then_success_attributes_failure_cost() -> None:
+    """3 attempts, last succeeds. Cost of first two attempts is failure cost."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+    succeeded_flag = {"ok": False}
+
+    with guard.goal("retry-goal", verifier=lambda: succeeded_flag["ok"]) as g:
+        # Attempt 1 - fails (the verifier won't see this, but the attempt
+        # counter accumulates calls under attempt_idx=1).
+        g.attempt()
+        guard.consume(tokens=100, calls=1, cost_usd=0.10)
+
+        # Attempt 2 - fails.
+        g.attempt()
+        guard.consume(tokens=120, calls=1, cost_usd=0.12)
+
+        # Attempt 3 - succeeds.
+        g.attempt()
+        guard.consume(tokens=80, calls=1, cost_usd=0.08)
+        succeeded_flag["ok"] = True
+
+    assert g.succeeded is True
+    assert g.attempts == 3
+    assert g.cost_usd == pytest.approx(0.30)
+    # Failure cost = cost of attempts 1 and 2 = 0.10 + 0.12 = 0.22
+    assert g.failure_cost == pytest.approx(0.22)
+    assert len(g.calls) == 3
+    assert [c.attempt_idx for c in g.calls] == [1, 2, 3]
+
+
+def test_failed_goal_all_cost_is_failure_cost() -> None:
+    """Verifier returns False. All direct calls count as failure cost."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+
+    with guard.goal("doomed", verifier=lambda: False) as g:
+        g.attempt()
+        guard.consume(tokens=50, calls=1, cost_usd=0.05)
+        g.attempt()
+        guard.consume(tokens=50, calls=1, cost_usd=0.05)
+
+    assert g.succeeded is False
+    assert g.cost_usd == pytest.approx(0.10)
+    assert g.failure_cost == pytest.approx(0.10)
+
+
+def test_nested_goals_no_double_count() -> None:
+    """Parent total = own calls + sub-goal totals, with no double-counting."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+
+    with guard.goal("parent", verifier=lambda: True) as parent:
+        parent.attempt()
+        guard.consume(tokens=10, calls=1, cost_usd=0.01)  # parent direct
+
+        with guard.goal("child-a", verifier=lambda: True) as child_a:
+            child_a.attempt()
+            guard.consume(tokens=20, calls=1, cost_usd=0.02)  # child-a only
+
+        with guard.goal("child-b", verifier=lambda: True) as child_b:
+            child_b.attempt()
+            guard.consume(tokens=30, calls=1, cost_usd=0.03)  # child-b only
+
+        guard.consume(tokens=5, calls=1, cost_usd=0.005)  # parent direct (post-child)
+
+    assert child_a.cost_usd == pytest.approx(0.02)
+    assert child_b.cost_usd == pytest.approx(0.03)
+    assert parent.own_cost_usd == pytest.approx(0.015)
+    # Total = 0.015 (parent direct) + 0.02 + 0.03 = 0.065
+    assert parent.cost_usd == pytest.approx(0.065)
+    # Child calls must not also appear in parent.calls (no double count).
+    assert len(parent.calls) == 2
+    assert len(child_a.calls) == 1
+    assert len(child_b.calls) == 1
+    # All sub-goals succeeded so failure cost rolls up to 0.
+    assert parent.failure_cost == pytest.approx(0.0)
+
+
+def test_verifier_must_be_callable() -> None:
+    guard = BudgetGuard(max_cost_usd=1.0)
+    with pytest.raises(TypeError):
+        guard.goal("bad", verifier="not-callable")  # type: ignore[arg-type]
+
+
+def test_exception_inside_block_marks_goal_failed() -> None:
+    """If the block exits with an exception, succeeded=False and verifier
+    is NOT called (fail loudly is upstream's job)."""
+    guard = BudgetGuard(max_cost_usd=1.0)
+    verifier_called = {"called": False}
+
+    def verifier() -> bool:
+        verifier_called["called"] = True
+        return True
+
+    with pytest.raises(ValueError):
+        with guard.goal("crash", verifier=verifier) as g:
+            g.attempt()
+            guard.consume(tokens=10, calls=1, cost_usd=0.01)
+            raise ValueError("boom")
+
+    assert g.succeeded is False
+    assert verifier_called["called"] is False
+    # Cost still recorded.
+    assert g.cost_usd == pytest.approx(0.01)
+
+
+def test_consume_outside_goal_is_unaffected() -> None:
+    """The hook is a pure no-op when no goal is active. Budget guard semantics
+    unchanged."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+    guard.consume(tokens=100, calls=1, cost_usd=0.05)
+    assert guard.state.cost_used == pytest.approx(0.05)
+    assert guard.state.calls_used == 1
+
+
+def test_to_dict_is_json_serializable() -> None:
+    import json
+
+    guard = BudgetGuard(max_cost_usd=1.0)
+    with guard.goal("serialize-me", verifier=lambda: True) as g:
+        g.attempt()
+        guard.consume(tokens=10, calls=1, cost_usd=0.01)
+
+    payload = g.to_dict()
+    # Must round-trip through JSON without error.
+    serialized = json.dumps(payload)
+    parsed = json.loads(serialized)
+    assert parsed["name"] == "serialize-me"
+    assert parsed["succeeded"] is True
+    assert parsed["attempts"] == 1
+    assert parsed["cost_usd"] == pytest.approx(0.01)
+    assert len(parsed["calls"]) == 1


### PR DESCRIPTION
## Summary
- Adds `BudgetGuard.goal(name, verifier)` context manager that buckets nested call costs against a named goal, runs a verifier on exit, and exposes a structured ledger including `failure_cost`. Implements the cost-per-completed-goal unit-economics framing from arXiv:2605.22883.
- New `sdk/agentguard/goal.py` with `Goal` + `Call` dataclasses and a `ContextVar`-based active-goal stack so nesting works through `async` + threadpools. `BudgetGuard.consume` hooks into the active goal as a side effect; no breaking change for callers that do not open goals.
- README section "Goal-level metering" with canonical example. No new dependencies.

## Test plan
- [x] 8 new tests in `sdk/tests/test_goal.py` cover happy path, 3-attempts-then-success (failure_cost > 0), nested goals (no double-count), failed goal (full cost = failure cost), exception inside block, verifier validation, consume-outside-goal no-op, and JSON serialization.
- [x] Full SDK suite green: 769 passed, 0 failed.
- [x] Pylint/mypy unchanged; only stdlib imports added.

## Artifacts
- `WORK_PLAN.md`, `RESEARCH.md`, `QA_REPORT.md` at repo root.
- Source card: `Knowledge/concepts/cost-per-completed-goal.md`.
- Closes queue task: `Queue/agent47/goal-level-metering-api-prototype.md`.

## Risk
Low. The only behavior change to existing code is one no-op append inside `BudgetGuard.consume` when no goal block is active. All existing tests pass unchanged.