### PR TITLE
docs(readme): add agent exfiltration threat model with Copilot Cowork cite

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,18 @@ memory/       SDK-only state and decisions
 - Hosted ingest API keys should be stored in environment variables.
 - Local guards remain authoritative even when hosted ingest is configured.
 
+### Threat model: agent data exfiltration
+
+A recurring class of agent attack uses the agent's own write surface as an
+outbound channel. Example pattern from Microsoft Copilot Cowork (May 2026):
+the agent emails the user's own inbox with no approval, the rendered message
+fetches an external image, and the image URL encodes data the attacker wanted
+out. AgentGuard's network and URL policies are designed to catch this class
+at runtime by gating which hosts an agent may reach, regardless of which
+tool initiated the request.
+
+Citation: https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/
+
 Report security issues through GitHub Security Advisories or by email:
 `pat@bmdpat.com`.
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -475,6 +475,18 @@ memory/       SDK-only state and decisions
 - Hosted ingest API keys should be stored in environment variables.
 - Local guards remain authoritative even when hosted ingest is configured.
 
+### Threat model: agent data exfiltration
+
+A recurring class of agent attack uses the agent's own write surface as an
+outbound channel. Example pattern from Microsoft Copilot Cowork (May 2026):
+the agent emails the user's own inbox with no approval, the rendered message
+fetches an external image, and the image URL encodes data the attacker wanted
+out. AgentGuard's network and URL policies are designed to catch this class
+at runtime by gating which hosts an agent may reach, regardless of which
+tool initiated the request.
+
+Citation: https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/
+
 Report security issues through GitHub Security Advisories or by email:
 `pat@bmdpat.com`.
 


### PR DESCRIPTION
## Summary
- Adds a Threat model subsection under Security in README citing the Microsoft Copilot Cowork self-inbox image-render exfiltration pattern (May 2026).
- Frames AgentGuard's network/URL policy as the runtime mitigation for agent-side egress.
- Regenerates sdk/PYPI_README.md to keep the sync gate green.

## Source
https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/

## Test plan
- [x] PYPI_README sync gate (regenerated)
- [x] Docs-only change, no code paths touched