### PR TITLE
docs(readme): cite MSFT Claude Code cost retreat as validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ A 9-second sequence of destructive calls trips `LoopGuard` or
 in-process. Pair this with scoped credentials and out-of-environment
 backups for the rest of the blast radius.
 
+### Microsoft — engineers told to ease off Claude Code over inference cost (May 2026)
+
+Microsoft engineering management reportedly asked teams to reduce Claude
+Code usage after monthly inference bills exceeded budget. If Microsoft
+cannot absorb coding-agent inference cost without a memo, runaway agent
+spend is no longer a solo-founder problem.
+
+Source: [TheNextWeb](https://thenextweb.com/news/microsoft-claude-code-retreat-ai-cost)
+
+A memo asks engineers to self-throttle. A `BudgetGuard` makes the cap a
+config value enforced inside the process:
+
+```python
+from agentguard import BudgetGuard
+
+BudgetGuard(max_cost_usd=5.00, max_calls=50, warn_at_pct=0.8)
+```
+
+The guard raises `BudgetExceeded` before the run blows the cap. Same
+conversation, one config line instead of a memo.
+
 ## Local Proof in 60 Seconds
 
 ```bash

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -113,6 +113,27 @@ A 9-second sequence of destructive calls trips `LoopGuard` or
 in-process. Pair this with scoped credentials and out-of-environment
 backups for the rest of the blast radius.
 
+### Microsoft — engineers told to ease off Claude Code over inference cost (May 2026)
+
+Microsoft engineering management reportedly asked teams to reduce Claude
+Code usage after monthly inference bills exceeded budget. If Microsoft
+cannot absorb coding-agent inference cost without a memo, runaway agent
+spend is no longer a solo-founder problem.
+
+Source: [TheNextWeb](https://thenextweb.com/news/microsoft-claude-code-retreat-ai-cost)
+
+A memo asks engineers to self-throttle. A `BudgetGuard` makes the cap a
+config value enforced inside the process:
+
+```python
+from agentguard import BudgetGuard
+
+BudgetGuard(max_cost_usd=5.00, max_calls=50, warn_at_pct=0.8)
+```
+
+The guard raises `BudgetExceeded` before the run blows the cap. Same
+conversation, one config line instead of a memo.
+
 ## Local Proof in 60 Seconds
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a third-party validation entry to the "Real Incidents" section of the README citing the May 2026 Microsoft Claude Code cost retreat (TheNextWeb).
- Frames the AgentGuard pitch as empirical: if MSFT cannot absorb coding-agent inference cost without a memo, runaway spend is no longer a solo-founder problem.
- Source: Knowledge/sources/2026-05-26-microsoft-claude-code-cost-retreat.md (vault); routed via Queue/auto-tonight/.

## Test plan
- [x] README renders cleanly on GitHub
- [x] Link to source resolves
- [x] No code or build changes; docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)