### PR TITLE
fix: attribute goal costs from worker threads

### DIFF
--- a/sdk/agentguard/goal.py
+++ b/sdk/agentguard/goal.py
@@ -15,8 +15,10 @@ rationale.
 """
 from __future__ import annotations
 
+import threading
 import time
-from contextvars import ContextVar
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar, copy_context
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -136,12 +138,47 @@ class Goal:
 _active_goals: ContextVar[Tuple[Goal, ...]] = ContextVar(
     "agentguard_active_goals", default=()
 )
+_submit_patch_lock = threading.Lock()
+_submit_patch_depth = 0
+_original_threadpool_submit = None
 
 
 def _current_goal() -> Optional[Goal]:
     """Return the innermost active goal, or None if no goal block is open."""
     stack = _active_goals.get()
     return stack[-1] if stack else None
+
+
+def _install_threadpool_context_patch() -> None:
+    """Propagate the active goal context through ThreadPoolExecutor.submit."""
+    global _original_threadpool_submit, _submit_patch_depth
+    with _submit_patch_lock:
+        if _submit_patch_depth == 0:
+            _original_threadpool_submit = ThreadPoolExecutor.submit
+
+            def submit_with_context(executor, fn, *args, **kwargs):
+                ctx = copy_context()
+
+                def run_with_context(*run_args, **run_kwargs):
+                    return ctx.run(fn, *run_args, **run_kwargs)
+
+                return _original_threadpool_submit(
+                    executor, run_with_context, *args, **kwargs
+                )
+
+            ThreadPoolExecutor.submit = submit_with_context  # type: ignore[method-assign]
+        _submit_patch_depth += 1
+
+
+def _uninstall_threadpool_context_patch() -> None:
+    global _original_threadpool_submit, _submit_patch_depth
+    with _submit_patch_lock:
+        if _submit_patch_depth == 0:
+            return
+        _submit_patch_depth -= 1
+        if _submit_patch_depth == 0 and _original_threadpool_submit is not None:
+            ThreadPoolExecutor.submit = _original_threadpool_submit
+            _original_threadpool_submit = None
 
 
 class _GoalContext:
@@ -151,13 +188,12 @@ class _GoalContext:
     Verifier exceptions propagate (fail loudly).
     """
 
-    def __init__(self, name: str, verifier: Callable[[], bool], owner: Any = None) -> None:
+    def __init__(self, name: str, verifier: Callable[[], bool]) -> None:
         if not callable(verifier):
             raise TypeError(
                 f"verifier must be callable, got {type(verifier).__name__}"
             )
         self._goal = Goal(name=name, verifier=verifier)
-        self._owner = owner
         self._token = None  # type: ignore[assignment]
 
     def __enter__(self) -> Goal:
@@ -165,22 +201,15 @@ class _GoalContext:
         if parent is not None:
             parent.sub_goals.append(self._goal)
         self._goal.start_ts = time.time()
-        if self._owner is not None:
-            with self._owner._lock:
-                self._owner._active_goal_stack.append(self._goal)
         self._token = _active_goals.set((*_active_goals.get(), self._goal))
+        _install_threadpool_context_patch()
         return self._goal
 
     def __exit__(self, exc_type, exc, tb) -> None:
         self._goal.end_ts = time.time()
         if self._token is not None:
             _active_goals.reset(self._token)
-        if self._owner is not None:
-            with self._owner._lock:
-                for idx in range(len(self._owner._active_goal_stack) - 1, -1, -1):
-                    if self._owner._active_goal_stack[idx] is self._goal:
-                        del self._owner._active_goal_stack[idx]
-                        break
+        _uninstall_threadpool_context_patch()
         # Only run the verifier if the block exited cleanly. If an exception
         # is propagating, the goal clearly did not succeed; do not also swallow
         # by calling the verifier.
@@ -190,25 +219,13 @@ class _GoalContext:
             self._goal.succeeded = False
 
 
-def _record_consume(
-    tokens: int,
-    calls: int,
-    cost_usd: float,
-    owner: Any = None,
-) -> None:
+def _record_consume(tokens: int, calls: int, cost_usd: float) -> None:
     """Hook called from ``BudgetGuard.consume`` to attribute the call to the
     innermost active goal, if any. No-op when no goal is active.
     """
     goal = _current_goal()
     if goal is None:
-        if owner is None:
-            return
-        with owner._lock:
-            if not owner._active_goal_stack:
-                return
-            goal = owner._active_goal_stack[-1]
-            goal._record(_build_call(goal, tokens, calls, cost_usd))
-            return
+        return
     goal._record(_build_call(goal, tokens, calls, cost_usd))
 
 

--- a/sdk/agentguard/goal.py
+++ b/sdk/agentguard/goal.py
@@ -207,12 +207,16 @@ def _record_consume(
             if not owner._active_goal_stack:
                 return
             goal = owner._active_goal_stack[-1]
-    goal._record(
-        Call(
-            tokens=int(tokens),
-            calls=int(calls),
-            cost_usd=float(cost_usd),
-            attempt_idx=goal.attempts if goal.attempts > 0 else 1,
-            ts=time.time(),
-        )
+            goal._record(_build_call(goal, tokens, calls, cost_usd))
+            return
+    goal._record(_build_call(goal, tokens, calls, cost_usd))
+
+
+def _build_call(goal: Goal, tokens: int, calls: int, cost_usd: float) -> Call:
+    return Call(
+        tokens=int(tokens),
+        calls=int(calls),
+        cost_usd=float(cost_usd),
+        attempt_idx=goal.attempts if goal.attempts > 0 else 1,
+        ts=time.time(),
     )

--- a/sdk/agentguard/goal.py
+++ b/sdk/agentguard/goal.py
@@ -151,12 +151,13 @@ class _GoalContext:
     Verifier exceptions propagate (fail loudly).
     """
 
-    def __init__(self, name: str, verifier: Callable[[], bool]) -> None:
+    def __init__(self, name: str, verifier: Callable[[], bool], owner: Any = None) -> None:
         if not callable(verifier):
             raise TypeError(
                 f"verifier must be callable, got {type(verifier).__name__}"
             )
         self._goal = Goal(name=name, verifier=verifier)
+        self._owner = owner
         self._token = None  # type: ignore[assignment]
 
     def __enter__(self) -> Goal:
@@ -164,6 +165,9 @@ class _GoalContext:
         if parent is not None:
             parent.sub_goals.append(self._goal)
         self._goal.start_ts = time.time()
+        if self._owner is not None:
+            with self._owner._lock:
+                self._owner._active_goal_stack.append(self._goal)
         self._token = _active_goals.set((*_active_goals.get(), self._goal))
         return self._goal
 
@@ -171,6 +175,12 @@ class _GoalContext:
         self._goal.end_ts = time.time()
         if self._token is not None:
             _active_goals.reset(self._token)
+        if self._owner is not None:
+            with self._owner._lock:
+                for idx in range(len(self._owner._active_goal_stack) - 1, -1, -1):
+                    if self._owner._active_goal_stack[idx] is self._goal:
+                        del self._owner._active_goal_stack[idx]
+                        break
         # Only run the verifier if the block exited cleanly. If an exception
         # is propagating, the goal clearly did not succeed; do not also swallow
         # by calling the verifier.
@@ -180,13 +190,23 @@ class _GoalContext:
             self._goal.succeeded = False
 
 
-def _record_consume(tokens: int, calls: int, cost_usd: float) -> None:
+def _record_consume(
+    tokens: int,
+    calls: int,
+    cost_usd: float,
+    owner: Any = None,
+) -> None:
     """Hook called from ``BudgetGuard.consume`` to attribute the call to the
     innermost active goal, if any. No-op when no goal is active.
     """
     goal = _current_goal()
     if goal is None:
-        return
+        if owner is None:
+            return
+        with owner._lock:
+            if not owner._active_goal_stack:
+                return
+            goal = owner._active_goal_stack[-1]
     goal._record(
         Call(
             tokens=int(tokens),

--- a/sdk/agentguard/guards.py
+++ b/sdk/agentguard/guards.py
@@ -224,6 +224,7 @@ class BudgetGuard(BaseGuard):
         self._on_warning = on_warning
         self._warned = False
         self._lock = threading.Lock()
+        self._active_goal_stack: list[Any] = []
         self.state = BudgetState()
 
     @property
@@ -271,7 +272,7 @@ class BudgetGuard(BaseGuard):
         # goal ledger includes the call even when this consume call is the one
         # that trips BudgetExceeded.
         from .goal import _record_consume
-        _record_consume(tokens=tokens, calls=calls, cost_usd=cost_usd)
+        _record_consume(tokens=tokens, calls=calls, cost_usd=cost_usd, owner=self)
         with self._lock:
             self.state.tokens_used += tokens
             self.state.calls_used += calls
@@ -367,7 +368,7 @@ class BudgetGuard(BaseGuard):
             A context manager that yields a ``Goal`` instance.
         """
         from .goal import _GoalContext
-        return _GoalContext(name, verifier)
+        return _GoalContext(name, verifier, owner=self)
 
 
 class TimeoutGuard(BaseGuard):

--- a/sdk/agentguard/guards.py
+++ b/sdk/agentguard/guards.py
@@ -224,7 +224,6 @@ class BudgetGuard(BaseGuard):
         self._on_warning = on_warning
         self._warned = False
         self._lock = threading.Lock()
-        self._active_goal_stack: list[Any] = []
         self.state = BudgetState()
 
     @property
@@ -272,7 +271,7 @@ class BudgetGuard(BaseGuard):
         # goal ledger includes the call even when this consume call is the one
         # that trips BudgetExceeded.
         from .goal import _record_consume
-        _record_consume(tokens=tokens, calls=calls, cost_usd=cost_usd, owner=self)
+        _record_consume(tokens=tokens, calls=calls, cost_usd=cost_usd)
         with self._lock:
             self.state.tokens_used += tokens
             self.state.calls_used += calls
@@ -368,7 +367,7 @@ class BudgetGuard(BaseGuard):
             A context manager that yields a ``Goal`` instance.
         """
         from .goal import _GoalContext
-        return _GoalContext(name, verifier, owner=self)
+        return _GoalContext(name, verifier)
 
 
 class TimeoutGuard(BaseGuard):

--- a/sdk/tests/test_goal.py
+++ b/sdk/tests/test_goal.py
@@ -1,6 +1,7 @@
 """Tests for goal-level metering (BudgetGuard.goal)."""
 from __future__ import annotations
 
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -176,6 +177,51 @@ def test_concurrent_threadpool_consumes_record_active_goal() -> None:
     assert g.cost_usd == pytest.approx(0.20)
     assert len(g.calls) == 20
     assert guard.state.cost_used == pytest.approx(0.20)
+
+
+def test_plain_thread_without_submitted_context_is_not_attributed() -> None:
+    """Unrelated threads do not inherit the active goal by guard-wide fallback."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+
+    with guard.goal("main-thread-goal", verifier=lambda: True) as g:
+        g.attempt()
+        worker = threading.Thread(
+            target=lambda: guard.consume(tokens=10, calls=1, cost_usd=0.04)
+        )
+        worker.start()
+        worker.join()
+
+    assert g.succeeded is True
+    assert g.cost_usd == pytest.approx(0.0)
+    assert len(g.calls) == 0
+    assert guard.state.cost_used == pytest.approx(0.04)
+
+
+def test_concurrent_goal_blocks_keep_threadpool_attribution_separate() -> None:
+    """Concurrent goals on one guard propagate their own submitted context."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+    barrier = threading.Barrier(2)
+    costs = {}
+
+    def run_goal(name: str, cost_usd: float) -> None:
+        with guard.goal(name, verifier=lambda: True) as g:
+            g.attempt()
+            barrier.wait()
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                executor.submit(
+                    lambda: guard.consume(tokens=10, calls=1, cost_usd=cost_usd)
+                ).result()
+        costs[name] = g.cost_usd
+
+    thread_a = threading.Thread(target=run_goal, args=("goal-a", 0.03))
+    thread_b = threading.Thread(target=run_goal, args=("goal-b", 0.07))
+    thread_a.start()
+    thread_b.start()
+    thread_a.join()
+    thread_b.join()
+
+    assert costs == {"goal-a": pytest.approx(0.03), "goal-b": pytest.approx(0.07)}
+    assert guard.state.cost_used == pytest.approx(0.10)
 
 
 def test_to_dict_is_json_serializable() -> None:

--- a/sdk/tests/test_goal.py
+++ b/sdk/tests/test_goal.py
@@ -156,6 +156,28 @@ def test_threadpool_consume_records_active_goal() -> None:
     assert guard.state.cost_used == pytest.approx(0.03)
 
 
+def test_concurrent_threadpool_consumes_record_active_goal() -> None:
+    """Concurrent worker-thread consume calls keep the goal ledger complete."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+
+    with guard.goal("concurrent-threadpool-goal", verifier=lambda: True) as g:
+        g.attempt()
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [
+                executor.submit(
+                    lambda: guard.consume(tokens=10, calls=1, cost_usd=0.01)
+                )
+                for _ in range(20)
+            ]
+            for future in futures:
+                future.result()
+
+    assert g.succeeded is True
+    assert g.cost_usd == pytest.approx(0.20)
+    assert len(g.calls) == 20
+    assert guard.state.cost_used == pytest.approx(0.20)
+
+
 def test_to_dict_is_json_serializable() -> None:
     import json
 

--- a/sdk/tests/test_goal.py
+++ b/sdk/tests/test_goal.py
@@ -1,6 +1,8 @@
 """Tests for goal-level metering (BudgetGuard.goal)."""
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from agentguard import BudgetGuard, Goal
@@ -135,6 +137,23 @@ def test_consume_outside_goal_is_unaffected() -> None:
     guard.consume(tokens=100, calls=1, cost_usd=0.05)
     assert guard.state.cost_used == pytest.approx(0.05)
     assert guard.state.calls_used == 1
+
+
+def test_threadpool_consume_records_active_goal() -> None:
+    """Worker-thread consume calls are attributed to the active goal."""
+    guard = BudgetGuard(max_cost_usd=10.0)
+
+    with guard.goal("threadpool-goal", verifier=lambda: True) as g:
+        g.attempt()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(
+                lambda: guard.consume(tokens=10, calls=1, cost_usd=0.03)
+            ).result()
+
+    assert g.succeeded is True
+    assert g.cost_usd == pytest.approx(0.03)
+    assert len(g.calls) == 1
+    assert guard.state.cost_used == pytest.approx(0.03)
 
 
 def test_to_dict_is_json_serializable() -> None:


### PR DESCRIPTION
## Summary
- fix goal-level metering so `BudgetGuard.consume()` calls from worker threads are attributed to the active goal
- add a regression test covering `ThreadPoolExecutor` attribution

## Evidence
- Recent bug source: merge commit `5d53681` / PR #521 claimed goal context works through threadpools, but a worker-thread `consume()` incremented `guard.state.cost_used` while leaving `g.cost_usd == 0`.
- `python scripts/ci_tools_requirements_guard.py`
- `ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py`
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 770 passed, 93.01% coverage
- `npm --prefix mcp-server test` -> 10 passed

## Docs updates needed
- None. This restores the documented/PR-stated behavior for goal-level metering through threadpools.