### PR TITLE
fix: address daily bug scan findings

### DIFF
--- a/inbox/log.md
+++ b/inbox/log.md
@@ -3,6 +3,18 @@
 
 ---
 
+## 2026-05-31 | Codex
+
+### What shipped
+- Merged PR `#559` to harden release publishing against stale git tags.
+- `scripts/sdk_release_guard.py` now rejects a release tag when `GITHUB_REF` does not match `sdk/pyproject.toml`.
+
+### Decisions made
+- Keep the existing workflow-level tag check, and mirror the invariant in the Python release guard so local and CI checks fail before package build/upload.
+
+### Blockers
+- None. The failed `v1.2.12` publish run was a stale tag pointing at `1.2.10`; `v1.2.13` is already published and main CI, CodeQL, and Scorecard passed after `#559`.
+
 ## 2026-05-30 | Claude
 
 ### What shipped
@@ -260,15 +272,3 @@
 
 ### Blockers
 - None for `v1.2.10`; PyPI Trusted Publishing remains a known follow-up.
-
-## 2026-05-31 | Codex
-
-### What shipped
-- Merged PR `#559` to harden release publishing against stale git tags.
-- `scripts/sdk_release_guard.py` now rejects a release tag when `GITHUB_REF` does not match `sdk/pyproject.toml`.
-
-### Decisions made
-- Keep the existing workflow-level tag check, and mirror the invariant in the Python release guard so local and CI checks fail before package build/upload.
-
-### Blockers
-- None. The failed `v1.2.12` publish run was a stale tag pointing at `1.2.10`; `v1.2.13` is already published and main CI, CodeQL, and Scorecard passed after `#559`.

--- a/scripts/sdk_release_guard.py
+++ b/scripts/sdk_release_guard.py
@@ -110,7 +110,10 @@ def _release_tag_from_ref(ref: Optional[str]) -> Optional[str]:
     if not ref:
         return None
     if ref.startswith(RELEASE_TAG_PREFIX):
-        return ref.removeprefix(RELEASE_TAG_PREFIX)
+        tag = ref.removeprefix(RELEASE_TAG_PREFIX)
+        if re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+            return tag
+        return None
     if re.fullmatch(r"v\d+\.\d+\.\d+", ref):
         return ref
     return None

--- a/sdk/tests/test_sdk_release_guard.py
+++ b/sdk/tests/test_sdk_release_guard.py
@@ -82,6 +82,14 @@ class TestReleaseGuardHelpers(unittest.TestCase):
             findings[0].message,
         )
 
+    def test_check_release_tag_ignores_non_sdk_tag_ref(self):
+        findings = sdk_release_guard.check_release_tag(
+            "1.2.13",
+            ref="refs/tags/docs-refresh",
+        )
+
+        self.assertEqual(findings, [])
+
     def test_collect_findings_checks_github_release_tag(self):
         with patch.dict(sdk_release_guard.os.environ, {"GITHUB_REF": "refs/tags/v9.9.9"}):
             findings = sdk_release_guard.collect_findings(sdk_release_guard.REPO_ROOT)

--- a/site/index.html
+++ b/site/index.html
@@ -828,9 +828,9 @@
             <strong>AgentGuard<span>47</span></strong>
           </a>
           <div class="navlinks">
-            <a href="/quickstart">Quickstart</a>
-            <a href="/trust">Trust</a>
-            <a href="/pricing">Pricing</a>
+            <a href="/#local-proof">Quickstart</a>
+            <a href="/trust.html">Trust</a>
+            <a href="/compare.html">Compare</a>
             <a href="https://bmdpat.com/blog">Blog</a>
             <a href="https://app.agentguard47.com/sign-in">Sign in</a>
           </div>
@@ -1007,7 +1007,7 @@ with tracer.trace("agent.run") as span:
               <h3>After local proof</h3>
               <p>Open the quickstart for OpenAI, Anthropic, LangChain, LangGraph, CrewAI, or raw Python. Then connect the hosted dashboard only when the trace needs to be retained or shared.</p>
               <div class="hero-actions">
-                <a class="btn btn-red" href="/quickstart">Open quickstart</a>
+                <a class="btn btn-red" href="/#local-proof">Open quickstart</a>
                 <a class="btn btn-secondary" href="https://app.agentguard47.com/sign-up">Start hosted trial</a>
               </div>
             </div>
@@ -1023,7 +1023,7 @@ with tracer.trace("agent.run") as span:
               path, a trace file, and a guard they can copy into a real coding-agent loop.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-red" href="/quickstart">Run quickstart</a>
+              <a class="btn btn-red" href="/#local-proof">Run quickstart</a>
               <a class="btn btn-secondary" href="https://pypi.org/project/agentguard47/">View PyPI</a>
             </div>
             <form class="email-form" action="/api/lead" method="post" onsubmit="return submitLeadForm(event, this)">
@@ -1041,9 +1041,9 @@ with tracer.trace("agent.run") as span:
         <div class="footer-links">
           <a href="https://github.com/bmdhodl/agent47">GitHub</a>
           <a href="https://pypi.org/project/agentguard47/">PyPI</a>
-          <a href="/quickstart">Quickstart</a>
-          <a href="/trust">Trust</a>
-          <a href="/pricing">Pricing</a>
+          <a href="/#local-proof">Quickstart</a>
+          <a href="/trust.html">Trust</a>
+          <a href="/compare.html">Compare</a>
           <a href="https://bmdpat.com/blog">Blog</a>
           <a href="https://app.agentguard47.com/sign-in">Sign in</a>
         </div>


### PR DESCRIPTION
## Plan
- Fix concrete recent-main findings from the daily bug scan only.
- Keep changes minimal: release-tag parsing, landing-page internal links, and inbox ordering.

## Diff summary
- `scripts/sdk_release_guard.py` now ignores non-SDK tag refs such as `refs/tags/docs-refresh` while still checking `vX.Y.Z` tags.
- `site/index.html` no longer links to missing `/quickstart` or `/pricing` static routes; quickstart links target `/#local-proof`, and pricing nav/footer becomes the existing `/compare` page.
- `inbox/log.md` puts the 2026-05-31 entry at the top to match the newest-first contract.
- Added regression coverage for non-SDK tag refs.

## Tests
- `python -m pytest sdk/tests/test_sdk_release_guard.py -q`
- `python scripts/sdk_release_guard.py`
- `python -m ruff check sdk/agentguard/ scripts/sdk_release_guard.py scripts/sdk_preflight.py scripts/ci_tools_requirements_guard.py`
- Static landing link check for removed `/quickstart` and `/pricing`, existing `site/trust.html` / `site/compare.html`, and `#local-proof` anchor
- Inbox newest-first check
- `npm --prefix mcp-server ci && npm --prefix mcp-server test`
- `python -m pytest sdk/tests/ -q` (776 passed)
- `python -m bandit -r sdk/agentguard/ -s B101,B110,B112,B311 -q`
- `python scripts/sdk_preflight.py`
- Playwright browser loaded local landing page and confirmed Quickstart/Compare hrefs

## Docs updates needed
- None beyond the inbox ordering fix in this PR.