### PR TITLE
docs(readme): correct exfiltration guard claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,9 @@ A recurring class of agent attack uses the agent's own write surface as an
 outbound channel. Example pattern from Microsoft Copilot Cowork (May 2026):
 the agent emails the user's own inbox with no approval, the rendered message
 fetches an external image, and the image URL encodes data the attacker wanted
-out. AgentGuard's network and URL policies are designed to catch this class
-at runtime by gating which hosts an agent may reach, regardless of which
-tool initiated the request.
+out. AgentGuard does not replace an egress firewall or tool-permission layer,
+but it gives the agent runtime hard stops for the runaway loops, retries, and
+budget burn that often turn one bad tool call into a sustained incident.
 
 Citation: https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -481,9 +481,9 @@ A recurring class of agent attack uses the agent's own write surface as an
 outbound channel. Example pattern from Microsoft Copilot Cowork (May 2026):
 the agent emails the user's own inbox with no approval, the rendered message
 fetches an external image, and the image URL encodes data the attacker wanted
-out. AgentGuard's network and URL policies are designed to catch this class
-at runtime by gating which hosts an agent may reach, regardless of which
-tool initiated the request.
+out. AgentGuard does not replace an egress firewall or tool-permission layer,
+but it gives the agent runtime hard stops for the runaway loops, retries, and
+budget burn that often turn one bad tool call into a sustained incident.
 
 Citation: https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/
 


### PR DESCRIPTION
## Summary
- correct README/PyPI README wording that overstated current AgentGuard egress/network policy capabilities
- preserve the Copilot Cowork exfiltration threat-model example while tying AgentGuard to current runtime loop/retry/budget enforcement

## Evidence
- Recent commit: b0e872025e0b0980555ad5b3d376ec28f481744b added the unsupported claim that AgentGuard network and URL policies gate outbound hosts
- Repo evidence: no general egress policy guard exists; URL validation is scoped to HttpSink endpoint safety

## Tests
- python scripts/sdk_preflight.py
- python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py
- python scripts/ci_tools_requirements_guard.py
- python -m pytest sdk/tests/test_pypi_readme_sync.py sdk/tests/test_dashboard_handoff_docs.py sdk/tests/test_repo_config.py -q
- python -m pytest sdk/tests/test_pypi_readme_sync.py sdk/tests/test_guards.py -q
- python -m pytest sdk/tests/test_architecture.py -q
- python -m pytest sdk/tests/ -q
- npm --prefix mcp-server ci && npm --prefix mcp-server test
- python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q

Note: make is unavailable in this Windows shell, so equivalent commands were run directly. npm audit after installing mcp-server deps reports existing transitive advisories in fast-uri and qs; not changed by this docs fix.