### PR TITLE
Automate MCP Registry publish (OIDC); inbox log for #553

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,36 @@
+name: Publish MCP Registry
+
+# Manual, OIDC-authenticated publish of mcp-server/server.json to the official
+# MCP Registry. Replaces the manual `mcp-publisher login github` device flow:
+# GitHub Actions OIDC authorizes the `io.github.bmdhodl/*` namespace because the
+# workflow runs in a repository owned by `bmdhodl`. Run after the matching npm
+# package version is already published, since the registry validates the live
+# npm tarball.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz" \
+            | tar -xz mcp-publisher
+          ./mcp-publisher --version
+
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        working-directory: mcp-server
+        run: ../mcp-publisher publish

--- a/docs/launch/distribution-execution.md
+++ b/docs/launch/distribution-execution.md
@@ -24,14 +24,19 @@ Package and metadata are prepared in this repo:
 - registry name: `io.github.bmdhodl/agentguard47`
 - metadata file: [`mcp-server/server.json`](../../mcp-server/server.json)
 
-Manual steps:
+Registry publish is automated. After the npm package is published, the registry
+publish runs through GitHub Actions OIDC (no manual `mcp-publisher login github`
+device flow):
 
 ```bash
 cd mcp-server
-npm publish
-mcp-publisher login github
-mcp-publisher publish
+npm publish                                   # only when package.json changes
+gh workflow run publish-mcp-registry.yml      # OIDC-authenticated registry publish
 ```
+
+The [`publish-mcp-registry.yml`](../../.github/workflows/publish-mcp-registry.yml)
+workflow authorizes the `io.github.bmdhodl/*` namespace via OIDC because it runs
+in a `bmdhodl`-owned repo, then publishes `mcp-server/server.json`.
 
 Important:
 - publish the npm package first whenever `package.json` metadata changes

--- a/inbox/log.md
+++ b/inbox/log.md
@@ -3,6 +3,20 @@
 
 ---
 
+## 2026-05-30 | Claude
+
+### What shipped
+- Merged PR `#553`: added a shared `STAR_CALL_TO_ACTION` to `doctor`/`demo` output and the README/PyPI README to convert silent installs into GitHub stars (downloads in the thousands vs 3 stars).
+- Refreshed `memory/state.md` and `memory/blockers.md` now that `1.2.13` is live on PyPI; deleted the stale dead tags `v1.2.11`/`v1.2.12` from the remote (SHAs recorded for recovery).
+- Proof under `proof/star-cta-activation/`; ruff clean, 773 tests pass, PyPI README in sync, release guard passes.
+
+### Decisions made
+- Star CTA lives only in human-readable CLI output; `doctor --json` deliberately omits it (test-enforced).
+- MCP Registry metadata is staged at `0.2.2`; the remaining publish is the credentialed `mcp-publisher` step, not a code change.
+
+### Blockers
+- Glama still returns `tools: []` (UI-gated); `awesome-mcp-servers#4012` was closed and needs a fresh guideline-clean PR.
+
 ## 2026-05-30 | Codex
 
 ### What shipped


### PR DESCRIPTION
## Goal
Remove the manual credential gate on the MCP Registry refresh and record the post-merge inbox entry for #553.

## What changed
- **`.github/workflows/publish-mcp-registry.yml`** — `workflow_dispatch` job that installs `mcp-publisher` (v1.7.9) and publishes `mcp-server/server.json` to the official MCP Registry using **GitHub Actions OIDC**. No interactive `mcp-publisher login github` device flow; OIDC authorizes the `io.github.bmdhodl/*` namespace because the workflow runs in a `bmdhodl`-owned repo. `id-token: write` scoped to the job.
- **`docs/launch/distribution-execution.md`** — documents the automated path (`gh workflow run publish-mcp-registry.yml`).
- **`inbox/log.md`** — post-merge entry for #553.

## Why
`server.json` + `package.json` + npm are all at `0.2.2`, but the registry still reports `0.2.1`. The only missing step was a credentialed publish. This makes that step a repeatable, auditable CI action instead of a manual device-flow login.

## Proof
- YAML valid; `pytest sdk/tests/test_ci_guardrails.py` passes (new workflow doesn't disturb existing workflow guardrails).
- actionlint runs on `.github/workflows/**` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)