### PR TITLE
Release v1.2.11

### DIFF
--- a/.claude/agents/sdk-dev.md
+++ b/.claude/agents/sdk-dev.md
@@ -18,7 +18,7 @@ gh issue list --repo bmdhodl/agent47 --label component:sdk --state open --limit 
 
 ## Current Focus
 
-Latest shipped SDK release: `v1.2.10`.
+Latest shipped SDK release: `v1.2.11`.
 
 Source of truth for priorities:
 - `ops/00-NORTHSTAR.md`

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+# Categorization for `gh release create --generate-notes`, called from
+# `.github/workflows/publish.yml` after PyPI publish succeeds.
+#
+# GitHub's generated notes group by PR labels. Labels follow the repo's
+# existing `type:*` scheme from the issue templates.
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - dependencies
+  categories:
+    - title: "Security"
+      labels:
+        - type:security
+    - title: "Features"
+      labels:
+        - type:feature
+        - enhancement
+    - title: "Fixes"
+      labels:
+        - type:bug
+        - bug
+    - title: "Performance and refactors"
+      labels:
+        - type:perf
+        - type:refactor
+    - title: "CI and tests"
+      labels:
+        - type:ci
+        - type:test
+    - title: "Docs"
+      labels:
+        - type:docs
+        - documentation
+    - title: "Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PYTHONPATH: sdk
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
     steps:
@@ -24,6 +24,15 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
+
+      - name: Verify tag matches sdk/pyproject.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("sdk/pyproject.toml","rb"))["project"]["version"])')"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag $TAG_VERSION does not match sdk/pyproject.toml version $PKG_VERSION" >&2
+            exit 1
+          fi
 
       - name: Install build and test tools
         run: python -m pip install --require-hashes -r .github/requirements/ci-tools.txt
@@ -59,3 +68,13 @@ jobs:
         with:
           packages-dir: sdk/dist/
           attestations: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ AgentGuard — a zero-dependency runtime guardrails SDK for coding agents and AI
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.10)
+- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.11)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -197,7 +197,7 @@ Read .Codex/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** latest shipped SDK release is v1.2.10. Read `memory/` for the
+**Current:** latest shipped SDK release is v1.2.11. Read `memory/` for the
 current SDK state, blockers, decisions, and distribution priorities.
 
 ## Agent Navigation Guide
@@ -242,7 +242,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** latest shipped release is 1.2.10. Check `sdk/pyproject.toml` for the branch version under preparation.
+- **Version:** latest shipped release is 1.2.11. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 1.2.11
+
+### Reliability
+- Hardened `agentguard.__version__` so malformed local package metadata falls
+  back to `0.0.0-dev` instead of crashing source-checkout imports.
+- Fixed the coding-agent review-loop proof to record cumulative guard spend as
+  `total_cost_usd`, preventing local reports from double-counting the stopped
+  budget event.
+
+### Public Docs
+- Corrected the README threat-model copy so AgentGuard is positioned as local
+  runtime hard stops for loops, retries, and budget burn, not as a replacement
+  for egress firewalls or tool-permission layers.
+- Added release runbook documentation for tag-triggered PyPI publish and
+  GitHub Release creation.
+
 ### Profiles
 - Added a `deployed-agent` guard profile (`agentguard.init(profile="deployed-agent")`)
   for unattended production agents. Tightens defaults to `loop_max=2`,
@@ -53,6 +69,10 @@
   distribution train from the monthly SDK release train.
 - Added a scheduled release cadence workflow that opens or updates one active
   release queue issue with SDK, npm MCP, and Glama indexing status.
+- Added tag/version validation to the PyPI publish workflow and creates the
+  GitHub Release only after PyPI publish succeeds.
+- Refreshed the MCP server lockfile so `npm audit` no longer reports the
+  transitive `fast-uri` or `qs` advisories.
 
 ## 1.2.10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ For this repo, the most relevant Claude-side assets are:
 - official MCP Registry listing: live
 - dashboard remains private
 
-Current: latest shipped release: v1.2.10.
-<!-- latest shipped release is 1.2.10 -->
+Current: latest shipped release: v1.2.11.
+<!-- latest shipped release is 1.2.11 -->
 
 Core message to preserve:
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ assert result.passed
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](docs/guides/managed-agent-sessions.md) |
 | Activation metrics design | [`docs/guides/activation-metrics-design.md`](docs/guides/activation-metrics-design.md) |
 | Proof gallery | [`docs/examples/proof-gallery.md`](docs/examples/proof-gallery.md) |
+| Releasing | [`docs/RELEASING.md`](docs/RELEASING.md) |
 | Release cadence | [`docs/release/cadence.md`](docs/release/cadence.md) |
 | PyPI Trusted Publishing | [`docs/release/trusted-publishing.md`](docs/release/trusted-publishing.md) |
 
@@ -479,9 +480,9 @@ A recurring class of agent attack uses the agent's own write surface as an
 outbound channel. Example pattern from Microsoft Copilot Cowork (May 2026):
 the agent emails the user's own inbox with no approval, the rendered message
 fetches an external image, and the image URL encodes data the attacker wanted
-out. AgentGuard's network and URL policies are designed to catch this class
-at runtime by gating which hosts an agent may reach, regardless of which
-tool initiated the request.
+out. AgentGuard does not replace an egress firewall or tool-permission layer,
+but it gives the agent runtime hard stops for runaway loops, retries, and
+budget burn that can turn one bad tool call into a sustained incident.
 
 Citation: https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing
+
+AgentGuard SDK releases are tag-triggered. Push a `vX.Y.Z` tag after the
+release-prep PR lands on `main`.
+
+| Workflow | What it does |
+| --- | --- |
+| [`publish.yml`](../.github/workflows/publish.yml) | Verifies the tag matches `sdk/pyproject.toml`, runs lint, Bandit, pytest, builds the wheel, publishes `agentguard47` to PyPI, then creates the GitHub Release. |
+| [`release-content.yml`](../.github/workflows/release-content.yml) | Posts optional release announcements. It skips safely when Discussions or dashboard credentials are unavailable. |
+
+## Cut A Release
+
+1. Land all intended release PRs on `main`.
+2. Bump `sdk/pyproject.toml`.
+3. Move `CHANGELOG.md` entries from `Unreleased` into `X.Y.Z`.
+4. Update release markers checked by `scripts/sdk_release_guard.py`.
+5. Regenerate the package README:
+
+   ```bash
+   python scripts/generate_pypi_readme.py --write
+   ```
+
+6. Run the local gates:
+
+   ```bash
+   make release-guard
+   make check
+   make structural
+   make security
+   ```
+
+7. Merge the release-prep PR.
+8. Tag the merge commit:
+
+   ```bash
+   git checkout main
+   git pull --ff-only
+   VERSION=$(python -c "import tomllib; print(tomllib.load(open('sdk/pyproject.toml','rb'))['project']['version'])")
+   git tag "v$VERSION"
+   git push origin "v$VERSION"
+   ```
+
+9. Watch the tag workflows. The GitHub Release is created only after PyPI
+   publish succeeds.
+
+## Verification
+
+After the workflows finish:
+
+- Confirm `gh release view vX.Y.Z --repo bmdhodl/agent47` succeeds.
+- Confirm `python -m pip index versions agentguard47` reports the new version.
+- Install the published wheel in a clean venv and run `agentguard doctor`,
+  `agentguard demo`, `agentguard quickstart --framework raw --write`, the
+  generated file, and `agentguard report`.
+- Confirm PyPI files show Trusted Publishing provenance and attestations.
+
+## Release Notes
+
+GitHub release notes are public. Keep PR titles and generated categories clear:
+
+- No customer, revenue, or private roadmap claims.
+- No internal-only incident language.
+- No security admissions beyond what is already public.
+- Use labels from `.github/release.yml` before merging PRs.

--- a/docs/examples/coding-agent-review-loop-incident.md
+++ b/docs/examples/coding-agent-review-loop-incident.md
@@ -10,7 +10,7 @@ Primary cause: **retry_limit_exceeded**
 - Spans: 4
 - Events: 9
 - Duration: 1.7 ms
-- Estimated cost: $0.1020
+- Estimated cost: $0.0510
 - Guard events: 2
 - Errors: 0
 - Exact savings: $0.0000

--- a/examples/coding_agent_review_loop.py
+++ b/examples/coding_agent_review_loop.py
@@ -81,7 +81,7 @@ def _run_review_budget_loop(tracer: Tracer) -> None:
                     data={
                         "attempt": turn["attempt"],
                         "reason": str(exc),
-                        "cost_usd": round(budget.state.cost_used, 6),
+                        "total_cost_usd": round(budget.state.cost_used, 6),
                         "tokens_used": budget.state.tokens_used,
                     },
                 )

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -450,9 +450,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -851,9 +851,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/memory/distribution.md
+++ b/memory/distribution.md
@@ -1,6 +1,6 @@
 # SDK Distribution
 
-**Last Updated:** 2026-05-15
+**Last Updated:** 2026-05-29
 
 ## Core Message
 AgentGuard stops coding agents from looping, retrying forever, and burning

--- a/memory/state.md
+++ b/memory/state.md
@@ -1,6 +1,6 @@
 # SDK State
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-29
 
 ## Product
 - AgentGuard = zero-dependency Python SDK for runtime guardrails.
@@ -9,7 +9,7 @@
 
 ## Public Artifacts
 - PyPI package: `agentguard47`
-- Latest shipped SDK release: `1.2.10`
+- Latest shipped SDK release: `1.2.11`
 - npm MCP package: `@agentguard47/mcp-server@0.2.2` is published.
 - Local budget MCP package: `agentguard-mcp` exists in this repo but is not
   published to npm or PyPI; dogfood installs it from the checkout.
@@ -26,6 +26,6 @@
 - hosted dashboard remains private and separate
 
 ## Current Focus
-- post-release hardening for `1.2.10`
+- post-release hardening for `1.2.11`
 - distribution before new features
 - coding-agent onboarding and proof

--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-**Last reviewed:** 2026-05-02
+**Last reviewed:** 2026-05-29
 
 ## High-level shape
 
@@ -127,6 +127,14 @@ The SDK uses deterministic local proof before hosted adoption:
 - `agentguard quickstart` and `examples/starters/` provide minimal stack-specific starters.
 - `examples/coding_agent_review_loop.py` demonstrates a coding-agent review/refinement loop stopped by `BudgetGuard` and a patch retry storm stopped by `RetryGuard`.
 - `agentguard report` and `agentguard incident` turn local traces into readable proof artifacts.
+
+## Release flow
+
+SDK releases are tag-triggered from `main`. The publish workflow validates that
+the pushed `vX.Y.Z` tag matches `sdk/pyproject.toml`, runs the release gates,
+publishes `agentguard47` to PyPI, then creates the GitHub Release. The GitHub
+Release is intentionally last so the public release page does not advertise a
+version that failed to publish.
 
 These proof surfaces should stay offline by default and must not require the
 hosted dashboard.

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,11 +3,11 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
-**Last reviewed:** 2026-05-08
+**Last reviewed:** 2026-05-29
 
 ## Current Focus Notes
 
-- Latest shipped SDK release is `v1.2.10`; current work is post-release
+- Latest shipped SDK release is `v1.2.11`; current work is post-release
   hardening and activation, not a new feature push.
 - Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`,
   but public registry search still reports MCP package version `0.2.1`; refresh
@@ -54,6 +54,7 @@ they directly strengthen coding-agent adoption.
 | Item | Success Signal |
 |------|---------------|
 | Activation proof polish | A fresh local flow from `pip install` to `agentguard doctor`, `agentguard demo`, and `agentguard quickstart` stays deterministic; repo-only examples and starters remain offline and easy to copy into real repos |
+| Release proof hygiene | The tag publish path verifies the tag matches `sdk/pyproject.toml`, publishes to PyPI first, then creates the GitHub Release |
 | MCP distribution hygiene | Official MCP Registry metadata is refreshed to `0.2.2`; Glama tool catalog indexes the seven MCP tools; `awesome-mcp-servers` receives the Glama URL without building unrelated features |
 | Dashboard contract drift checks | Hosted ingest, decision-trace event names, required fields, and remote-kill boundaries remain documented and covered by tests before any release |
 | Ops/doc freshness | `ops/02-ARCHITECTURE.md`, this roadmap, `ops/FOLLOWUP.md`, and memory files stay concise and current enough that agents do not start from stale assumptions |

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -17,7 +17,7 @@ enough to create surprise spend.
 [![Python](https://img.shields.io/pypi/pyversions/agentguard47)](https://pypi.org/project/agentguard47/)
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.10/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.11/LICENSE)
 [![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/score.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
@@ -158,7 +158,7 @@ What you should see:
 - `report` shows local trace counts, cost, savings, and guard events.
 
 Notebook version:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.10/examples/quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.11/examples/quickstart.ipynb)
 
 ## Copy-Paste Repo Setup
 
@@ -252,12 +252,12 @@ All examples are local-first. No API key is required unless the example says so.
 
 | Example | What it proves |
 |---|---|
-| [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/try_it_now.py) | budget, loop, and retry stops |
 | [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/main/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
-| [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
-| [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
-| [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |
-| [`examples/decision_trace_workflow.py`](https://github.com/bmdhodl/agent47/blob/v1.2.10/examples/decision_trace_workflow.py) | proposal, edit, approval, and binding decision events |
+| [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
+| [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
+| [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |
+| [`examples/decision_trace_workflow.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/decision_trace_workflow.py) | proposal, edit, approval, and binding decision events |
 
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md)
@@ -266,7 +266,7 @@ Proof gallery:
 [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md)
 
 Starter files:
-[`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.10/examples/starters)
+[`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.11/examples/starters)
 
 ## Framework Integrations
 
@@ -308,8 +308,8 @@ layer.
 
 Competitive notes:
 
-- [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/competitive/vercel-ai-gateway.md)
-- [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/competitive/manifest.md)
+- [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/competitive/vercel-ai-gateway.md)
+- [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](https://github.com/bmdhodl/agent47/blob/main/docs/competitive/agent-security-stack.md)
 
 ## Decision Traces
@@ -424,7 +424,7 @@ assert result.passed
 - Core runtime dependencies: zero
 - Trace format: JSONL
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
-- MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.10/mcp-server)
+- MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.11/mcp-server)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 [![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/card.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
@@ -433,14 +433,15 @@ assert result.passed
 
 | Topic | Link |
 |---|---|
-| Getting started | [`docs/guides/getting-started.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/getting-started.md) |
-| Coding-agent setup | [`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/coding-agents.md) |
-| Safety pack | [`docs/guides/coding-agent-safety-pack.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/coding-agent-safety-pack.md) |
+| Getting started | [`docs/guides/getting-started.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/getting-started.md) |
+| Coding-agent setup | [`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/coding-agents.md) |
+| Safety pack | [`docs/guides/coding-agent-safety-pack.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/coding-agent-safety-pack.md) |
 | Dashboard contract | [`docs/guides/dashboard-contract.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/dashboard-contract.md) |
 | Decision traces | [`docs/guides/decision-tracing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/decision-tracing.md) |
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/managed-agent-sessions.md) |
-| Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/docs/guides/activation-metrics-design.md) |
+| Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/activation-metrics-design.md) |
 | Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md) |
+| Releasing | [`docs/RELEASING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/RELEASING.md) |
 | Release cadence | [`docs/release/cadence.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/cadence.md) |
 | PyPI Trusted Publishing | [`docs/release/trusted-publishing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/trusted-publishing.md) |
 
@@ -481,9 +482,9 @@ A recurring class of agent attack uses the agent's own write surface as an
 outbound channel. Example pattern from Microsoft Copilot Cowork (May 2026):
 the agent emails the user's own inbox with no approval, the rendered message
 fetches an external image, and the image URL encodes data the attacker wanted
-out. AgentGuard's network and URL policies are designed to catch this class
-at runtime by gating which hosts an agent may reach, regardless of which
-tool initiated the request.
+out. AgentGuard does not replace an egress firewall or tool-permission layer,
+but it gives the agent runtime hard stops for runaway loops, retries, and
+budget burn that can turn one bad tool call into a sustained incident.
 
 Citation: https://simonwillison.net/2026/May/26/copilot-cowork-exfiltrates-files/
 
@@ -505,24 +506,83 @@ python scripts/sdk_release_guard.py
 
 Useful links:
 
-- [`CONTRIBUTING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/CONTRIBUTING.md)
-- [`GOLDEN_PRINCIPLES.md`](https://github.com/bmdhodl/agent47/blob/v1.2.10/GOLDEN_PRINCIPLES.md)
+- [`CONTRIBUTING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/CONTRIBUTING.md)
+- [`GOLDEN_PRINCIPLES.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/GOLDEN_PRINCIPLES.md)
 
 ## License
 
-MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.10/LICENSE).
+MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.11/LICENSE).
 
-## Latest Release Notes (1.2.10)
+## Latest Release Notes (1.2.11)
 
-### Activation Proof Path
-- Tightened the README and getting-started path around `doctor`, `demo`, and `quickstart` so first-time SDK users can reach local guard proof faster.
-- Added a coding-agent review-loop proof artifact that shows budget and retry guards stopping a simulated review/refinement loop without API keys or network calls.
-- Added sync coverage for the public sample incident and generated PyPI README so release-facing activation assets do not silently drift.
+### Reliability
+- Hardened `agentguard.__version__` so malformed local package metadata falls
+  back to `0.0.0-dev` instead of crashing source-checkout imports.
+- Fixed the coding-agent review-loop proof to record cumulative guard spend as
+  `total_cost_usd`, preventing local reports from double-counting the stopped
+  budget event.
 
-### Release And Distribution Hygiene
-- Added an opt-in activation metrics design doc that defines allowed activation questions and local-first consent boundaries without adding telemetry.
-- Hardened release discussion category handling so missing GitHub Discussion categories do not block the package release path.
-- Updated the package build timestamp seed to the ZIP-safe reproducible epoch so local and CI release builds do not fail on pre-1980 metadata.
-- Clarified hosted ingest language in incident reporting so `HttpSink` is described as event mirroring for retained alerts and follow-up, not a remote kill switch by itself.
+### Public Docs
+- Corrected the README threat-model copy so AgentGuard is positioned as local
+  runtime hard stops for loops, retries, and budget burn, not as a replacement
+  for egress firewalls or tool-permission layers.
+- Added release runbook documentation for tag-triggered PyPI publish and
+  GitHub Release creation.
 
-Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.10/CHANGELOG.md)
+### Profiles
+- Added a `deployed-agent` guard profile (`agentguard.init(profile="deployed-agent")`)
+  for unattended production agents. Tightens defaults to `loop_max=2`,
+  `retry_max=1`, `warn_pct=0.5`. Motivated by the arxiv:2605.00055
+  ambient-persuasion incident where a deployed agent installed 107
+  unauthorized components and overrode its own oversight gate.
+
+### Release Proof
+- Added a deterministic sticky agent proof example that simulates a
+  CrewAI-style retry storm, repeated tool loop, budget burn, local incident
+  output, and dashboard-compatible hosted NDJSON without adding dependencies.
+- Added contract tests that post the sticky proof NDJSON to the local hosted
+  ingest harness so SDK proof events stay aligned with dashboard expectations.
+
+### Activation
+- Added `python -m agentguard.cli ...` fallback guidance to `doctor`, `demo`,
+  and `quickstart` so first-run users are not blocked when console scripts
+  install outside `PATH`.
+- Added a post-demo next-step block so `agentguard demo` points directly to
+  `agentguard quickstart --framework raw --write`, the generated starter, and
+  the follow-up local report command.
+- Added an MCP read-path proof to the proof gallery and test coverage that
+  catches stale local example and sample-doc references.
+- Added an optional local-first Pydantic AI starter recipe using Pydantic AI's
+  `TestModel`, so users can try the pattern without API keys or network calls
+  after installing the optional framework package.
+- Clarified incident-report dashboard handoff copy so hosted ingest is framed as
+  useful when incidents need retained history, alerts, spend trends, or
+  team-visible follow-up, not as a requirement for local safety.
+- Added a concise local-vs-hosted adoption table to the README and dashboard
+  contract docs so the dashboard CTA is explicit without making local SDK use
+  feel limited.
+
+### Release Security
+- Switched the PyPI publish workflow from long-lived `PYPI_TOKEN` authentication
+  to OIDC Trusted Publishing for the `pypi` GitHub environment, with PyPI
+  attestations enabled for release artifacts.
+- Added release documentation for the required PyPI trusted-publisher tuple and
+  post-release verification steps.
+- Added an MCP package publishing checklist and normalized npm package metadata
+  so the `@agentguard47/mcp-server` release path does not rely on npm publish
+  autocorrections.
+- Added an optional release-guard npm check so release operators can verify the
+  repo MCP package version is actually published as npm latest without making
+  normal CI depend on the network.
+
+### Release Operations
+- Added a release cadence document that separates the weekly MCP / Glama
+  distribution train from the monthly SDK release train.
+- Added a scheduled release cadence workflow that opens or updates one active
+  release queue issue with SDK, npm MCP, and Glama indexing status.
+- Added tag/version validation to the PyPI publish workflow and creates the
+  GitHub Release only after PyPI publish succeeds.
+- Refreshed the MCP server lockfile so `npm audit` no longer reports the
+  transitive `fast-uri` or `qs` advisories.
+
+Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.11/CHANGELOG.md)

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -59,10 +59,15 @@ from .setup import get_budget_guard, get_tracer, init, shutdown
 from .sinks import HttpSink
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
 
-try:
-    __version__ = version("agentguard47")
-except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.0.0-dev"
+
+def _package_version(package_name: str = "agentguard47") -> str:
+    try:
+        return version(package_name)
+    except (PackageNotFoundError, TypeError):  # pragma: no cover
+        return "0.0.0-dev"
+
+
+__version__ = _package_version()
 
 # Libraries should not configure logging; only add a NullHandler so
 # consumers do not see "No handler found" warnings.

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentguard47"
-version = "1.2.10"
+version = "1.2.11"
 description = "Zero-dependency runtime control for production Python agents - stop loops, retry storms, and budget burn"
 readme = "PYPI_README.md"
 requires-python = ">=3.9"

--- a/sdk/tests/test_example_starters.py
+++ b/sdk/tests/test_example_starters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import json
+import math
 import os
 import re
 import subprocess
@@ -221,13 +222,34 @@ def test_coding_agent_review_loop_example_runs_offline() -> None:
         trace_path = Path(tmpdir, "coding_agent_review_loop_traces.jsonl")
         assert trace_path.exists()
         names = []
+        budget_events = []
         with trace_path.open("r", encoding="utf-8") as handle:
             for line in handle:
                 if line.strip():
-                    names.append(json.loads(line)["name"])
+                    event = json.loads(line)
+                    names.append(event["name"])
+                    if event["name"] == "guard.budget_exceeded":
+                        budget_events.append(event)
         assert "review.iteration" in names
         assert "guard.budget_exceeded" in names
         assert "guard.retry_limit_exceeded" in names
+        assert budget_events
+
+        iteration_costs = []
+        with trace_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    event = json.loads(line)
+                    if event["name"] == "review.iteration":
+                        iteration_costs.append(event["cost_usd"])
+
+        assert "cost_usd" not in budget_events[0].get("data", {})
+        assert "cost_usd" not in budget_events[0]
+        assert math.isclose(
+            budget_events[0]["data"]["total_cost_usd"],
+            sum(iteration_costs),
+            rel_tol=1e-9,
+        )
 
 
 def test_coding_agent_review_loop_sample_incident_is_in_sync() -> None:

--- a/sdk/tests/test_hardening.py
+++ b/sdk/tests/test_hardening.py
@@ -73,6 +73,14 @@ class TestVersion:
     def test_version_in_all(self):
         assert "__version__" in agentguard.__all__
 
+    def test_malformed_package_metadata_falls_back_to_dev_version(self, monkeypatch):
+        def broken_version(_: str) -> str:
+            raise TypeError("'NoneType' object is not subscriptable")
+
+        monkeypatch.setattr(agentguard, "version", broken_version)
+
+        assert agentguard._package_version() == "0.0.0-dev"
+
 
 # --- Thread safety: LoopGuard ---
 

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires Python 3.9+
 metadata:
   author: bmdhodl
-  version: "1.2.10"
+  version: "1.2.11"
   pypi: agentguard47
 ---
 


### PR DESCRIPTION
﻿## Summary
- prepare AgentGuard SDK `v1.2.11` release metadata, changelog, generated PyPI README, memory, roadmap, and architecture notes
- add tag-version validation plus GitHub Release creation after PyPI publish succeeds
- fold useful fixes from stale dogfood/dependabot PRs without committing dogfood proof spam: package metadata fallback, review-loop cost proof, MCP lockfile audit fixes
- correct the README exfiltration wording so AgentGuard stays positioned as local runtime stops, not an egress firewall replacement

## Bug classes killed
- release tag can no longer drift from `sdk/pyproject.toml` before publish
- malformed local package metadata no longer crashes `import agentguard`
- stopped budget events no longer double-count review-loop proof cost
- MCP lockfile no longer carries the transitive `fast-uri` / `qs` advisories found during release smoke

## Proof
- `python scripts/sdk_release_guard.py --json` -> `[]`
- `python scripts/generate_pypi_readme.py --check` -> passed
- `python -m pytest sdk/tests/test_hardening.py::TestVersion::test_malformed_package_metadata_falls_back_to_dev_version sdk/tests/test_example_starters.py::test_coding_agent_review_loop_example_runs_offline sdk/tests/test_example_starters.py::test_coding_agent_review_loop_sample_incident_is_in_sync -q` -> 3 passed
- `python scripts/sdk_preflight.py` -> passed, including ruff, focused pytest, architecture, bandit, PyPI README sync, and MCP test
- `python scripts/ci_tools_requirements_guard.py` -> passed
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py` -> passed
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 770 passed, 92.76% coverage
- `python -m pytest sdk/tests/test_architecture.py -v` -> 9 passed
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q` -> passed
- `python scripts/sdk_release_guard.py --check-mcp-npm` -> passed
- `npm --prefix mcp-server ci && npm --prefix mcp-server test && npm --prefix mcp-server run build` -> 10 MCP tests passed, build passed
- `npm audit --prefix mcp-server --audit-level=moderate` -> found 0 vulnerabilities
- `python -m pip install -e ./agentguard-mcp && cd agentguard-mcp && python -m ruff check agentguard_mcp tests && python -m pytest` -> 15 passed
- clean venv wheel proof from `agentguard47-1.2.11-py3-none-any.whl`: import reported version `1.2.11` from the venv site-packages path; `agentguard doctor`, `agentguard demo`, `agentguard quickstart --framework raw --write`, `python agentguard_raw_quickstart.py`, `agentguard report .agentguard/traces.jsonl`, and `agentguard report agentguard_demo_traces.jsonl` all passed

## Notes
- `make` is not installed in this Windows shell, so I ran the Makefile equivalents directly.
- Local `actionlint` is not installed; the repo Actionlint workflow should validate the workflow syntax on this PR.
- No release tag has been pushed from this branch yet.
