### PR TITLE
test: guard PyPI publish tag version check

### DIFF
--- a/sdk/tests/test_ci_guardrails.py
+++ b/sdk/tests/test_ci_guardrails.py
@@ -71,6 +71,19 @@ def test_publish_workflow_release_steps_are_post_publish_rerunnable() -> None:
     assert _contains_ordered_lines(
         lines,
         [
+            "      - name: Verify tag matches sdk/pyproject.toml version",
+            "        run: |",
+            '          TAG_VERSION="${GITHUB_REF#refs/tags/v}"',
+            '          PKG_VERSION="$(python -c \'import tomllib; print(tomllib.load(open("sdk/pyproject.toml","rb"))["project"]["version"])\')"',
+            '          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then',
+            '            echo "Tag $TAG_VERSION does not match sdk/pyproject.toml version $PKG_VERSION" >&2',
+            "            exit 1",
+            "          fi",
+        ],
+    )
+    assert _contains_ordered_lines(
+        lines,
+        [
             "  github-release:",
             "    runs-on: ubuntu-latest",
             "    needs: publish",


### PR DESCRIPTION
## Summary
- lock the existing publish workflow tag/package-version check behind `test_ci_guardrails`
- prevent a repeat of the v1.2.12 stale-tag failure where a `v1.2.12` tag built `agentguard47-1.2.10` and PyPI rejected the immutable file reuse

## Bug class killed
Stale release tag points at a package version that does not match the tag, allowing the release workflow to reach PyPI upload with already-published artifacts.

## Failure evidence
- Failed run: https://github.com/bmdhodl/agent47/actions/runs/26689523701
- Log showed: `Checking sdk/dist/agentguard47-1.2.10-py3-none-any.whl: PASSED`, then PyPI returned `400 File already exists ('agentguard47-1.2.10-py3-none-any.whl')` for tag `v1.2.12`.
- Superseding run: https://github.com/bmdhodl/agent47/actions/runs/26690058864 succeeded for tag `v1.2.13`.
- PyPI now reports latest `agentguard47 (1.2.13)`.

## Tests
- `python -m pytest sdk/tests/test_ci_guardrails.py::test_publish_workflow_release_steps_are_post_publish_rerunnable -q`
- `python -m pytest sdk/tests/test_ci_guardrails.py sdk/tests/test_sdk_release_guard.py -q`
- `python scripts/sdk_preflight.py`
- `python scripts/ci_tools_requirements_guard.py`
- `python scripts/sdk_release_guard.py`
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py sdk/tests/test_ci_guardrails.py`
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `python -m pytest sdk/tests/ -q --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 773 passed, 93% coverage