### PR TITLE
Prepare v1.2.12 release

### DIFF
--- a/.claude/agents/sdk-dev.md
+++ b/.claude/agents/sdk-dev.md
@@ -18,7 +18,7 @@ gh issue list --repo bmdhodl/agent47 --label component:sdk --state open --limit 
 
 ## Current Focus
 
-Latest shipped SDK release: `v1.2.12`.
+Current SDK release candidate: `v1.2.12`.
 
 Source of truth for priorities:
 - `ops/00-NORTHSTAR.md`

--- a/.claude/agents/sdk-dev.md
+++ b/.claude/agents/sdk-dev.md
@@ -18,7 +18,7 @@ gh issue list --repo bmdhodl/agent47 --label component:sdk --state open --limit 
 
 ## Current Focus
 
-Latest shipped SDK release: `v1.2.11`.
+Latest shipped SDK release: `v1.2.12`.
 
 Source of truth for priorities:
 - `ops/00-NORTHSTAR.md`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,10 +86,19 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub Release $TAG already exists"
           else
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --generate-notes \
-              --verify-tag
+            PREV_RELEASE_TAG="$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --jq '.[].tagName' | awk -v current="$TAG" '$0 != current { print; exit }')"
+            if [ -n "$PREV_RELEASE_TAG" ]; then
+              gh release create "$TAG" \
+                --title "$TAG" \
+                --generate-notes \
+                --notes-start-tag "$PREV_RELEASE_TAG" \
+                --verify-tag
+            else
+              gh release create "$TAG" \
+                --title "$TAG" \
+                --generate-notes \
+                --verify-tag
+            fi
           fi
 
       - name: Trigger release announcements

--- a/.github/workflows/release-content.yml
+++ b/.github/workflows/release-content.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   announce:
     runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -27,6 +29,7 @@ jobs:
       - name: Get release info
         id: release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
         run: |
           TAG="$RELEASE_TAG"
@@ -36,8 +39,8 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          # Find previous tag.
-          PREV_TAG=$(git tag --sort=-creatordate | awk -v current="$TAG" '$0 != current { print; exit }')
+          # Find previous published release, not merely the previous raw git tag.
+          PREV_TAG="$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --jq '.[].tagName' | awk -v current="$TAG" '$0 != current { print; exit }')"
           if [ -z "$PREV_TAG" ]; then
             PREV_TAG=$(git rev-list --max-parents=0 HEAD)
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ AgentGuard — a zero-dependency runtime guardrails SDK for coding agents and AI
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.11)
+- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.12)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -197,7 +197,7 @@ Read .Codex/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** latest shipped SDK release is v1.2.11. Read `memory/` for the
+**Current:** latest shipped SDK release is v1.2.12. Read `memory/` for the
 current SDK state, blockers, decisions, and distribution priorities.
 
 ## Agent Navigation Guide
@@ -242,7 +242,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** latest shipped release is 1.2.11. Check `sdk/pyproject.toml` for the branch version under preparation.
+- **Version:** latest shipped release is 1.2.12. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ AgentGuard — a zero-dependency runtime guardrails SDK for coding agents and AI
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (latest shipped release: v1.2.12)
+- **Package:** `agentguard47` on PyPI (release status tracked in `memory/state.md`; release candidate: v1.2.12)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -197,8 +197,8 @@ Read .Codex/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** latest shipped SDK release is v1.2.12. Read `memory/` for the
-current SDK state, blockers, decisions, and distribution priorities.
+**Current:** current SDK release candidate is 1.2.12. Read `memory/` for the
+public package state, blockers, decisions, and distribution priorities.
 
 ## Agent Navigation Guide
 
@@ -242,7 +242,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** latest shipped release is 1.2.12. Check `sdk/pyproject.toml` for the branch version under preparation.
+- **Version:** current release candidate is 1.2.12. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,7 +100,9 @@ The two MCP servers are independent: `mcp-server/` is a read-only window onto ho
 Release tooling follows the same ordering rule: publish package artifacts first,
 then create or verify the public GitHub Release, then run announcement
 automation. Announcement jobs must be explicitly dispatchable because release
-events created by the workflow token are not a reliable trigger source.
+events created by the workflow token are not a reliable trigger source. Release
+notes and announcements must start from the last published GitHub Release, not
+the last raw git tag, because a tag can exist for a failed package publish.
 
 ## 8. Known Technical Debt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## Unreleased
 
+## 1.2.12
+
 ### Release Operations
 - Made post-PyPI GitHub Release creation a separate idempotent job and
   dispatch release announcements explicitly, so the release-content workflow no
   longer depends on `GITHUB_TOKEN` release events.
-
-## 1.2.11
+- Hardened generated GitHub Release notes and release-content announcements so
+  they start from the last published GitHub Release instead of a stale raw tag.
+  This lets `v1.2.12` supersede the failed `v1.2.11` tag without truncating
+  public release notes.
+- Includes the release candidate originally prepared under the failed
+  `v1.2.11` tag. That tag did not publish to PyPI and has no GitHub Release.
 
 ### Reliability
 - Hardened `agentguard.__version__` so malformed local package metadata falls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ For this repo, the most relevant Claude-side assets are:
 - official MCP Registry listing: live
 - dashboard remains private
 
-Current: latest shipped release: v1.2.11.
-<!-- latest shipped release is 1.2.11 -->
+Current: latest shipped release: v1.2.12.
+<!-- latest shipped release is 1.2.12 -->
 
 Core message to preserve:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ For this repo, the most relevant Claude-side assets are:
 - official MCP Registry listing: live
 - dashboard remains private
 
-Current: latest shipped release: v1.2.12.
-<!-- latest shipped release is 1.2.12 -->
+Current release candidate: v1.2.12.
+<!-- release candidate is 1.2.12 -->
 
 Core message to preserve:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,6 +45,12 @@ package publishes and the GitHub Release exists.
    publish succeeds. If the post-publish GitHub Release or announcement step
    fails, rerun that failed job instead of republishing the package.
 
+If a tag exists but PyPI publish failed before a GitHub Release was created,
+prefer cutting the next patch version from current `main`. Do not force-move or
+delete a public release tag unless the repo owner explicitly approves it. The
+release workflow generates notes from the last published GitHub Release, not
+the last raw git tag, so a stale failed tag will not truncate public notes.
+
 ## Verification
 
 After the workflows finish:

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -1,8 +1,15 @@
 # SDK Blockers
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-29
 
 ## Active
+- **PyPI Trusted Publishing is not configured for `agentguard47`.** The
+  `v1.2.11` tag workflow passed release gates, build, and attestation, then
+  failed at PyPI with `invalid-publisher` for
+  `repo:bmdhodl/agent47:environment:pypi`. Configure the PyPI project Trusted
+  Publisher with owner `bmdhodl`, repo `agent47`, workflow filename
+  `publish.yml`, and environment `pypi`, then cut the next release from current
+  `main`.
 - **Glama tool catalog is not indexed yet.** Patrick published the first Glama
   release on 2026-05-08 and the listing is live. Glama renders tool and score
   pages, but `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` still

--- a/memory/state.md
+++ b/memory/state.md
@@ -8,8 +8,9 @@
 - SDK stays free, MIT, and local-first.
 
 ## Public Artifacts
-- PyPI package: `agentguard47`
-- Latest shipped SDK release: `1.2.11`
+- PyPI package: `agentguard47` (public latest remains `1.2.10` until the next
+  Trusted Publishing run succeeds)
+- Current release candidate: `1.2.12`
 - npm MCP package: `@agentguard47/mcp-server@0.2.2` is published.
 - Local budget MCP package: `agentguard-mcp` exists in this repo but is not
   published to npm or PyPI; dogfood installs it from the checkout.
@@ -26,6 +27,6 @@
 - hosted dashboard remains private and separate
 
 ## Current Focus
-- post-release hardening for `1.2.11`
+- release candidate `1.2.12` from current `main`
 - distribution before new features
 - coding-agent onboarding and proof

--- a/ops/02-ARCHITECTURE.md
+++ b/ops/02-ARCHITECTURE.md
@@ -135,9 +135,11 @@ the pushed `vX.Y.Z` tag matches `sdk/pyproject.toml`, runs the release gates,
 publishes `agentguard47` to PyPI, then creates or verifies the GitHub Release in
 a separate post-publish job. That job explicitly dispatches release-content
 automation after the release exists, so announcements do not depend on release
-events emitted by the workflow token. The GitHub Release remains intentionally
-after PyPI publish so the public release page does not advertise a version that
-failed to publish.
+events emitted by the workflow token. Generated release notes and release
+announcements start from the last published GitHub Release rather than the last
+raw git tag, so a failed tag without a public release does not truncate the next
+release notes. The GitHub Release remains intentionally after PyPI publish so
+the public release page does not advertise a version that failed to publish.
 
 These proof surfaces should stay offline by default and must not require the
 hosted dashboard.

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -7,8 +7,9 @@ they directly strengthen coding-agent adoption.
 
 ## Current Focus Notes
 
-- Latest shipped SDK release is `v1.2.11`; current work is post-release
-  hardening and activation, not a new feature push.
+- Current SDK release candidate is `v1.2.12` from `main`; public PyPI latest
+  remains `v1.2.10` until Trusted Publishing succeeds. The stale `v1.2.11` tag
+  failed to publish and should not be reused without explicit owner approval.
 - Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`,
   but public registry search still reports MCP package version `0.2.1`; refresh
   metadata without changing SDK runtime code.

--- a/proof/release-v1.2.12/clean-venv-smoke.log
+++ b/proof/release-v1.2.12/clean-venv-smoke.log
@@ -1,0 +1,49 @@
+AgentGuard v1.2.12 clean venv smoke
+Date: 2026-05-29
+
+Built wheel:
+  agentguard47-1.2.12-py3-none-any.whl
+
+Installed into isolated venv:
+  Successfully installed agentguard47-1.2.12
+  agentguard.__version__=1.2.12
+  metadata=1.2.12
+  import path=<temp-venv>\Lib\site-packages\agentguard\__init__.py
+
+agentguard doctor:
+  [ok] Python: 3.13.2
+  [ok] agentguard47: 1.2.12
+  [ok] init(local_only=True): wrote 4 events to agentguard_doctor_trace.jsonl
+  [ok] Optional integrations detected: none
+
+agentguard demo:
+  BudgetGuard warning fired at $0.84
+  BudgetGuard stopped on call 9: cost $1.08 exceeded $1.00
+  LoopGuard stopped repeated tool.search calls
+  RetryGuard stopped fetch_docs retry storm
+  Trace written to: agentguard_demo_traces.jsonl
+
+agentguard quickstart --framework raw --write:
+  Wrote starter: agentguard_raw_quickstart.py
+  No dashboard and no provider API keys required.
+
+python agentguard_raw_quickstart.py:
+  BudgetGuard stopped simulated spend: cost budget exceeded $5.02 > $5.00
+  LoopGuard stopped repeated tool.search calls
+  Traces saved to .agentguard/traces.jsonl
+
+agentguard report .agentguard/traces.jsonl:
+  Total events: 14
+  Estimated cost: $5.0200
+  Guard events:
+    guard.budget_exceeded: 1
+    guard.loop_detected: 1
+
+agentguard report agentguard_demo_traces.jsonl:
+  Total events: 36
+  Estimated cost: $1.0800
+  Guard events:
+    guard.budget_warning: 1
+    guard.budget_exceeded: 1
+    guard.loop_detected: 1
+    guard.retry_limit_exceeded: 1

--- a/proof/release-v1.2.12/validation-summary.md
+++ b/proof/release-v1.2.12/validation-summary.md
@@ -1,0 +1,64 @@
+# AgentGuard v1.2.12 Release Prep Validation
+
+Date: 2026-05-29
+
+## Release Context
+
+- `v1.2.11` tag exists, but PyPI publish failed before a GitHub Release was created.
+- `v1.2.12` is the next release candidate from current `main`.
+- Release notes and release-content automation now start from the last published GitHub Release instead of the last raw git tag.
+
+## Commands Run
+
+```powershell
+python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py sdk/tests/test_sdk_release_guard.py -q
+python scripts/sdk_release_guard.py --json
+git diff --check
+python -m ruff check sdk/tests/test_ci_guardrails.py scripts/generate_pypi_readme.py scripts/sdk_release_guard.py scripts/sdk_preflight.py
+python scripts/ci_tools_requirements_guard.py
+python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py
+python scripts/sdk_preflight.py
+python -m pytest sdk/tests/test_architecture.py -v
+python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80
+python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q
+npm --prefix mcp-server ci
+npm --prefix mcp-server test
+npm --prefix mcp-server run build
+python -m pip install -e ./agentguard-mcp
+python -m ruff check agentguard_mcp tests
+python -m pytest
+python -m build ./sdk --wheel
+python -m venv <temp-venv>
+pip install --no-index --find-links <wheelhouse> agentguard47-1.2.12-py3-none-any.whl
+agentguard doctor
+agentguard demo
+agentguard quickstart --framework raw --write
+python agentguard_raw_quickstart.py
+agentguard report .agentguard/traces.jsonl
+agentguard report agentguard_demo_traces.jsonl
+```
+
+## Results
+
+- Targeted release tests: 18 passed.
+- Release guard: no findings.
+- SDK preflight: passed.
+- Direct `make check` equivalents: CI tools guard passed, Makefile lint target passed, full SDK test passed, MCP test passed.
+- Structural tests: 9 passed.
+- Security scan: passed.
+- Full SDK suite: 772 passed, coverage 92.84%.
+- TypeScript MCP server: `npm ci`, 10 tests, and `tsc` build passed.
+- Python local-budget MCP: ruff passed, 15 tests passed.
+- Clean venv wheel smoke:
+  - `agentguard.__version__=1.2.12`
+  - package metadata `1.2.12`
+  - `doctor` verified local-only install.
+  - `demo` visibly tripped budget, loop, and retry guards.
+  - generated raw quickstart ran and tripped budget plus loop guards.
+  - local reports showed guard events and non-zero local trace output.
+
+## Notes
+
+- Local `go` is not installed, so `go run actionlint` was not available. CI Actionlint remains the workflow syntax authority.
+- Local `make` is not installed; direct Makefile command equivalents were run instead.
+- The user-site Python install has stale/broken `~gentguard47` metadata. Clean venv proof above avoids that contamination.

--- a/proof/release-v1.2.12/validation-summary.md
+++ b/proof/release-v1.2.12/validation-summary.md
@@ -46,7 +46,7 @@ agentguard report agentguard_demo_traces.jsonl
 - Direct `make check` equivalents: CI tools guard passed, Makefile lint target passed, full SDK test passed, MCP test passed.
 - Structural tests: 9 passed.
 - Security scan: passed.
-- Full SDK suite: 772 passed, coverage 92.84%.
+- Full SDK suite: 772 passed, coverage 92.82% after the release-candidate wording review fix.
 - TypeScript MCP server: `npm ci`, 10 tests, and `tsc` build passed.
 - Python local-budget MCP: ruff passed, 15 tests passed.
 - Clean venv wheel smoke:

--- a/scripts/sdk_release_guard.py
+++ b/scripts/sdk_release_guard.py
@@ -21,11 +21,12 @@ MCP_PACKAGE_PATH = Path("mcp-server/package.json")
 MCP_SERVER_JSON_PATH = Path("mcp-server/server.json")
 MCP_RUNTIME_INDEX_PATH = Path("mcp-server/src/index.ts")
 RELEASE_MARKERS = (
-    ("AGENTS.md", r"latest shipped release: v(?P<version>\d+\.\d+\.\d+)"),
-    ("AGENTS.md", r"latest shipped release is (?P<version>\d+\.\d+\.\d+)"),
-    ("CLAUDE.md", r"latest shipped release: v(?P<version>\d+\.\d+\.\d+)"),
-    ("CLAUDE.md", r"latest shipped release is (?P<version>\d+\.\d+\.\d+)"),
-    (".claude/agents/sdk-dev.md", r"Latest shipped SDK release: `v(?P<version>\d+\.\d+\.\d+)`"),
+    ("AGENTS.md", r"release candidate: v(?P<version>\d+\.\d+\.\d+)"),
+    ("AGENTS.md", r"current SDK release candidate is (?P<version>\d+\.\d+\.\d+)"),
+    ("AGENTS.md", r"current release candidate is (?P<version>\d+\.\d+\.\d+)"),
+    ("CLAUDE.md", r"Current release candidate: v(?P<version>\d+\.\d+\.\d+)"),
+    ("CLAUDE.md", r"release candidate is (?P<version>\d+\.\d+\.\d+)"),
+    (".claude/agents/sdk-dev.md", r"Current SDK release candidate: `v(?P<version>\d+\.\d+\.\d+)`"),
 )
 
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -17,7 +17,7 @@ enough to create surprise spend.
 [![Python](https://img.shields.io/pypi/pyversions/agentguard47)](https://pypi.org/project/agentguard47/)
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.11/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.12/LICENSE)
 [![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/score.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
@@ -158,7 +158,7 @@ What you should see:
 - `report` shows local trace counts, cost, savings, and guard events.
 
 Notebook version:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.11/examples/quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.12/examples/quickstart.ipynb)
 
 ## Copy-Paste Repo Setup
 
@@ -252,12 +252,12 @@ All examples are local-first. No API key is required unless the example says so.
 
 | Example | What it proves |
 |---|---|
-| [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/try_it_now.py) | budget, loop, and retry stops |
 | [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/main/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
-| [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
-| [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
-| [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |
-| [`examples/decision_trace_workflow.py`](https://github.com/bmdhodl/agent47/blob/v1.2.11/examples/decision_trace_workflow.py) | proposal, edit, approval, and binding decision events |
+| [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
+| [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
+| [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |
+| [`examples/decision_trace_workflow.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/decision_trace_workflow.py) | proposal, edit, approval, and binding decision events |
 
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md)
@@ -266,7 +266,7 @@ Proof gallery:
 [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md)
 
 Starter files:
-[`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.11/examples/starters)
+[`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.12/examples/starters)
 
 ## Framework Integrations
 
@@ -308,8 +308,8 @@ layer.
 
 Competitive notes:
 
-- [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/competitive/vercel-ai-gateway.md)
-- [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/competitive/manifest.md)
+- [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/competitive/vercel-ai-gateway.md)
+- [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](https://github.com/bmdhodl/agent47/blob/main/docs/competitive/agent-security-stack.md)
 
 ## Decision Traces
@@ -424,7 +424,7 @@ assert result.passed
 - Core runtime dependencies: zero
 - Trace format: JSONL
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
-- MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.11/mcp-server)
+- MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.12/mcp-server)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 [![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/card.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
@@ -433,15 +433,15 @@ assert result.passed
 
 | Topic | Link |
 |---|---|
-| Getting started | [`docs/guides/getting-started.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/getting-started.md) |
-| Coding-agent setup | [`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/coding-agents.md) |
-| Safety pack | [`docs/guides/coding-agent-safety-pack.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/coding-agent-safety-pack.md) |
+| Getting started | [`docs/guides/getting-started.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/getting-started.md) |
+| Coding-agent setup | [`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/coding-agents.md) |
+| Safety pack | [`docs/guides/coding-agent-safety-pack.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/coding-agent-safety-pack.md) |
 | Dashboard contract | [`docs/guides/dashboard-contract.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/dashboard-contract.md) |
 | Decision traces | [`docs/guides/decision-tracing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/decision-tracing.md) |
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/managed-agent-sessions.md) |
-| Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/guides/activation-metrics-design.md) |
+| Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/activation-metrics-design.md) |
 | Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md) |
-| Releasing | [`docs/RELEASING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/docs/RELEASING.md) |
+| Releasing | [`docs/RELEASING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/RELEASING.md) |
 | Release cadence | [`docs/release/cadence.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/cadence.md) |
 | PyPI Trusted Publishing | [`docs/release/trusted-publishing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/trusted-publishing.md) |
 
@@ -506,14 +506,25 @@ python scripts/sdk_release_guard.py
 
 Useful links:
 
-- [`CONTRIBUTING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/CONTRIBUTING.md)
-- [`GOLDEN_PRINCIPLES.md`](https://github.com/bmdhodl/agent47/blob/v1.2.11/GOLDEN_PRINCIPLES.md)
+- [`CONTRIBUTING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/CONTRIBUTING.md)
+- [`GOLDEN_PRINCIPLES.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/GOLDEN_PRINCIPLES.md)
 
 ## License
 
-MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.11/LICENSE).
+MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.12/LICENSE).
 
-## Latest Release Notes (1.2.11)
+## Latest Release Notes (1.2.12)
+
+### Release Operations
+- Made post-PyPI GitHub Release creation a separate idempotent job and
+  dispatch release announcements explicitly, so the release-content workflow no
+  longer depends on `GITHUB_TOKEN` release events.
+- Hardened generated GitHub Release notes and release-content announcements so
+  they start from the last published GitHub Release instead of a stale raw tag.
+  This lets `v1.2.12` supersede the failed `v1.2.11` tag without truncating
+  public release notes.
+- Includes the release candidate originally prepared under the failed
+  `v1.2.11` tag. That tag did not publish to PyPI and has no GitHub Release.
 
 ### Reliability
 - Hardened `agentguard.__version__` so malformed local package metadata falls
@@ -587,4 +598,4 @@ MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.11/LICENSE).
 - Refreshed the MCP server lockfile so `npm audit` no longer reports the
   transitive `fast-uri` or `qs` advisories.
 
-Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.11/CHANGELOG.md)
+Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.12/CHANGELOG.md)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentguard47"
-version = "1.2.11"
+version = "1.2.12"
 description = "Zero-dependency runtime control for production Python agents - stop loops, retry storms, and budget burn"
 readme = "PYPI_README.md"
 requires-python = ">=3.9"

--- a/sdk/tests/test_ci_guardrails.py
+++ b/sdk/tests/test_ci_guardrails.py
@@ -56,6 +56,9 @@ def test_release_content_waits_for_published_github_release() -> None:
     )
     assert all(not line.startswith("  push:") for line in lines)
     assert "github.event.inputs.tag || github.event.release.tag_name" in text
+    assert 'gh release list --exclude-drafts --exclude-pre-releases --json tagName' in text
+    assert 'PREV_TAG="$(gh release list' in text
+    assert 'git tag --sort=-creatordate' not in text
 
 
 def test_publish_workflow_release_steps_are_post_publish_rerunnable() -> None:
@@ -90,5 +93,7 @@ def test_publish_workflow_release_steps_are_post_publish_rerunnable() -> None:
     assert "Create GitHub Release" not in publish_job
     assert 'gh release view "$TAG"' in release_job
     assert 'gh release create "$TAG"' in release_job
+    assert "--notes-start-tag" in release_job
+    assert 'PREV_RELEASE_TAG="$(gh release list' in release_job
     assert "gh workflow run release-content.yml" in release_job
     assert '-f tag="$TAG"' in release_job

--- a/sdk/tests/test_sdk_release_guard.py
+++ b/sdk/tests/test_sdk_release_guard.py
@@ -46,17 +46,18 @@ class TestReleaseGuardHelpers(unittest.TestCase):
             files = {
                 "AGENTS.md": textwrap.dedent(
                     """
-                    latest shipped release: v0.0.1
-                    latest shipped release is 0.0.1
+                    release candidate: v0.0.1
+                    current SDK release candidate is 0.0.1
+                    current release candidate is 0.0.1
                     """
                 ),
                 "CLAUDE.md": textwrap.dedent(
                     """
-                    latest shipped release: v0.0.1
-                    latest shipped release is 0.0.1
+                    Current release candidate: v0.0.1
+                    release candidate is 0.0.1
                     """
                 ),
-                ".claude/agents/sdk-dev.md": "Latest shipped SDK release: `v0.0.1`\n",
+                ".claude/agents/sdk-dev.md": "Current SDK release candidate: `v0.0.1`\n",
             }
             for relative_path, content in files.items():
                 path = repo_root / relative_path

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires Python 3.9+
 metadata:
   author: bmdhodl
-  version: "1.2.11"
+  version: "1.2.12"
   pypi: agentguard47
 ---
 


### PR DESCRIPTION
﻿## Summary
- prepares `agentguard47` release candidate `v1.2.12` from current `main` because `v1.2.11` is a stale failed tag with no PyPI publish and no GitHub Release
- hardens release-note generation and release-content announcements to diff from the last published GitHub Release instead of the last raw git tag
- updates release docs, memory/ops notes, PyPI README, SDK skill/version markers, and adds durable validation proof under `proof/release-v1.2.12/`

## Bug class killed
Release automation could truncate public notes after a failed tag because generated notes used the previous raw git tag, even when that tag never became a published GitHub Release.

## Proof
- `python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py sdk/tests/test_sdk_release_guard.py -q` -> 18 passed
- `python scripts/sdk_release_guard.py --json` -> `[]`
- `python scripts/sdk_preflight.py` -> passed
- `python scripts/ci_tools_requirements_guard.py` -> passed
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py` -> passed
- `python -m pytest sdk/tests/test_architecture.py -v` -> 9 passed
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 772 passed, coverage 92.84%
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q` -> passed
- `npm --prefix mcp-server ci && npm --prefix mcp-server test && npm --prefix mcp-server run build` -> passed, 10 MCP tests
- `python -m pip install -e ./agentguard-mcp && cd agentguard-mcp && python -m ruff check agentguard_mcp tests && python -m pytest` -> passed, 15 tests
- clean venv wheel smoke from built `agentguard47-1.2.12-py3-none-any.whl`: `doctor`, `demo`, `quickstart --framework raw --write`, generated starter, and local reports passed

Saved proof: `proof/release-v1.2.12/validation-summary.md` and `proof/release-v1.2.12/clean-venv-smoke.log`.

## Notes
- Local `make` is not installed here, so direct Makefile equivalents were run.
- Local `go` is not installed, so `go run actionlint` was not available. CI Actionlint should remain the workflow syntax authority.
- Do not tag `v1.2.12` until PyPI Trusted Publishing is configured for owner `bmdhodl`, repo `agent47`, workflow `publish.yml`, environment `pypi`.
