### PR TITLE
docs: sync v1.2.13 release state

### DIFF
--- a/memory/blockers.md
+++ b/memory/blockers.md
@@ -3,16 +3,6 @@
 **Last Updated:** 2026-05-30
 
 ## Active
-- **`v1.2.12` is a stale failed release tag.** The tag was pushed from
-  `8fd0295db19333d882bffed6002e18ea24fadec3`, a checkout whose
-  `sdk/pyproject.toml` still says `1.2.10`. The publish workflow authenticated
-  and reached PyPI, then failed because it tried to upload existing
-  `agentguard47-1.2.10` files. Do not rerun or reuse `v1.2.12`; cut the next
-  patch release from current `main`.
-- **`v1.2.11` is also stale.** The tag workflow passed release gates, build, and
-  attestation, then failed at PyPI with `invalid-publisher` for
-  `repo:bmdhodl/agent47:environment:pypi`. It has no PyPI release and no GitHub
-  Release.
 - **Glama tool catalog is not indexed yet.** Patrick published the first Glama
   release on 2026-05-08 and the listing is live. Glama renders tool and score
   pages, but `https://glama.ai/api/mcp/v1/servers/bmdhodl/agent47` still
@@ -29,6 +19,19 @@
   `https://glama.ai/mcp/servers/bmdhodl/agent47` once the Glama tool catalog is
   confirmed or Patrick accepts posting the live listing while indexing catches
   up.
+
+## Resolved / Historical
+- **`v1.2.13` published successfully.** GitHub Release `v1.2.13` and PyPI
+  `agentguard47==1.2.13` are public as of 2026-05-30.
+- **`v1.2.12` is a stale failed release tag.** The tag was pushed from
+  `8fd0295db19333d882bffed6002e18ea24fadec3`, a checkout whose
+  `sdk/pyproject.toml` still says `1.2.10`. The publish workflow authenticated
+  and reached PyPI, then failed because it tried to upload existing
+  `agentguard47-1.2.10` files. Do not rerun or reuse `v1.2.12`.
+- **`v1.2.11` is also stale.** The tag workflow passed release gates, build, and
+  attestation, then failed at PyPI with `invalid-publisher` for
+  `repo:bmdhodl/agent47:environment:pypi`. It has no PyPI release and no GitHub
+  Release.
 
 ## Do Not Route Around
 - Do not build new guards just because registry indexing lags.

--- a/memory/distribution.md
+++ b/memory/distribution.md
@@ -1,6 +1,6 @@
 # SDK Distribution
 
-**Last Updated:** 2026-05-29
+**Last Updated:** 2026-05-30
 
 ## Core Message
 AgentGuard stops coding agents from looping, retrying forever, and burning
@@ -12,6 +12,8 @@ budget.
 - teams worried about runaway spend and unsafe automation
 
 ## Channels
+- PyPI `agentguard47`: latest `1.2.13`, with GitHub Release `v1.2.13`
+  published on 2026-05-30
 - npm `@agentguard47/mcp-server`: latest `0.2.2`, modified 2026-05-04; matches
   `mcp-server/package.json` and `mcp-server/server.json`
 - Official MCP Registry: live as `io.github.bmdhodl/agentguard47`; public API

--- a/memory/state.md
+++ b/memory/state.md
@@ -1,6 +1,6 @@
 # SDK State
 
-**Last Updated:** 2026-05-29
+**Last Updated:** 2026-05-30
 
 ## Product
 - AgentGuard = zero-dependency Python SDK for runtime guardrails.
@@ -8,9 +8,8 @@
 - SDK stays free, MIT, and local-first.
 
 ## Public Artifacts
-- PyPI package: `agentguard47` (public latest remains `1.2.10` until the next
-  Trusted Publishing run succeeds)
-- Current release candidate: `1.2.13`
+- PyPI package: `agentguard47@1.2.13` is public.
+- Latest GitHub Release: `v1.2.13`
 - npm MCP package: `@agentguard47/mcp-server@0.2.2` is published.
 - Local budget MCP package: `agentguard-mcp` exists in this repo but is not
   published to npm or PyPI; dogfood installs it from the checkout.
@@ -27,6 +26,6 @@
 - hosted dashboard remains private and separate
 
 ## Current Focus
-- release candidate `1.2.13` from current `main`
+- post-`v1.2.13` distribution health and adoption proof
 - distribution before new features
 - coding-agent onboarding and proof

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,14 +3,14 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
-**Last reviewed:** 2026-05-29
+**Last reviewed:** 2026-05-30
 
 ## Current Focus Notes
 
-- Current SDK release candidate is `v1.2.13` from `main`; public PyPI latest
-  remains `v1.2.10` until the next tag publish succeeds. The stale `v1.2.11`
-  tag failed before PyPI publish, and the stale `v1.2.12` tag points at a
-  `1.2.10` checkout. Do not reuse either tag without explicit owner approval.
+- Current public SDK release is `v1.2.13`; GitHub Release `v1.2.13` and PyPI
+  `agentguard47==1.2.13` are both public. The stale `v1.2.11` tag failed
+  before PyPI publish, and the stale `v1.2.12` tag points at a `1.2.10`
+  checkout. Do not reuse either tag without explicit owner approval.
 - Official MCP Registry listing is live as `io.github.bmdhodl/agentguard47`,
   but public registry search still reports MCP package version `0.2.1`; refresh
   metadata without changing SDK runtime code.


### PR DESCRIPTION
## Summary
- sync SDK memory and roadmap now that `v1.2.13` is public on GitHub Releases and PyPI
- move the stale `v1.2.11` / `v1.2.12` release tag notes out of active blockers while preserving them as historical warnings
- keep MCP/Glama distribution blockers unchanged

## Proof
- `gh release view --json tagName,publishedAt,url,isPrerelease,isDraft,name` -> `v1.2.13`, published `2026-05-30T17:18:10Z`
- `python -m pip index versions agentguard47` -> latest `1.2.13`
- `npm view @agentguard47/mcp-server version` -> `0.2.2`

## Dogfood proof
- `python -m agentguard.cli doctor --trace-file C:\Users\patri\.codex\tmp\agent47-worker-2026-05-30-run22\doctor_trace.jsonl`
- `python -m agentguard.cli demo --trace-file C:\Users\patri\.codex\tmp\agent47-worker-2026-05-30-run22\demo_trace.jsonl`
- `python examples/coding_agent_review_loop.py` from the temp proof directory with `PYTHONPATH=./sdk`
- Demo trace emitted `guard.budget_warning`, `guard.budget_exceeded`, `guard.loop_detected`, and `guard.retry_limit_exceeded`
- Review-loop trace emitted `guard.budget_exceeded` at `$0.0510 > $0.0450` and `guard.retry_limit_exceeded` for `apply_patch` attempt 4

## Validation
- `python -m pytest sdk/tests/test_demo.py sdk/tests/test_doctor.py sdk/tests/test_cli_report.py sdk/tests/test_example_starters.py sdk/tests/test_mcp_registry_metadata.py -q` -> 35 passed
- `python scripts/sdk_release_guard.py --check-mcp-npm` -> passed
- `git diff --check` -> passed