### PR TITLE
harden: reject mismatched release tags

### DIFF
--- a/scripts/sdk_release_guard.py
+++ b/scripts/sdk_release_guard.py
@@ -28,6 +28,7 @@ RELEASE_MARKERS = (
     ("CLAUDE.md", r"release candidate is (?P<version>\d+\.\d+\.\d+)"),
     (".claude/agents/sdk-dev.md", r"Current SDK release candidate: `v(?P<version>\d+\.\d+\.\d+)`"),
 )
+RELEASE_TAG_PREFIX = "refs/tags/"
 
 
 @dataclass(frozen=True)
@@ -103,6 +104,39 @@ def check_release_markers(repo_root: Path, version: str) -> List[Finding]:
                 )
             )
     return findings
+
+
+def _release_tag_from_ref(ref: Optional[str]) -> Optional[str]:
+    if not ref:
+        return None
+    if ref.startswith(RELEASE_TAG_PREFIX):
+        return ref.removeprefix(RELEASE_TAG_PREFIX)
+    if re.fullmatch(r"v\d+\.\d+\.\d+", ref):
+        return ref
+    return None
+
+
+def check_release_tag(version: str, ref: Optional[str] = None) -> List[Finding]:
+    release_ref = ref if ref is not None else os.environ.get("GITHUB_REF")
+    tag = _release_tag_from_ref(release_ref)
+    if tag is None:
+        return []
+
+    expected = f"v{version}"
+    if tag == expected:
+        return []
+
+    return [
+        Finding(
+            check="release-tag",
+            path="GITHUB_REF",
+            message=(
+                f"Tag {tag} does not match sdk/pyproject.toml version {version}. "
+                f"Expected release tag {expected}; delete the stale tag and retag "
+                "the release commit before publishing."
+            ),
+        )
+    ]
 
 
 def check_mcp_metadata(repo_root: Path) -> List[Finding]:
@@ -256,6 +290,7 @@ def check_mcp_npm_package(repo_root: Path, npm_command: Optional[str] = None) ->
 def collect_findings(repo_root: Path, check_mcp_npm: bool = False) -> List[Finding]:
     version = load_version(repo_root)
     findings: List[Finding] = []
+    findings.extend(check_release_tag(version))
     findings.extend(check_changelog(repo_root, version))
     findings.extend(check_pypi_readme(repo_root))
     findings.extend(check_release_markers(repo_root, version))

--- a/sdk/tests/test_sdk_release_guard.py
+++ b/sdk/tests/test_sdk_release_guard.py
@@ -68,6 +68,27 @@ class TestReleaseGuardHelpers(unittest.TestCase):
             self.assertEqual(len(findings), len(sdk_release_guard.RELEASE_MARKERS))
             self.assertTrue(all("Expected release marker 9.9.9" in finding.message for finding in findings))
 
+    def test_check_release_tag_reports_mismatched_publish_tag(self):
+        findings = sdk_release_guard.check_release_tag(
+            "1.2.10",
+            ref="refs/tags/v1.2.12",
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].check, "release-tag")
+        self.assertEqual(findings[0].path, "GITHUB_REF")
+        self.assertIn(
+            "Tag v1.2.12 does not match sdk/pyproject.toml version 1.2.10",
+            findings[0].message,
+        )
+
+    def test_collect_findings_checks_github_release_tag(self):
+        with patch.dict(sdk_release_guard.os.environ, {"GITHUB_REF": "refs/tags/v9.9.9"}):
+            findings = sdk_release_guard.collect_findings(sdk_release_guard.REPO_ROOT)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].check, "release-tag")
+
     def test_check_pypi_readme_reports_generation_errors(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = pathlib.Path(tmp)


### PR DESCRIPTION
## Summary
- add a Python release-guard check that compares `GITHUB_REF` release tags to `sdk/pyproject.toml`
- fail with an actionable stale-tag message before build/upload when tags and package versions disagree
- cover the `v1.2.12`-style stale tag class with regression tests

## Bug class killed
Stale release tag pointing at an older package version, causing PyPI `400 File already exists` after build/attestation.

## Red test proof
- Before the fix: `python -m pytest sdk/tests/test_sdk_release_guard.py::TestReleaseGuardHelpers::test_check_release_tag_reports_mismatched_publish_tag sdk/tests/test_sdk_release_guard.py::TestReleaseGuardHelpers::test_collect_findings_checks_github_release_tag -q` failed with missing `check_release_tag` and no `collect_findings` tag finding.

## Validation
- `python -m pytest sdk/tests/test_sdk_release_guard.py::TestReleaseGuardHelpers::test_check_release_tag_reports_mismatched_publish_tag sdk/tests/test_sdk_release_guard.py::TestReleaseGuardHelpers::test_collect_findings_checks_github_release_tag -q` -> 2 passed
- `python -m pytest sdk/tests/test_ci_guardrails.py::test_publish_workflow_release_steps_are_post_publish_rerunnable -q` -> 1 passed
- `python -m pytest sdk/tests/test_sdk_release_guard.py sdk/tests/test_ci_guardrails.py -q` -> 15 passed
- `python scripts/sdk_release_guard.py` -> Release guard passed
- `python scripts/sdk_preflight.py` -> targeted release-guard checks passed
- `python scripts/ci_tools_requirements_guard.py` -> direct pins support Python 3.9
- `python -m ruff check sdk/agentguard/ scripts/generate_pypi_readme.py scripts/sdk_preflight.py scripts/sdk_release_guard.py scripts/ci_tools_requirements_guard.py` -> All checks passed
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q` -> passed
- `python -m pytest sdk/tests/ -v --cov=agentguard --cov-report=term-missing --cov-fail-under=80` -> 775 passed, 92.77% coverage
- `python -m build ./sdk` -> built `agentguard47-1.2.13.tar.gz` and wheel
- `GITHUB_REF=refs/tags/v9.9.9 python scripts/sdk_release_guard.py` -> expected failure before upload: tag mismatch against `1.2.13`