### PR TITLE
Gate release announcements on published releases

### DIFF
--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -1,9 +1,9 @@
-name: Release Content — Auto-generate announcements
+name: Release Content - Auto-generate announcements
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types:
+      - published
 
 permissions:
   contents: read
@@ -15,22 +15,25 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0  # full history for changelog
 
       - name: Get release info
         id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="$RELEASE_TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          # Find previous tag
-          PREV_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+          # Find previous tag.
+          PREV_TAG=$(git tag --sort=-creatordate | awk -v current="$TAG" '$0 != current { print; exit }')
           if [ -z "$PREV_TAG" ]; then
             PREV_TAG=$(git rev-list --max-parents=0 HEAD)
           fi
           echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
-          # Generate changelog
+          # Generate changelog.
           CHANGELOG=$(git log --oneline "$PREV_TAG".."$TAG" -- sdk/ | head -20)
           echo "changelog<<EOF" >> "$GITHUB_OUTPUT"
           echo "$CHANGELOG" >> "$GITHUB_OUTPUT"
@@ -92,13 +95,13 @@ jobs:
         run: |
           TAG="${{ steps.release.outputs.tag }}"
 
-          # Skip if no DASHBOARD_PAT configured
+          # Skip if no DASHBOARD_PAT configured.
           if [ -z "$GH_TOKEN" ]; then
-            echo "No DASHBOARD_PAT — skipping social queue"
+            echo "No DASHBOARD_PAT - skipping social queue"
             exit 0
           fi
 
-          # Trigger X post
+          # Trigger X post.
           gh workflow run add-social-post.yml \
             --repo bmdhodl/agent47-dashboard \
             -f platform=x \
@@ -109,14 +112,14 @@ jobs:
 
           changelog: https://github.com/bmdhodl/agent47/releases/tag/$TAG" || echo "Failed to trigger X post workflow"
 
-          # Trigger LinkedIn post
+          # Trigger LinkedIn post.
           gh workflow run add-social-post.yml \
             --repo bmdhodl/agent47-dashboard \
             -f platform=linkedin \
             -f title="$TAG released" \
             -f body="AgentGuard $TAG is now available on PyPI.
 
-          Runtime guardrails for AI agents — loop detection, budget enforcement, cost tracking. Zero dependencies.
+          Runtime guardrails for AI agents - loop detection, budget enforcement, cost tracking. Zero dependencies.
 
           Upgrade: pip install --upgrade agentguard47
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@
   release queue issue with SDK, npm MCP, and Glama indexing status.
 - Added tag/version validation to the PyPI publish workflow and creates the
   GitHub Release only after PyPI publish succeeds.
+- Changed release announcement automation to run from a published GitHub Release
+  instead of a raw tag push, so failed PyPI publishes cannot announce as shipped.
 - Refreshed the MCP server lockfile so `npm audit` no longer reports the
   transitive `fast-uri` or `qs` advisories.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,12 +1,13 @@
 # Releasing
 
-AgentGuard SDK releases are tag-triggered. Push a `vX.Y.Z` tag after the
-release-prep PR lands on `main`.
+AgentGuard SDK publishing is tag-triggered. Push a `vX.Y.Z` tag after the
+release-prep PR lands on `main`. Release announcements run only after the
+GitHub Release is published.
 
 | Workflow | What it does |
 | --- | --- |
 | [`publish.yml`](../.github/workflows/publish.yml) | Verifies the tag matches `sdk/pyproject.toml`, runs lint, Bandit, pytest, builds the wheel, publishes `agentguard47` to PyPI, then creates the GitHub Release. |
-| [`release-content.yml`](../.github/workflows/release-content.yml) | Posts optional release announcements. It skips safely when Discussions or dashboard credentials are unavailable. |
+| [`release-content.yml`](../.github/workflows/release-content.yml) | Runs from the `release.published` event and posts optional release announcements. It skips safely when Discussions or dashboard credentials are unavailable. |
 
 ## Cut A Release
 
@@ -40,8 +41,9 @@ release-prep PR lands on `main`.
    git push origin "v$VERSION"
    ```
 
-9. Watch the tag workflows. The GitHub Release is created only after PyPI
-   publish succeeds.
+9. Watch the tag workflow. The GitHub Release is created only after PyPI
+   publish succeeds. Announcement automation runs from that published release,
+   not from the raw tag.
 
 ## Verification
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -582,6 +582,8 @@ MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.11/LICENSE).
   release queue issue with SDK, npm MCP, and Glama indexing status.
 - Added tag/version validation to the PyPI publish workflow and creates the
   GitHub Release only after PyPI publish succeeds.
+- Changed release announcement automation to run from a published GitHub Release
+  instead of a raw tag push, so failed PyPI publishes cannot announce as shipped.
 - Refreshed the MCP server lockfile so `npm audit` no longer reports the
   transitive `fast-uri` or `qs` advisories.
 

--- a/sdk/tests/test_ci_guardrails.py
+++ b/sdk/tests/test_ci_guardrails.py
@@ -14,3 +14,14 @@ def test_actionlint_workflow_is_wired() -> None:
     assert "actionlint -shellcheck=" in text
     assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6" in text
     assert "actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5" in text
+
+
+def test_release_content_waits_for_published_github_release() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = repo_root / ".github" / "workflows" / "release-content.yml"
+
+    text = workflow.read_text(encoding="utf-8")
+    assert "release:" in text
+    assert "published" in text
+    assert "push:\n    tags:" not in text
+    assert "github.event.release.tag_name" in text


### PR DESCRIPTION
﻿## Summary
- change release announcements from raw tag pushes to the `release.published` event
- checkout the published release tag for changelog generation
- add a guardrail test so `release-content.yml` cannot go back to `push.tags`
- update release docs and generated PyPI README for the announcement gate

## Why
The `v1.2.11` publish run correctly failed before creating a GitHub Release because PyPI Trusted Publishing is not configured yet. The separate release-content workflow still ran on tag push. It skipped Discussions and social queue in this run, but that trigger is still wrong: failed PyPI publishes must not be able to announce as shipped.

## Proof
- `python scripts/sdk_release_guard.py` -> Release guard passed
- `python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py -q` -> 7 passed
- `python scripts/sdk_preflight.py` -> passed

## Notes
- The release is still blocked on PyPI project Trusted Publisher configuration for `repo:bmdhodl/agent47:environment:pypi`.
- After this lands and PyPI is configured, retag `v1.2.11` at the new `main` commit and rerun publish.
