### PR TITLE
Harden post-publish release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PYTHONPATH: sdk
     permissions:
-      contents: write
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -69,12 +69,32 @@ jobs:
           packages-dir: sdk/dist/
           attestations: true
 
+  github-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    env:
+      GH_REPO: ${{ github.repository }}
+    permissions:
+      contents: write
+      actions: write
+    steps:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            --verify-tag
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists"
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              --verify-tag
+          fi
+
+      - name: Trigger release announcements
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh workflow run release-content.yml -f tag="$TAG"

--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to announce
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,15 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
           fetch-depth: 0  # full history for changelog
 
       - name: Get release info
         id: release
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
         run: |
           TAG="$RELEASE_TAG"
+          if [ -z "$TAG" ]; then
+            echo "Release tag missing" >&2
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           # Find previous tag.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,6 +97,11 @@ The two MCP servers are independent: `mcp-server/` is a read-only window onto ho
    - release-facing docs: regenerated [`sdk/PYPI_README.md`](sdk/PYPI_README.md) and sync tests
 6. If the change evolves the architecture, update this file in the same PR.
 
+Release tooling follows the same ordering rule: publish package artifacts first,
+then create or verify the public GitHub Release, then run announcement
+automation. Announcement jobs must be explicitly dispatchable because release
+events created by the workflow token are not a reliable trigger source.
+
 ## 8. Known Technical Debt
 
 - Architecture knowledge is still split between this root doc and [`ops/02-ARCHITECTURE.md`](ops/02-ARCHITECTURE.md). They can drift if only one gets updated; treat this root doc as the law.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Release Operations
+- Made post-PyPI GitHub Release creation a separate idempotent job and
+  dispatch release announcements explicitly, so the release-content workflow no
+  longer depends on `GITHUB_TOKEN` release events.
+
 ## 1.2.11
 
 ### Reliability

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,12 +2,12 @@
 
 AgentGuard SDK publishing is tag-triggered. Push a `vX.Y.Z` tag after the
 release-prep PR lands on `main`. Release announcements run only after the
-GitHub Release is published.
+package publishes and the GitHub Release exists.
 
 | Workflow | What it does |
 | --- | --- |
-| [`publish.yml`](../.github/workflows/publish.yml) | Verifies the tag matches `sdk/pyproject.toml`, runs lint, Bandit, pytest, builds the wheel, publishes `agentguard47` to PyPI, then creates the GitHub Release. |
-| [`release-content.yml`](../.github/workflows/release-content.yml) | Runs from the `release.published` event and posts optional release announcements. It skips safely when Discussions or dashboard credentials are unavailable. |
+| [`publish.yml`](../.github/workflows/publish.yml) | Verifies the tag matches `sdk/pyproject.toml`, runs lint, Bandit, pytest, builds the wheel, publishes `agentguard47` to PyPI, then creates or verifies the GitHub Release in a separate post-publish job. |
+| [`release-content.yml`](../.github/workflows/release-content.yml) | Runs from explicit `workflow_dispatch` after publish, or from a manual `release.published` event, and posts optional release announcements. It skips safely when Discussions or dashboard credentials are unavailable. |
 
 ## Cut A Release
 
@@ -41,9 +41,9 @@ GitHub Release is published.
    git push origin "v$VERSION"
    ```
 
-9. Watch the tag workflow. The GitHub Release is created only after PyPI
-   publish succeeds. Announcement automation runs from that published release,
-   not from the raw tag.
+9. Watch the tag workflow. The GitHub Release job starts only after PyPI
+   publish succeeds. If the post-publish GitHub Release or announcement step
+   fails, rerun that failed job instead of republishing the package.
 
 ## Verification
 
@@ -55,6 +55,9 @@ After the workflows finish:
   `agentguard demo`, `agentguard quickstart --framework raw --write`, the
   generated file, and `agentguard report`.
 - Confirm PyPI files show Trusted Publishing provenance and attestations.
+- Confirm the `Release Content - Auto-generate announcements` workflow ran for
+  the same tag, or skipped only optional destinations because Discussions or
+  dashboard credentials were unavailable.
 
 ## Release Notes
 

--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -132,9 +132,12 @@ The SDK uses deterministic local proof before hosted adoption:
 
 SDK releases are tag-triggered from `main`. The publish workflow validates that
 the pushed `vX.Y.Z` tag matches `sdk/pyproject.toml`, runs the release gates,
-publishes `agentguard47` to PyPI, then creates the GitHub Release. The GitHub
-Release is intentionally last so the public release page does not advertise a
-version that failed to publish.
+publishes `agentguard47` to PyPI, then creates or verifies the GitHub Release in
+a separate post-publish job. That job explicitly dispatches release-content
+automation after the release exists, so announcements do not depend on release
+events emitted by the workflow token. The GitHub Release remains intentionally
+after PyPI publish so the public release page does not advertise a version that
+failed to publish.
 
 These proof surfaces should stay offline by default and must not require the
 hosted dashboard.

--- a/sdk/tests/test_ci_guardrails.py
+++ b/sdk/tests/test_ci_guardrails.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 
 
+def _contains_ordered_lines(lines: list[str], expected: list[str]) -> bool:
+    if not expected:
+        return True
+
+    cursor = 0
+    for line in lines:
+        if line == expected[cursor]:
+            cursor += 1
+            if cursor == len(expected):
+                return True
+    return False
+
+
 def test_actionlint_workflow_is_wired() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     workflow = repo_root / ".github" / "workflows" / "actionlint.yml"
@@ -20,8 +33,62 @@ def test_release_content_waits_for_published_github_release() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     workflow = repo_root / ".github" / "workflows" / "release-content.yml"
 
+    assert workflow.exists(), "release announcements must stay under workflow guardrails"
     text = workflow.read_text(encoding="utf-8")
-    assert "release:" in text
-    assert "published" in text
-    assert "push:\n    tags:" not in text
-    assert "github.event.release.tag_name" in text
+    lines = text.splitlines()
+    assert _contains_ordered_lines(
+        lines,
+        [
+            "on:",
+            "  release:",
+            "    types:",
+            "      - published",
+        ],
+    )
+    assert _contains_ordered_lines(
+        lines,
+        [
+            "  workflow_dispatch:",
+            "    inputs:",
+            "      tag:",
+            "        required: true",
+        ],
+    )
+    assert all(not line.startswith("  push:") for line in lines)
+    assert "github.event.inputs.tag || github.event.release.tag_name" in text
+
+
+def test_publish_workflow_release_steps_are_post_publish_rerunnable() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = repo_root / ".github" / "workflows" / "publish.yml"
+
+    assert workflow.exists(), "PyPI publishing must stay under workflow guardrails"
+    text = workflow.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    assert _contains_ordered_lines(
+        lines,
+        [
+            "  github-release:",
+            "    runs-on: ubuntu-latest",
+            "    needs: publish",
+            "    env:",
+            "      GH_REPO: ${{ github.repository }}",
+        ],
+    )
+    assert _contains_ordered_lines(
+        lines,
+        [
+            "    permissions:",
+            "      contents: write",
+            "      actions: write",
+        ],
+    )
+
+    normalized_text = text.replace("\r\n", "\n")
+    publish_job = normalized_text.split("\n  github-release:", maxsplit=1)[0]
+    release_job = normalized_text.split("\n  github-release:", maxsplit=1)[1]
+    assert "Create GitHub Release" not in publish_job
+    assert 'gh release view "$TAG"' in release_job
+    assert 'gh release create "$TAG"' in release_job
+    assert "gh workflow run release-content.yml" in release_job
+    assert '-f tag="$TAG"' in release_job


### PR DESCRIPTION
## Summary
- split GitHub Release creation into a post-PyPI `github-release` job so a release-page failure can be rerun without rerunning package publish
- make release announcements explicit via `workflow_dispatch` with a tag, while keeping manual `release.published` support
- add CI guardrails that fail if release creation moves back into the PyPI job or announcement automation depends only on token-created release events

## Red test
```text
python -m pytest sdk/tests/test_ci_guardrails.py -q
2 failed, 1 passed
FAILED test_release_content_waits_for_published_github_release
FAILED test_publish_workflow_release_steps_are_post_publish_rerunnable
```

## Proof
```text
python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py -q
8 passed

python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py sdk/tests/test_architecture.py -q
17 passed

python scripts/sdk_release_guard.py
Release guard passed.

python scripts/sdk_preflight.py
All checks passed.

python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py sdk/tests/test_ci_guardrails.py
All checks passed.

python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
passed

python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
772 passed, coverage 92.79%

git diff --check
passed
```

Local actionlint could not run because `go` is not installed on this Windows host. GitHub Actionlint is the authoritative syntax gate for this PR.

## Review loop
Addressed automated review by adding explicit `GH_REPO` context for checkout-free `gh` commands, handling empty ordered-line checks, and normalizing CRLF before workflow job splits.

## Bug class killed
Post-PyPI release-page or announcement failures cannot strand the release path behind an immutable PyPI publish step, and release announcements no longer depend on `GITHUB_TOKEN` release events.

## Hardening artifact
`C:\Users\patri\Documents\Obsidian Vault\Reports\Hardening\2026-05-29-agent47-release-postpublish-rerun.md`
