### PR TITLE
Shorten MCP server description to satisfy registry 100-char limit

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentguard47/mcp-server",
   "version": "0.2.2",
-  "description": "Read-only MCP server for coding-agent traces, decision events, alerts, costs, usage, and budget health",
+  "description": "Read-only MCP server for coding-agent traces, alerts, costs, usage, and budget health",
   "mcpName": "io.github.bmdhodl/agentguard47",
   "license": "MIT",
   "type": "module",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.bmdhodl/agentguard47",
-  "description": "Read-only MCP server for coding-agent traces, decision events, alerts, costs, usage, and budget health.",
+  "description": "Read-only MCP server for coding-agent traces, alerts, costs, usage, and budget health.",
   "repository": {
     "url": "https://github.com/bmdhodl/agent47",
     "source": "github"


### PR DESCRIPTION
## Why
The OIDC registry-publish workflow (added in #554) authenticated successfully but the publish failed with a 422:

```
validation failed ... body.description: expected length <= 100
```

`server.json` description was 103 chars. The MCP Registry now enforces a 100-char cap.

## What changed
- Trim "decision events, " from the description in `mcp-server/server.json` (103 → 86) and `mcp-server/package.json` (102 → 85), keeping them identical. Traces already cover decision events.

## Proof
- Both descriptions verified ≤ 100 chars.
- `pytest sdk/tests/test_mcp_registry_metadata.py`: 5 passed (version/name/env-var sync intact).

After merge, re-dispatch `publish-mcp-registry.yml` to push `0.2.2` to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)