### PR TITLE
Prepare v1.2.13 release

### DIFF
--- a/.claude/agents/sdk-dev.md
+++ b/.claude/agents/sdk-dev.md
@@ -18,7 +18,7 @@ gh issue list --repo bmdhodl/agent47 --label component:sdk --state open --limit 
 
 ## Current Focus
 
-Current SDK release candidate: `v1.2.12`.
+Current SDK release candidate: `v1.2.13`.
 
 Source of truth for priorities:
 - `ops/00-NORTHSTAR.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ AgentGuard — a zero-dependency runtime guardrails SDK for coding agents and AI
 
 - **Repo:** github.com/bmdhodl/agent47
 - **Dashboard repo:** github.com/bmdhodl/agent47-dashboard (private)
-- **Package:** `agentguard47` on PyPI (release status tracked in `memory/state.md`; release candidate: v1.2.12)
+- **Package:** `agentguard47` on PyPI (release status tracked in `memory/state.md`; release candidate: v1.2.13)
 - **Landing page:** site/index.html (Vercel)
 
 ## Agent Contract (MANDATORY)
@@ -197,7 +197,7 @@ Read .Codex/agents/sdk-dev.md and follow those instructions.
 
 **Project board:** https://github.com/users/bmdhodl/projects/4
 
-**Current:** current SDK release candidate is 1.2.12. Read `memory/` for the
+**Current:** current SDK release candidate is 1.2.13. Read `memory/` for the
 public package state, blockers, decisions, and distribution priorities.
 
 ## Agent Navigation Guide
@@ -242,7 +242,7 @@ Step-by-step instructions for common tasks. Follow these patterns for consistenc
 ### Identity
 
 - **Package:** `agentguard47`
-- **Version:** current release candidate is 1.2.12. Check `sdk/pyproject.toml` for the branch version under preparation.
+- **Version:** current release candidate is 1.2.13. Check `sdk/pyproject.toml` for the branch version under preparation.
 - **Repo:** https://github.com/bmdhodl/agent47
 - **License:** MIT
 - **Dashboard:** Private repo `agent47-dashboard` (BSL 1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.2.12
+## 1.2.13
 
 ### Release Operations
 - Made post-PyPI GitHub Release creation a separate idempotent job and
@@ -10,10 +10,13 @@
   longer depends on `GITHUB_TOKEN` release events.
 - Hardened generated GitHub Release notes and release-content announcements so
   they start from the last published GitHub Release instead of a stale raw tag.
-  This lets `v1.2.12` supersede the failed `v1.2.11` tag without truncating
-  public release notes.
+  This lets `v1.2.13` supersede the failed `v1.2.11` and `v1.2.12` tags without
+  truncating public release notes.
 - Includes the release candidate originally prepared under the failed
   `v1.2.11` tag. That tag did not publish to PyPI and has no GitHub Release.
+- Supersedes the stale `v1.2.12` tag, which was pushed from a checkout still
+  carrying `sdk/pyproject.toml` version `1.2.10`. That tag did not publish a new
+  PyPI version and has no GitHub Release.
 
 ### Reliability
 - Hardened `agentguard.__version__` so malformed local package metadata falls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ For this repo, the most relevant Claude-side assets are:
 - official MCP Registry listing: live
 - dashboard remains private
 
-Current release candidate: v1.2.12.
-<!-- release candidate is 1.2.12 -->
+Current release candidate: v1.2.13.
+<!-- release candidate is 1.2.13 -->
 
 Core message to preserve:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,12 +31,13 @@ package publishes and the GitHub Release exists.
    ```
 
 7. Merge the release-prep PR.
-8. Tag the merge commit:
+8. Tag the merge commit. Verify the version from `HEAD` before pushing:
 
    ```bash
    git checkout main
    git pull --ff-only
    VERSION=$(python -c "import tomllib; print(tomllib.load(open('sdk/pyproject.toml','rb'))['project']['version'])")
+   git show HEAD:sdk/pyproject.toml | grep -Fx "version = \"$VERSION\"" || exit 1
    git tag "v$VERSION"
    git push origin "v$VERSION"
    ```

--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -1,15 +1,18 @@
 # SDK Blockers
 
-**Last Updated:** 2026-05-29
+**Last Updated:** 2026-05-30
 
 ## Active
-- **PyPI Trusted Publishing is not configured for `agentguard47`.** The
-  `v1.2.11` tag workflow passed release gates, build, and attestation, then
-  failed at PyPI with `invalid-publisher` for
-  `repo:bmdhodl/agent47:environment:pypi`. Configure the PyPI project Trusted
-  Publisher with owner `bmdhodl`, repo `agent47`, workflow filename
-  `publish.yml`, and environment `pypi`, then cut the next release from current
-  `main`.
+- **`v1.2.12` is a stale failed release tag.** The tag was pushed from
+  `8fd0295db19333d882bffed6002e18ea24fadec3`, a checkout whose
+  `sdk/pyproject.toml` still says `1.2.10`. The publish workflow authenticated
+  and reached PyPI, then failed because it tried to upload existing
+  `agentguard47-1.2.10` files. Do not rerun or reuse `v1.2.12`; cut the next
+  patch release from current `main`.
+- **`v1.2.11` is also stale.** The tag workflow passed release gates, build, and
+  attestation, then failed at PyPI with `invalid-publisher` for
+  `repo:bmdhodl/agent47:environment:pypi`. It has no PyPI release and no GitHub
+  Release.
 - **Glama tool catalog is not indexed yet.** Patrick published the first Glama
   release on 2026-05-08 and the listing is live. Glama renders tool and score
   pages, but `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` still

--- a/memory/state.md
+++ b/memory/state.md
@@ -10,7 +10,7 @@
 ## Public Artifacts
 - PyPI package: `agentguard47` (public latest remains `1.2.10` until the next
   Trusted Publishing run succeeds)
-- Current release candidate: `1.2.12`
+- Current release candidate: `1.2.13`
 - npm MCP package: `@agentguard47/mcp-server@0.2.2` is published.
 - Local budget MCP package: `agentguard-mcp` exists in this repo but is not
   published to npm or PyPI; dogfood installs it from the checkout.
@@ -27,6 +27,6 @@
 - hosted dashboard remains private and separate
 
 ## Current Focus
-- release candidate `1.2.12` from current `main`
+- release candidate `1.2.13` from current `main`
 - distribution before new features
 - coding-agent onboarding and proof

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -7,9 +7,10 @@ they directly strengthen coding-agent adoption.
 
 ## Current Focus Notes
 
-- Current SDK release candidate is `v1.2.12` from `main`; public PyPI latest
-  remains `v1.2.10` until Trusted Publishing succeeds. The stale `v1.2.11` tag
-  failed to publish and should not be reused without explicit owner approval.
+- Current SDK release candidate is `v1.2.13` from `main`; public PyPI latest
+  remains `v1.2.10` until the next tag publish succeeds. The stale `v1.2.11`
+  tag failed before PyPI publish, and the stale `v1.2.12` tag points at a
+  `1.2.10` checkout. Do not reuse either tag without explicit owner approval.
 - Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`,
   but public registry search still reports MCP package version `0.2.1`; refresh
   metadata without changing SDK runtime code.

--- a/proof/release-v1.2.13/clean-venv-smoke.log
+++ b/proof/release-v1.2.13/clean-venv-smoke.log
@@ -1,0 +1,470 @@
+AgentGuard v1.2.13 clean venv smoke
+Date: 2026-05-30
+
+> python -m build sdk --outdir C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-dist-aaacbfa4ddc9454ab36c049957c9f816
+running egg_info
+writing agentguard47.egg-info\PKG-INFO
+writing dependency_links to agentguard47.egg-info\dependency_links.txt
+writing entry points to agentguard47.egg-info\entry_points.txt
+writing requirements to agentguard47.egg-info\requires.txt
+writing top-level names to agentguard47.egg-info\top_level.txt
+reading manifest file 'agentguard47.egg-info\SOURCES.txt'
+adding license file 'LICENSE'
+writing manifest file 'agentguard47.egg-info\SOURCES.txt'
+running sdist
+running egg_info
+writing agentguard47.egg-info\PKG-INFO
+writing dependency_links to agentguard47.egg-info\dependency_links.txt
+writing entry points to agentguard47.egg-info\entry_points.txt
+writing requirements to agentguard47.egg-info\requires.txt
+writing top-level names to agentguard47.egg-info\top_level.txt
+reading manifest file 'agentguard47.egg-info\SOURCES.txt'
+adding license file 'LICENSE'
+writing manifest file 'agentguard47.egg-info\SOURCES.txt'
+running check
+creating agentguard47-1.2.13
+creating agentguard47-1.2.13\agentguard
+creating agentguard47-1.2.13\agentguard\integrations
+creating agentguard47-1.2.13\agentguard\sinks
+creating agentguard47-1.2.13\agentguard47.egg-info
+creating agentguard47-1.2.13\tests
+copying files to agentguard47-1.2.13...
+copying LICENSE -> agentguard47-1.2.13
+copying PYPI_README.md -> agentguard47-1.2.13
+copying README.md -> agentguard47-1.2.13
+copying pyproject.toml -> agentguard47-1.2.13
+copying .\agentguard\__init__.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\_trace_naming.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\atracing.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\cli.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\cost.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\decision.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\demo.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\doctor.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\escalation.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\evaluation.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\export.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\first_run.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\goal.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\guards.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\instrument.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\profiles.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\py.typed -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\quickstart.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\repo_config.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\reporting.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\savings.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\schemas.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\setup.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\skillpack.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\tracing.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\usage.py -> agentguard47-1.2.13\.\agentguard
+copying .\agentguard\integrations\__init__.py -> agentguard47-1.2.13\.\agentguard\integrations
+copying .\agentguard\integrations\crewai.py -> agentguard47-1.2.13\.\agentguard\integrations
+copying .\agentguard\integrations\langchain.py -> agentguard47-1.2.13\.\agentguard\integrations
+copying .\agentguard\integrations\langgraph.py -> agentguard47-1.2.13\.\agentguard\integrations
+copying .\agentguard\sinks\__init__.py -> agentguard47-1.2.13\.\agentguard\sinks
+copying .\agentguard\sinks\http.py -> agentguard47-1.2.13\.\agentguard\sinks
+copying .\agentguard\sinks\otel.py -> agentguard47-1.2.13\.\agentguard\sinks
+copying agentguard\__init__.py -> agentguard47-1.2.13\agentguard
+copying agentguard\_trace_naming.py -> agentguard47-1.2.13\agentguard
+copying agentguard\atracing.py -> agentguard47-1.2.13\agentguard
+copying agentguard\cli.py -> agentguard47-1.2.13\agentguard
+copying agentguard\cost.py -> agentguard47-1.2.13\agentguard
+copying agentguard\decision.py -> agentguard47-1.2.13\agentguard
+copying agentguard\demo.py -> agentguard47-1.2.13\agentguard
+copying agentguard\doctor.py -> agentguard47-1.2.13\agentguard
+copying agentguard\escalation.py -> agentguard47-1.2.13\agentguard
+copying agentguard\evaluation.py -> agentguard47-1.2.13\agentguard
+copying agentguard\export.py -> agentguard47-1.2.13\agentguard
+copying agentguard\first_run.py -> agentguard47-1.2.13\agentguard
+copying agentguard\goal.py -> agentguard47-1.2.13\agentguard
+copying agentguard\guards.py -> agentguard47-1.2.13\agentguard
+copying agentguard\instrument.py -> agentguard47-1.2.13\agentguard
+copying agentguard\profiles.py -> agentguard47-1.2.13\agentguard
+copying agentguard\py.typed -> agentguard47-1.2.13\agentguard
+copying agentguard\quickstart.py -> agentguard47-1.2.13\agentguard
+copying agentguard\repo_config.py -> agentguard47-1.2.13\agentguard
+copying agentguard\reporting.py -> agentguard47-1.2.13\agentguard
+copying agentguard\savings.py -> agentguard47-1.2.13\agentguard
+copying agentguard\schemas.py -> agentguard47-1.2.13\agentguard
+copying agentguard\setup.py -> agentguard47-1.2.13\agentguard
+copying agentguard\skillpack.py -> agentguard47-1.2.13\agentguard
+copying agentguard\tracing.py -> agentguard47-1.2.13\agentguard
+copying agentguard\usage.py -> agentguard47-1.2.13\agentguard
+copying agentguard47.egg-info\PKG-INFO -> agentguard47-1.2.13\agentguard47.egg-info
+copying agentguard47.egg-info\SOURCES.txt -> agentguard47-1.2.13\agentguard47.egg-info
+copying agentguard47.egg-info\dependency_links.txt -> agentguard47-1.2.13\agentguard47.egg-info
+copying agentguard47.egg-info\entry_points.txt -> agentguard47-1.2.13\agentguard47.egg-info
+copying agentguard47.egg-info\requires.txt -> agentguard47-1.2.13\agentguard47.egg-info
+copying agentguard47.egg-info\top_level.txt -> agentguard47-1.2.13\agentguard47.egg-info
+copying agentguard\integrations\__init__.py -> agentguard47-1.2.13\agentguard\integrations
+copying agentguard\integrations\crewai.py -> agentguard47-1.2.13\agentguard\integrations
+copying agentguard\integrations\langchain.py -> agentguard47-1.2.13\agentguard\integrations
+copying agentguard\integrations\langgraph.py -> agentguard47-1.2.13\agentguard\integrations
+copying agentguard\sinks\__init__.py -> agentguard47-1.2.13\agentguard\sinks
+copying agentguard\sinks\http.py -> agentguard47-1.2.13\agentguard\sinks
+copying agentguard\sinks\otel.py -> agentguard47-1.2.13\agentguard\sinks
+copying tests\test_architecture.py -> agentguard47-1.2.13\tests
+copying tests\test_async_patches.py -> agentguard47-1.2.13\tests
+copying tests\test_atracing.py -> agentguard47-1.2.13\tests
+copying tests\test_ci_guardrails.py -> agentguard47-1.2.13\tests
+copying tests\test_ci_tools_requirements_guard.py -> agentguard47-1.2.13\tests
+copying tests\test_cli_report.py -> agentguard47-1.2.13\tests
+copying tests\test_concurrency.py -> agentguard47-1.2.13\tests
+copying tests\test_cost.py -> agentguard47-1.2.13\tests
+copying tests\test_cost_guardrail.py -> agentguard47-1.2.13\tests
+copying tests\test_coverage_gaps.py -> agentguard47-1.2.13\tests
+copying tests\test_crewai_integration.py -> agentguard47-1.2.13\tests
+copying tests\test_dashboard_handoff_docs.py -> agentguard47-1.2.13\tests
+copying tests\test_decision_trace.py -> agentguard47-1.2.13\tests
+copying tests\test_demo.py -> agentguard47-1.2.13\tests
+copying tests\test_doctor.py -> agentguard47-1.2.13\tests
+copying tests\test_dx.py -> agentguard47-1.2.13\tests
+copying tests\test_e2e_pipeline.py -> agentguard47-1.2.13\tests
+copying tests\test_evaluation.py -> agentguard47-1.2.13\tests
+copying tests\test_example_starters.py -> agentguard47-1.2.13\tests
+copying tests\test_export.py -> agentguard47-1.2.13\tests
+copying tests\test_exports.py -> agentguard47-1.2.13\tests
+copying tests\test_first_run.py -> agentguard47-1.2.13\tests
+copying tests\test_goal.py -> agentguard47-1.2.13\tests
+copying tests\test_guards.py -> agentguard47-1.2.13\tests
+copying tests\test_hardening.py -> agentguard47-1.2.13\tests
+copying tests\test_hosted_ingest_contract.py -> agentguard47-1.2.13\tests
+copying tests\test_http_sink.py -> agentguard47-1.2.13\tests
+copying tests\test_init.py -> agentguard47-1.2.13\tests
+copying tests\test_instrument.py -> agentguard47-1.2.13\tests
+copying tests\test_instrument_patch.py -> agentguard47-1.2.13\tests
+copying tests\test_integration_cost_guardrail.py -> agentguard47-1.2.13\tests
+copying tests\test_integration_dashboard_script.py -> agentguard47-1.2.13\tests
+copying tests\test_langchain_integration.py -> agentguard47-1.2.13\tests
+copying tests\test_langgraph_integration.py -> agentguard47-1.2.13\tests
+copying tests\test_mcp_registry_metadata.py -> agentguard47-1.2.13\tests
+copying tests\test_otel_sink.py -> agentguard47-1.2.13\tests
+copying tests\test_production.py -> agentguard47-1.2.13\tests
+copying tests\test_pypi_readme_sync.py -> agentguard47-1.2.13\tests
+copying tests\test_quickstart.py -> agentguard47-1.2.13\tests
+copying tests\test_release_discussion_category.py -> agentguard47-1.2.13\tests
+copying tests\test_repo_config.py -> agentguard47-1.2.13\tests
+copying tests\test_reporting.py -> agentguard47-1.2.13\tests
+copying tests\test_savings.py -> agentguard47-1.2.13\tests
+copying tests\test_schemas.py -> agentguard47-1.2.13\tests
+copying tests\test_sdk_preflight.py -> agentguard47-1.2.13\tests
+copying tests\test_sdk_release_guard.py -> agentguard47-1.2.13\tests
+copying tests\test_skillpack.py -> agentguard47-1.2.13\tests
+copying tests\test_smoke.py -> agentguard47-1.2.13\tests
+copying tests\test_sticky_agent_proof.py -> agentguard47-1.2.13\tests
+copying tests\test_tracing.py -> agentguard47-1.2.13\tests
+copying tests\test_v1_coverage.py -> agentguard47-1.2.13\tests
+copying agentguard47.egg-info\SOURCES.txt -> agentguard47-1.2.13\agentguard47.egg-info
+Writing agentguard47-1.2.13\setup.cfg
+Creating tar archive
+removing 'agentguard47-1.2.13' (and everything under it)
+running egg_info
+writing agentguard47.egg-info\PKG-INFO
+writing dependency_links to agentguard47.egg-info\dependency_links.txt
+writing entry points to agentguard47.egg-info\entry_points.txt
+writing requirements to agentguard47.egg-info\requires.txt
+writing top-level names to agentguard47.egg-info\top_level.txt
+reading manifest file 'agentguard47.egg-info\SOURCES.txt'
+adding license file 'LICENSE'
+writing manifest file 'agentguard47.egg-info\SOURCES.txt'
+running bdist_wheel
+running build
+running build_py
+creating build\lib\agentguard
+copying .\agentguard\atracing.py -> build\lib\agentguard
+copying .\agentguard\cli.py -> build\lib\agentguard
+copying .\agentguard\cost.py -> build\lib\agentguard
+copying .\agentguard\decision.py -> build\lib\agentguard
+copying .\agentguard\demo.py -> build\lib\agentguard
+copying .\agentguard\doctor.py -> build\lib\agentguard
+copying .\agentguard\escalation.py -> build\lib\agentguard
+copying .\agentguard\evaluation.py -> build\lib\agentguard
+copying .\agentguard\export.py -> build\lib\agentguard
+copying .\agentguard\first_run.py -> build\lib\agentguard
+copying .\agentguard\goal.py -> build\lib\agentguard
+copying .\agentguard\guards.py -> build\lib\agentguard
+copying .\agentguard\instrument.py -> build\lib\agentguard
+copying .\agentguard\profiles.py -> build\lib\agentguard
+copying .\agentguard\quickstart.py -> build\lib\agentguard
+copying .\agentguard\reporting.py -> build\lib\agentguard
+copying .\agentguard\repo_config.py -> build\lib\agentguard
+copying .\agentguard\savings.py -> build\lib\agentguard
+copying .\agentguard\schemas.py -> build\lib\agentguard
+copying .\agentguard\setup.py -> build\lib\agentguard
+copying .\agentguard\skillpack.py -> build\lib\agentguard
+copying .\agentguard\tracing.py -> build\lib\agentguard
+copying .\agentguard\usage.py -> build\lib\agentguard
+copying .\agentguard\_trace_naming.py -> build\lib\agentguard
+copying .\agentguard\__init__.py -> build\lib\agentguard
+creating build\lib\agentguard\integrations
+copying .\agentguard\integrations\crewai.py -> build\lib\agentguard\integrations
+copying .\agentguard\integrations\langchain.py -> build\lib\agentguard\integrations
+copying .\agentguard\integrations\langgraph.py -> build\lib\agentguard\integrations
+copying .\agentguard\integrations\__init__.py -> build\lib\agentguard\integrations
+creating build\lib\agentguard\sinks
+copying .\agentguard\sinks\http.py -> build\lib\agentguard\sinks
+copying .\agentguard\sinks\otel.py -> build\lib\agentguard\sinks
+copying .\agentguard\sinks\__init__.py -> build\lib\agentguard\sinks
+running egg_info
+writing agentguard47.egg-info\PKG-INFO
+writing dependency_links to agentguard47.egg-info\dependency_links.txt
+writing entry points to agentguard47.egg-info\entry_points.txt
+writing requirements to agentguard47.egg-info\requires.txt
+writing top-level names to agentguard47.egg-info\top_level.txt
+reading manifest file 'agentguard47.egg-info\SOURCES.txt'
+adding license file 'LICENSE'
+writing manifest file 'agentguard47.egg-info\SOURCES.txt'
+copying .\agentguard\py.typed -> build\lib\agentguard
+installing to build\bdist.win-amd64\wheel
+running install
+running install_lib
+creating build\bdist.win-amd64\wheel
+creating build\bdist.win-amd64\wheel\agentguard
+copying build\lib\agentguard\atracing.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\cli.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\cost.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\decision.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\demo.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\doctor.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\escalation.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\evaluation.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\export.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\first_run.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\goal.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\guards.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\instrument.py -> build\bdist.win-amd64\wheel\.\agentguard
+creating build\bdist.win-amd64\wheel\agentguard\integrations
+copying build\lib\agentguard\integrations\crewai.py -> build\bdist.win-amd64\wheel\.\agentguard\integrations
+copying build\lib\agentguard\integrations\langchain.py -> build\bdist.win-amd64\wheel\.\agentguard\integrations
+copying build\lib\agentguard\integrations\langgraph.py -> build\bdist.win-amd64\wheel\.\agentguard\integrations
+copying build\lib\agentguard\integrations\__init__.py -> build\bdist.win-amd64\wheel\.\agentguard\integrations
+copying build\lib\agentguard\profiles.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\py.typed -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\quickstart.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\reporting.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\repo_config.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\savings.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\schemas.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\setup.py -> build\bdist.win-amd64\wheel\.\agentguard
+creating build\bdist.win-amd64\wheel\agentguard\sinks
+copying build\lib\agentguard\sinks\http.py -> build\bdist.win-amd64\wheel\.\agentguard\sinks
+copying build\lib\agentguard\sinks\otel.py -> build\bdist.win-amd64\wheel\.\agentguard\sinks
+copying build\lib\agentguard\sinks\__init__.py -> build\bdist.win-amd64\wheel\.\agentguard\sinks
+copying build\lib\agentguard\skillpack.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\tracing.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\usage.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\_trace_naming.py -> build\bdist.win-amd64\wheel\.\agentguard
+copying build\lib\agentguard\__init__.py -> build\bdist.win-amd64\wheel\.\agentguard
+running install_egg_info
+Copying agentguard47.egg-info to build\bdist.win-amd64\wheel\.\agentguard47-1.2.13-py3.13.egg-info
+running install_scripts
+creating build\bdist.win-amd64\wheel\agentguard47-1.2.13.dist-info\WHEEL
+creating 'C:\\Users\\patri\\AppData\\Local\\Temp\\agentguard47-release-v1.2.13-dist-aaacbfa4ddc9454ab36c049957c9f816\\.tmp-zethlqd5\\agentguard47-1.2.13-py3-none-any.whl' and adding 'build\\bdist.win-amd64\\wheel' to it
+adding 'agentguard/__init__.py'
+adding 'agentguard/_trace_naming.py'
+adding 'agentguard/atracing.py'
+adding 'agentguard/cli.py'
+adding 'agentguard/cost.py'
+adding 'agentguard/decision.py'
+adding 'agentguard/demo.py'
+adding 'agentguard/doctor.py'
+adding 'agentguard/escalation.py'
+adding 'agentguard/evaluation.py'
+adding 'agentguard/export.py'
+adding 'agentguard/first_run.py'
+adding 'agentguard/goal.py'
+adding 'agentguard/guards.py'
+adding 'agentguard/instrument.py'
+adding 'agentguard/profiles.py'
+adding 'agentguard/py.typed'
+adding 'agentguard/quickstart.py'
+adding 'agentguard/repo_config.py'
+adding 'agentguard/reporting.py'
+adding 'agentguard/savings.py'
+adding 'agentguard/schemas.py'
+adding 'agentguard/setup.py'
+adding 'agentguard/skillpack.py'
+adding 'agentguard/tracing.py'
+adding 'agentguard/usage.py'
+adding 'agentguard/integrations/__init__.py'
+adding 'agentguard/integrations/crewai.py'
+adding 'agentguard/integrations/langchain.py'
+adding 'agentguard/integrations/langgraph.py'
+adding 'agentguard/sinks/__init__.py'
+adding 'agentguard/sinks/http.py'
+adding 'agentguard/sinks/otel.py'
+adding 'agentguard47-1.2.13.dist-info/licenses/LICENSE'
+adding 'agentguard47-1.2.13.dist-info/METADATA'
+adding 'agentguard47-1.2.13.dist-info/WHEEL'
+adding 'agentguard47-1.2.13.dist-info/entry_points.txt'
+adding 'agentguard47-1.2.13.dist-info/top_level.txt'
+adding 'agentguard47-1.2.13.dist-info/RECORD'
+removing build\bdist.win-amd64\wheel
+Successfully built agentguard47-1.2.13.tar.gz and agentguard47-1.2.13-py3-none-any.whl
+* Creating isolated environment: venv+pip...
+* Installing packages in isolated environment:
+  - setuptools>=82.0.1
+  - wheel
+* Getting build dependencies for sdist...
+* Building sdist...
+* Building wheel from sdist
+* Creating isolated environment: venv+pip...
+* Installing packages in isolated environment:
+  - setuptools>=82.0.1
+  - wheel
+* Getting build dependencies for wheel...
+* Building wheel...
+built wheel: C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-dist-aaacbfa4ddc9454ab36c049957c9f816\agentguard47-1.2.13-py3-none-any.whl
+
+> python -m venv C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-venv-a85215975efb4822b81ebebc48f3f971
+
+> C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-venv-a85215975efb4822b81ebebc48f3f971\Scripts\python.exe -m pip install --upgrade pip
+Requirement already satisfied: pip in c:\users\patri\appdata\local\temp\agentguard47-release-v1.2.13-venv-a85215975efb4822b81ebebc48f3f971\lib\site-packages (24.3.1)
+Collecting pip
+  Using cached pip-26.1.1-py3-none-any.whl.metadata (4.6 kB)
+Using cached pip-26.1.1-py3-none-any.whl (1.8 MB)
+Installing collected packages: pip
+  Attempting uninstall: pip
+    Found existing installation: pip 24.3.1
+    Uninstalling pip-24.3.1:
+      Successfully uninstalled pip-24.3.1
+Successfully installed pip-26.1.1
+
+> C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-venv-a85215975efb4822b81ebebc48f3f971\Scripts\python.exe -m pip install --no-index --find-links C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-dist-aaacbfa4ddc9454ab36c049957c9f816 agentguard47==1.2.13
+Looking in links: c:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-dist-aaacbfa4ddc9454ab36c049957c9f816
+Processing C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-dist-aaacbfa4ddc9454ab36c049957c9f816\agentguard47-1.2.13-py3-none-any.whl
+Installing collected packages: agentguard47
+Successfully installed agentguard47-1.2.13
+
+> python import_proof.py
+agentguard.__file__=C:\Users\patri\AppData\Local\Temp\agentguard47-release-v1.2.13-venv-a85215975efb4822b81ebebc48f3f971\Lib\site-packages\agentguard\__init__.py
+agentguard.__version__=1.2.13
+metadata=1.2.13
+
+> agentguard doctor
+AgentGuard doctor
+No dashboard. No network calls. Local verification only.
+
+[ok] Python: 3.13.2
+[ok] agentguard47: 1.2.13
+[ok] init(local_only=True): wrote 4 events to agentguard_doctor_trace.jsonl
+[ok] Optional integrations detected: none
+
+Suggested repo config (.agentguard.json):
+{
+  "profile": "coding-agent",
+  "service": "my-agent",
+  "trace_file": ".agentguard/traces.jsonl",
+  "budget_usd": 5.0
+}
+
+Suggested next step:
+import agentguard
+
+agentguard.init(
+    service="my-agent",
+    budget_usd=5.00,
+    local_only=True,
+)
+
+Helpful commands:
+  agentguard demo
+  agentguard quickstart --framework raw --write
+  python agentguard_raw_quickstart.py
+  agentguard report .agentguard/traces.jsonl
+  agentguard report agentguard_doctor_trace.jsonl
+
+If 'agentguard' is not on PATH:
+  python -m agentguard.cli demo
+  python -m agentguard.cli quickstart --framework raw --write
+  python -m agentguard.cli report .agentguard/traces.jsonl
+  python -m agentguard.cli report agentguard_doctor_trace.jsonl
+
+> agentguard demo
+AgentGuard offline demo
+No API keys. No dashboard. No network calls.
+
+1. BudgetGuard: stopping runaway spend
+  warning: Budget warning: cost 84% of limit reached (threshold: 80%)
+  warning fired at $0.84
+  stopped on call 9: cost $1.08 exceeded $1.00
+
+2. LoopGuard: stopping repeated tool calls
+  tool.search attempt 1 allowed
+  tool.search attempt 2 allowed
+  stopped on repeated tool call: Loop detected: tool.search({"query":"python asyncio"}) repeated 3 times in last 6 calls. Consider varying the arguments or breaking the loop.
+
+3. RetryGuard: stopping retry storms
+  fetch_docs retry 1 allowed
+  fetch_docs retry 2 allowed
+  stopped retry storm: Retry limit exceeded: fetch_docs attempted 3 times (limit: 2)
+
+Local proof complete.
+Trace written to: agentguard_demo_traces.jsonl
+View summary: agentguard report agentguard_demo_traces.jsonl
+View incident report: agentguard incident agentguard_demo_traces.jsonl
+
+Next: add AgentGuard to a repo
+  agentguard quickstart --framework raw --write
+  python agentguard_raw_quickstart.py
+  agentguard report .agentguard/traces.jsonl
+
+If 'agentguard' is not on PATH:
+  python -m agentguard.cli report agentguard_demo_traces.jsonl
+  python -m agentguard.cli incident agentguard_demo_traces.jsonl
+  python -m agentguard.cli quickstart --framework raw --write
+  python -m agentguard.cli report .agentguard/traces.jsonl
+SDK gives you local enforcement. The dashboard adds alerts, retained history, and remote controls.
+
+> agentguard quickstart --framework raw --write
+AgentGuard quickstart
+Framework: raw
+Wrote starter: agentguard_raw_quickstart.py
+
+Install:
+  pip install agentguard47
+
+Offline starter that proves local tracing plus budget and loop stops without any API keys.
+
+Notes:
+  - This path is fully local. No dashboard and no provider API keys are required.
+  - The generated file catches simulated guard exceptions so the script exits cleanly.
+  - Copy the call_model and tool-event pattern into the loop that drives your coding agent.
+  - Commit a .agentguard.json file if you want coding agents to reuse the same local defaults.
+
+Next commands:
+  agentguard doctor
+  python agentguard_raw_quickstart.py
+  agentguard report .agentguard/traces.jsonl
+
+If 'agentguard' is not on PATH:
+  python -m agentguard.cli doctor
+  python -m agentguard.cli report .agentguard/traces.jsonl
+
+> python agentguard_raw_quickstart.py
+BudgetGuard stopped simulated spend: Cost budget exceeded: $5.0200 > $5.0000 (this call added $2.5100)
+LoopGuard stopped repeated tool calls: Loop detected: tool.search({"query":"agentguard quickstart"}) repeated 3 times in last 6 calls. Consider varying the arguments or breaking the loop.
+Traces saved to .agentguard/traces.jsonl
+Inspect with: agentguard report .agentguard/traces.jsonl
+
+> agentguard report .agentguard\traces.jsonl
+AgentGuard report
+  Total events: 14
+  Spans: 4  Events: 9
+  Approx run time: 3.2 ms
+  Reasoning steps: 0
+  Tool results: 1
+  LLM results: 2
+  Estimated cost: $5.0200
+  Savings ledger: exact 0 tokens / $0.0000, estimated 0 tokens / $2.5100
+  Loop guard triggered: 1 time(s)
+  Guard events:
+    guard.budget_exceeded: 1
+    guard.loop_detected: 1
+  Incident hint: rerun with `agentguard incident` for a shareable incident report
+
+Traced by AgentGuard | agentguard47.com
+
+clean venv proof log: C:\Users\patri\.codex\worktrees\agent47-release-prep-1-2-11\proof\release-v1.2.13\clean-venv-smoke.log

--- a/proof/release-v1.2.13/validation-summary.md
+++ b/proof/release-v1.2.13/validation-summary.md
@@ -1,0 +1,42 @@
+# AgentGuard v1.2.13 Release Prep Validation
+
+Date: 2026-05-30
+
+## Failure Diagnosis
+
+- Publish run `26689523701` reached PyPI upload, so Trusted Publishing no longer failed at the `invalid-publisher` step.
+- The run built `agentguard47-1.2.10` artifacts from stale tag `v1.2.12`.
+- PyPI rejected the upload because `agentguard47-1.2.10` already exists.
+- Recovery path: do not rerun or reuse `v1.2.12`; prepare `v1.2.13` from current `origin/main`.
+
+## Validation
+
+- `python scripts/generate_pypi_readme.py --check`: passed
+- `python scripts/sdk_release_guard.py --json`: `[]`
+- `python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py sdk/tests/test_sdk_release_guard.py -q`: 18 passed
+- `python scripts/sdk_preflight.py`: passed
+- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80`: 772 passed, 92.82% coverage
+- `python scripts/ci_tools_requirements_guard.py`: passed
+- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py`: passed
+- `python -m pytest sdk/tests/test_architecture.py -v`: 9 passed
+- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`: passed
+- `npm --prefix mcp-server ci`: passed, 0 vulnerabilities
+- `npm --prefix mcp-server test`: 10 passed
+- `npm --prefix mcp-server run build`: passed
+- `python -m pip install -e ./agentguard-mcp && cd agentguard-mcp && python -m ruff check agentguard_mcp tests && python -m pytest`: 15 passed
+
+## Clean Venv Wheel Smoke
+
+See `clean-venv-smoke.log` for the full transcript.
+
+- Built `agentguard47-1.2.13-py3-none-any.whl`.
+- Installed with `pip install --no-index --find-links <dist> agentguard47==1.2.13`.
+- Import proof:
+  - `agentguard.__version__=1.2.13`
+  - package metadata `1.2.13`
+  - `agentguard.__file__` resolved inside the temporary venv `site-packages`.
+- `agentguard doctor`: passed, local-only, no dashboard or network required.
+- `agentguard demo`: passed and visibly tripped budget, loop, and retry guards.
+- `agentguard quickstart --framework raw --write`: wrote `agentguard_raw_quickstart.py`.
+- `python agentguard_raw_quickstart.py`: tripped budget and loop guards.
+- `agentguard report .agentguard/traces.jsonl`: reported 14 events, estimated cost `$5.0200`, one budget guard event, and one loop guard event.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -17,7 +17,7 @@ enough to create surprise spend.
 [![Python](https://img.shields.io/pypi/pyversions/agentguard47)](https://pypi.org/project/agentguard47/)
 [![CI](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml/badge.svg)](https://github.com/bmdhodl/agent47/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/bmdhodl/agent47)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.12/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/bmdhodl/agent47/blob/v1.2.13/LICENSE)
 [![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/score.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
 [![GitHub stars](https://img.shields.io/github/stars/bmdhodl/agent47?style=social)](https://github.com/bmdhodl/agent47)
 
@@ -158,7 +158,7 @@ What you should see:
 - `report` shows local trace counts, cost, savings, and guard events.
 
 Notebook version:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.12/examples/quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.13/examples/quickstart.ipynb)
 
 ## Copy-Paste Repo Setup
 
@@ -252,12 +252,12 @@ All examples are local-first. No API key is required unless the example says so.
 
 | Example | What it proves |
 |---|---|
-| [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/try_it_now.py) | budget, loop, and retry stops |
+| [`examples/try_it_now.py`](https://github.com/bmdhodl/agent47/blob/v1.2.13/examples/try_it_now.py) | budget, loop, and retry stops |
 | [`examples/sticky_agent_proof.py`](https://github.com/bmdhodl/agent47/blob/main/examples/sticky_agent_proof.py) | one CrewAI-style retry storm proof with local incident and hosted NDJSON outputs |
-| [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
-| [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
-| [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |
-| [`examples/decision_trace_workflow.py`](https://github.com/bmdhodl/agent47/blob/v1.2.12/examples/decision_trace_workflow.py) | proposal, edit, approval, and binding decision events |
+| [`examples/coding_agent_review_loop.py`](https://github.com/bmdhodl/agent47/blob/v1.2.13/examples/coding_agent_review_loop.py) | review/refinement loop stopped by budget and retry guards |
+| [`examples/per_token_budget_spike.py`](https://github.com/bmdhodl/agent47/blob/v1.2.13/examples/per_token_budget_spike.py) | one oversized token-heavy turn can blow a run budget |
+| [`examples/budget_aware_escalation.py`](https://github.com/bmdhodl/agent47/blob/v1.2.13/examples/budget_aware_escalation.py) | when to escalate from a cheap model to a stronger one |
+| [`examples/decision_trace_workflow.py`](https://github.com/bmdhodl/agent47/blob/v1.2.13/examples/decision_trace_workflow.py) | proposal, edit, approval, and binding decision events |
 
 Sample incident:
 [`docs/examples/coding-agent-review-loop-incident.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/coding-agent-review-loop-incident.md)
@@ -266,7 +266,7 @@ Proof gallery:
 [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md)
 
 Starter files:
-[`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.12/examples/starters)
+[`examples/starters/`](https://github.com/bmdhodl/agent47/tree/v1.2.13/examples/starters)
 
 ## Framework Integrations
 
@@ -308,8 +308,8 @@ layer.
 
 Competitive notes:
 
-- [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/competitive/vercel-ai-gateway.md)
-- [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/competitive/manifest.md)
+- [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/competitive/vercel-ai-gateway.md)
+- [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](https://github.com/bmdhodl/agent47/blob/main/docs/competitive/agent-security-stack.md)
 
 ## Decision Traces
@@ -424,7 +424,7 @@ assert result.passed
 - Core runtime dependencies: zero
 - Trace format: JSONL
 - Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
-- MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.12/mcp-server)
+- MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.13/mcp-server)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 
 [![agent47 MCP server](https://glama.ai/mcp/servers/bmdhodl/agent47/badges/card.svg)](https://glama.ai/mcp/servers/bmdhodl/agent47)
@@ -433,15 +433,15 @@ assert result.passed
 
 | Topic | Link |
 |---|---|
-| Getting started | [`docs/guides/getting-started.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/getting-started.md) |
-| Coding-agent setup | [`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/coding-agents.md) |
-| Safety pack | [`docs/guides/coding-agent-safety-pack.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/coding-agent-safety-pack.md) |
+| Getting started | [`docs/guides/getting-started.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/guides/getting-started.md) |
+| Coding-agent setup | [`docs/guides/coding-agents.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/guides/coding-agents.md) |
+| Safety pack | [`docs/guides/coding-agent-safety-pack.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/guides/coding-agent-safety-pack.md) |
 | Dashboard contract | [`docs/guides/dashboard-contract.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/dashboard-contract.md) |
 | Decision traces | [`docs/guides/decision-tracing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/decision-tracing.md) |
 | Managed sessions | [`docs/guides/managed-agent-sessions.md`](https://github.com/bmdhodl/agent47/blob/main/docs/guides/managed-agent-sessions.md) |
-| Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/guides/activation-metrics-design.md) |
+| Activation metrics design | [`docs/guides/activation-metrics-design.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/guides/activation-metrics-design.md) |
 | Proof gallery | [`docs/examples/proof-gallery.md`](https://github.com/bmdhodl/agent47/blob/main/docs/examples/proof-gallery.md) |
-| Releasing | [`docs/RELEASING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/docs/RELEASING.md) |
+| Releasing | [`docs/RELEASING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/RELEASING.md) |
 | Release cadence | [`docs/release/cadence.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/cadence.md) |
 | PyPI Trusted Publishing | [`docs/release/trusted-publishing.md`](https://github.com/bmdhodl/agent47/blob/main/docs/release/trusted-publishing.md) |
 
@@ -506,14 +506,14 @@ python scripts/sdk_release_guard.py
 
 Useful links:
 
-- [`CONTRIBUTING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/CONTRIBUTING.md)
-- [`GOLDEN_PRINCIPLES.md`](https://github.com/bmdhodl/agent47/blob/v1.2.12/GOLDEN_PRINCIPLES.md)
+- [`CONTRIBUTING.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/CONTRIBUTING.md)
+- [`GOLDEN_PRINCIPLES.md`](https://github.com/bmdhodl/agent47/blob/v1.2.13/GOLDEN_PRINCIPLES.md)
 
 ## License
 
-MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.12/LICENSE).
+MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.13/LICENSE).
 
-## Latest Release Notes (1.2.12)
+## Latest Release Notes (1.2.13)
 
 ### Release Operations
 - Made post-PyPI GitHub Release creation a separate idempotent job and
@@ -521,10 +521,13 @@ MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.12/LICENSE).
   longer depends on `GITHUB_TOKEN` release events.
 - Hardened generated GitHub Release notes and release-content announcements so
   they start from the last published GitHub Release instead of a stale raw tag.
-  This lets `v1.2.12` supersede the failed `v1.2.11` tag without truncating
-  public release notes.
+  This lets `v1.2.13` supersede the failed `v1.2.11` and `v1.2.12` tags without
+  truncating public release notes.
 - Includes the release candidate originally prepared under the failed
   `v1.2.11` tag. That tag did not publish to PyPI and has no GitHub Release.
+- Supersedes the stale `v1.2.12` tag, which was pushed from a checkout still
+  carrying `sdk/pyproject.toml` version `1.2.10`. That tag did not publish a new
+  PyPI version and has no GitHub Release.
 
 ### Reliability
 - Hardened `agentguard.__version__` so malformed local package metadata falls
@@ -598,4 +601,4 @@ MIT. See [`LICENSE`](https://github.com/bmdhodl/agent47/blob/v1.2.12/LICENSE).
 - Refreshed the MCP server lockfile so `npm audit` no longer reports the
   transitive `fast-uri` or `qs` advisories.
 
-Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.12/CHANGELOG.md)
+Full changelog: [CHANGELOG.md](https://github.com/bmdhodl/agent47/blob/v1.2.13/CHANGELOG.md)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentguard47"
-version = "1.2.12"
+version = "1.2.13"
 description = "Zero-dependency runtime control for production Python agents - stop loops, retry storms, and budget burn"
 readme = "PYPI_README.md"
 requires-python = ">=3.9"

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires Python 3.9+
 metadata:
   author: bmdhodl
-  version: "1.2.12"
+  version: "1.2.13"
   pypi: agentguard47
 ---
 


### PR DESCRIPTION
## Summary
- prepare AgentGuard SDK release candidate `v1.2.13` from current `main`
- document why the stale `v1.2.12` tag must not be rerun or reused
- add a tag-time version verification step to the release docs
- add release proof artifacts under `proof/release-v1.2.13/`

## Failure class killed
`v1.2.12` was pushed from a checkout still declaring `sdk/pyproject.toml` version `1.2.10`, so the publish workflow built `agentguard47-1.2.10` files and PyPI rejected them as already existing. This PR prepares the next patch release and records the guardrail: verify the version from `HEAD` before tagging.

## Proof
- `python scripts/generate_pypi_readme.py --check`
- `python scripts/sdk_release_guard.py --json` -> `[]`
- `python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_pypi_readme_sync.py sdk/tests/test_sdk_release_guard.py -q` -> 18 passed
- `python scripts/sdk_preflight.py` -> passed
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 772 passed, 92.82% coverage
- `python scripts/ci_tools_requirements_guard.py` -> passed
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py` -> passed
- `python -m pytest sdk/tests/test_architecture.py -v` -> 9 passed
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q` -> passed
- `npm --prefix mcp-server ci` -> passed, 0 vulnerabilities
- `npm --prefix mcp-server test` -> 10 passed
- `npm --prefix mcp-server run build` -> passed
- `python -m pip install -e ./agentguard-mcp && cd agentguard-mcp && python -m ruff check agentguard_mcp tests && python -m pytest` -> 15 passed
- Clean venv wheel smoke from built `agentguard47-1.2.13` wheel: `doctor`, `demo`, `quickstart --framework raw --write`, generated quickstart run, and `report` passed. See `proof/release-v1.2.13/clean-venv-smoke.log`.

## Tag safety
Do not rerun `v1.2.12`. After this PR merges, tag only after proving `origin/main:sdk/pyproject.toml` contains `version = 1.2.13`.