### PR TITLE
docs(readme): position AgentGuard vs Anthropic per-tool max_tokens

### DIFF
--- a/QA_REPORT.md
+++ b/QA_REPORT.md
@@ -1,51 +1,24 @@
-# QA_REPORT
+# QA_REPORT.md - anthropic-advisor-max-tokens-update-positioning (agent47)
 
-Verdict: ✅
+**Verdict:** OK
 
-## Scope alignment
+## What was checked
 
-The task body's acceptance criteria, each checked against the diff:
+1. Diff scope: only `README.md` and the auto-generated `sdk/PYPI_README.md`. No code in `sdk/`. No `.github/workflows/`. No `.env*`. No `security/`. No `supabase/`. No secrets.
+2. Banned-word scan (grep -i over README.md): no matches for harness / leverage / streamline / delve / landscape / cutting-edge / game-changer / revolutionary / seamless / robust / holistic / synergy / ecosystem.
+3. `pytest sdk/tests/test_pypi_readme_sync.py` -- 5/5 pass. The PYPI_README sync test is the gate on this README change; it is green.
+4. Full SDK test suite (`pytest sdk/tests/`) revealed ONE failure: `test_init.py::TestInit::test_init_default_local_sink`. Confirmed pre-existing by re-running on stock `main` with my changes stashed -- same failure. Cause: local environment has `AGENTGUARD_API_KEY` + `AGENTGUARD_SERVICE` env vars set (vault config) that override the default sink. Unrelated to this PR.
+5. Scope match: WORK_PLAN.md said README lead-paragraph reframe + new comparison section + PYPI_README regen. Diff does exactly that.
+6. Voice rules: builder-to-builder, short sentences, numbers (the 2026-06-02 date and the concrete table), no fluff, no em dashes in new content. Existing em-dash on the lead paragraph was replaced with `--` as part of the rewrite.
+7. README total diff: ~50 LOC added, well under the 400-LOC merge ceiling.
 
-| Criterion | Status | Evidence |
-|---|---|---|
-| `Goal` exposes `cost_usd`, `attempts`, `succeeded`, `failure_cost`, `duration_sec`, `calls`, `to_dict()` | ✅ | `sdk/agentguard/goal.py:44-126` |
-| `BudgetGuard.goal(name, verifier)` context manager | ✅ | `sdk/agentguard/guards.py` new method; verified `with guard.goal(...) as g:` works in test suite |
-| Cost accumulates across nested calls via contextvars | ✅ | `_active_goals: ContextVar` + hook in `BudgetGuard.consume` |
-| Verifier runs on exit, populates `succeeded` | ✅ | `_GoalContext.__exit__` |
-| `g.attempt()` explicit | ✅ | `Goal.attempt()` |
-| `failure_cost` = failed-attempt cost | ✅ | `Goal.failure_cost`, tested by `test_three_attempts_then_success_attributes_failure_cost` |
-| Goals nest cleanly, no double-count | ✅ | `test_nested_goals_no_double_count` |
-| Goals do not cross sessions | ✅ | ContextVar scope; goals are local objects, not module-level state |
-| `to_dict()` JSON-serializable | ✅ | `test_to_dict_is_json_serializable` |
-| Happy-path test | ✅ |
-| 3-attempts-then-success test | ✅ |
-| Nested-goals test | ✅ |
-| Failed-goal test | ✅ |
-| README section | ✅ | `sdk/README.md` new "Goal-level metering" section |
-| All existing tests still pass | ✅ | 769 passed, 0 failed |
-| No new external dependencies | ✅ | Only stdlib (`contextvars`, `dataclasses`, `time`) |
+## What was NOT changed
 
-## Path note
+- No code under `sdk/`.
+- No tests added or modified.
+- No new dependencies.
+- No claims about Anthropic API beyond what the 2026-06-03 source page documents (per-tool `max_tokens` on the advisor tool, refusal-not-billed).
 
-Task body said `agent47/goal.py`. Actual package layout is `sdk/agentguard/` — so the new file lives at `sdk/agentguard/goal.py`. This matches the rest of the package (`guards.py`, `cost.py`, etc.). The task wording was shorthand; the implementation respects the real layout.
+## Independent verifier note
 
-## Security / denylist check
-
-- No changes under `.github/workflows/`, `.env*`, `supabase/migrations/`, `security/`, secrets, or Stripe/Clerk config.
-- No new credentials or API keys.
-- No new external network calls. The verifier is user-supplied; the SDK itself does not invoke external services here.
-
-## Pattern compliance
-
-- `Goal` and `Call` are `@dataclass` like `BudgetState` (`sdk/agentguard/guards.py:176`).
-- `_GoalContext` follows the same context-manager pattern as `TimeoutGuard` (`sdk/agentguard/guards.py:397-405`).
-- Error type for bad verifier is `TypeError`, matching the type-checking patterns elsewhere in `BudgetGuard.consume` (`sdk/agentguard/guards.py:258-269`).
-- Docstrings include `Usage::` example blocks per existing convention.
-
-## Risk
-
-Low. The diff is 79 lines plus a 200-line new module. The only behavior change to existing code is one function-call append inside `BudgetGuard.consume` that is a no-op when no goal is active. All existing tests including `test_concurrency.py`, `test_cost.py`, `test_e2e_pipeline.py` pass unchanged.
-
-## Test coverage regressions
-
-None. Added 8 new tests; no existing test removed or skipped.
+Task `signal_type: vendor-announcement`, not `security-threat`. CVE-Bench second-verifier requirement does not apply.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ Most agent tooling tells you what happened after the run. AgentGuard stops the
 bad run while it is happening.
 
 AgentGuard is an **in-process agentic-loop guard**, not an LLM cost router. It
-runs inside the agent's process, sees the call graph, and raises exceptions
-that kill the run before the next bad call lands. Routers and gateways like
-Manifest or Vercel AI Gateway sit at the network layer and shape egress
-traffic. The layers are complementary — see the
+runs inside the agent's process, sees the call graph **across calls, retries,
+and providers**, and raises exceptions that kill the run before the next bad
+call lands. Single-call limits (Anthropic's per-tool `max_tokens`, OpenAI's
+`max_tokens`, model-side stop sequences) cap one response on one provider.
+AgentGuard caps the multi-call envelope the agent is running inside, no matter
+which provider answers the next call. Routers and gateways like Manifest or
+Vercel AI Gateway sit at the network layer and shape egress traffic. The
+layers are complementary -- see the
 [competitive notes](#runtime-control-vs-observability) for when each fits.
 
 | Problem | What AgentGuard does |
@@ -311,6 +315,44 @@ Competitive notes:
 - [AgentGuard vs Vercel AI Gateway](docs/competitive/vercel-ai-gateway.md)
 - [AgentGuard vs Manifest (LLM router)](docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](docs/competitive/agent-security-stack.md)
+
+## Anthropic per-tool `max_tokens` vs AgentGuard cross-call budget
+
+On 2026-06-02 Anthropic shipped a per-tool `max_tokens` parameter on the
+advisor tool. That is a useful single-call output cap. It is not a substitute
+for the multi-call, multi-provider budget envelope an agent loop actually
+spends inside of.
+
+| Concern | Anthropic per-tool `max_tokens` | AgentGuard `BudgetGuard` |
+|---|---|---|
+| Scope | one tool call, one response | the whole run: every call, every retry, every nested goal |
+| Providers | Anthropic API only | Anthropic, OpenAI, local LLMs, anything you call from Python |
+| Counts | output tokens on that response | calls + USD across the run (input + output + retries) |
+| Failure mode | response truncates at the cap | `BudgetExceeded` raised in-process; the run stops |
+| Retry storms | not handled (each retry caps independently) | `RetryGuard` and `LoopGuard` stop the storm before it accumulates |
+| Cross-provider migration | re-cap per provider | one ceiling, regardless of which provider the next call hits |
+
+```python
+from agentguard import BudgetGuard, LoopGuard, RetryGuard, Tracer
+
+# One ceiling for the whole run, regardless of provider or retry count.
+budget = BudgetGuard(max_cost_usd=2.00, max_calls=20)
+loop = LoopGuard(max_repeats=3)
+retry = RetryGuard(max_retries=3)
+tracer = Tracer(service="multi-provider-agent", guards=[loop, retry])
+
+with tracer.trace("agent.run"):
+    budget.consume(calls=1, cost_usd=0.02)   # anthropic call
+    budget.consume(calls=1, cost_usd=0.01)   # openai fallback
+    budget.consume(calls=1, cost_usd=0.00)   # local llama.cpp
+    # If the cumulative cost or call count crosses the ceiling,
+    # BudgetExceeded is raised here. The provider-side max_tokens
+    # of any single call would not have stopped this.
+```
+
+Use both. Set per-call output caps where the provider supports them. Wrap the
+agent loop in `BudgetGuard` for the run-level ceiling. The two layers protect
+different failure modes.
 
 ## Decision Traces
 

--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -1,41 +1,34 @@
-# WORK_PLAN: goal-level metering API prototype
+# WORK_PLAN.md - anthropic-advisor-max-tokens-update-positioning (agent47)
 
-## Problem
-AgentGuard today only meters per-session via `BudgetGuard`. Operators care about cost-per-completed-goal (per the arXiv:2605.22883 framing). Ship v1 of a `guard.goal(name, verifier=...)` context manager that buckets nested call costs against a named goal, runs a verifier on exit, and exposes a structured ledger.
+## Problem statement
+
+On 2026-06-02 Anthropic shipped per-tool `max_tokens` caps on the advisor tool. That narrows the bare "you need a third-party library to cap tokens" pitch for callers already on the first-party Claude API. AgentGuard's actual moat is cross-call and cross-provider budget enforcement, runtime loop/retry/rate guards, and language-agnostic enforcement that survives provider migrations. The README needs to make that explicit so a reader who heard about the Anthropic change does not conclude AgentGuard is now redundant.
 
 ## Approach
-- New module `sdk/agentguard/goal.py`:
-  - `Call` dataclass — single accounted call (tokens, calls, cost_usd, attempt_idx, ts).
-  - `Goal` dataclass holding name, verifier, calls, sub-goals, attempts counter, start/end ts. Methods: `attempt()`, `_record(call)`, `to_dict()`. Properties: `cost_usd`, `failure_cost`, `duration_sec`, `succeeded` (set on exit).
-  - `_active_goal_stack: ContextVar[tuple[Goal, ...]]` so nested calls inside async/threadpool see the right goal. The stack holds parent + descendants so we can implement nesting cleanly.
-- `BudgetGuard.goal(name, verifier)` returns a context manager. On `__enter__` pushes a new Goal onto the contextvar stack and records start. On `__exit__` pops, runs verifier, sets succeeded, attaches goal to parent (if any) as a sub-goal.
-- Hook into `BudgetGuard.consume(...)` so that, when a goal is active, we also append a `Call` to the innermost goal. This keeps all existing call accounting intact (no breaking change) and adds goal-bucketing as a side effect.
-- `cost_usd` = own calls + sub-goal totals (no double-count: own calls only contain direct `consume` calls; sub-goals' calls live on the sub-goal objects).
-- `failure_cost` = cost of all calls in failed attempts. An attempt is failed if it is not the final attempt of a successful goal. If `not succeeded`, all calls are failure cost.
-- Verifier MUST be a callable returning bool. We do not catch verifier exceptions — they propagate (fail loudly per global instructions).
+
+Surgical README edit:
+1. Lightly reframe the "Why AgentGuard" lead paragraph to say in one line that the guard sits across calls, retries, and providers, not just inside a single call.
+2. Add a new section "Anthropic per-tool max_tokens vs AgentGuard cross-call/cross-provider budget" just after the existing "Runtime Control vs Observability" section. Short comparison table + one paragraph that says: single-call output cap (Anthropic) and multi-call/multi-provider envelope (AgentGuard) are complementary, not substitutes.
+3. Run `scripts/generate_pypi_readme.py` so `sdk/PYPI_README.md` stays in sync (enforced by `test_committed_pypi_readme_is_in_sync`).
+
+No core feature changes. No new dependencies. No code under `sdk/`. No `.github/workflows/` edits. Comparison framing is factual and only describes what each tool does today.
 
 ## Files likely to touch
-- `sdk/agentguard/goal.py` (new)
-- `sdk/agentguard/guards.py` (BudgetGuard.goal method + hook into consume)
-- `sdk/agentguard/__init__.py` (export Goal)
-- `sdk/tests/test_goal.py` (new)
-- `sdk/README.md` (new section)
-- `README.md` at repo root if it mirrors
 
-## Done checklist
-- [ ] `Goal` exposes `cost_usd`, `attempts`, `succeeded`, `failure_cost`, `duration_sec`, `calls`, `to_dict()`.
-- [ ] `BudgetGuard.goal(name, verifier)` works as a context manager.
-- [ ] Nested goals: parent total = own + sub totals, no double count.
-- [ ] Happy path test (1 attempt, succeeds).
-- [ ] 3-attempts-then-success test (failure_cost > 0).
-- [ ] Nested goals test.
-- [ ] Failed goal test (succeeded=False, full cost = failure cost).
-- [ ] README section "Goal-level metering".
-- [ ] All existing tests still pass.
-- [ ] No new external deps.
+- `README.md` (the lead-paragraph reframe + new comparison section)
+- `sdk/PYPI_README.md` (regenerated, not hand-edited)
+
+## What "done" looks like
+
+- [ ] `README.md` lead-paragraph reframed to mention cross-call / cross-provider envelope.
+- [ ] `README.md` has a new section comparing Anthropic per-tool `max_tokens` and AgentGuard's multi-call/multi-provider budget.
+- [ ] `sdk/PYPI_README.md` regenerated and matches generator output.
+- [ ] `pytest sdk/tests/test_pypi_readme_sync.py` passes.
+- [ ] PR opened against `bmdhodl/agent47`.
 
 ## Risks / assumptions
-- Hooking into `BudgetGuard.consume` is the right integration point. Alternative would be a separate `record_call` API, but consume is already where every cost lands. The hook is one append; zero behavior change when no goal is active.
-- Contextvars are the right propagation mechanism (async + threadpool safe, as the paper assumes). The standard lib provides this — no new deps.
-- Verifier contract is binary bool in v1 (per task scope). Fuzzy verifiers are v2.
-- Per the concept page sketch, the `guard` in `with guard.goal(...)` is a `BudgetGuard` instance (the only "guard" with cost state). The concept page's reference to `AgentGuard(budget_usd=5.00)` is aspirational naming — current package uses `BudgetGuard(max_cost_usd=...)`. We stay consistent with the existing API.
+
+- Risk: `test_pypi_readme_sync.py` fails if I forget to regenerate. Mitigation: run the regenerate script as the last step before commit.
+- Risk: Banned words leak in (harness, leverage, etc.). Mitigation: grep the diff before commit.
+- Risk: New section grows past 400 LOC budget. Mitigation: keep section ~30 lines.
+- Assumption: the linked Knowledge source page (2026-06-03-anthropic-advisor-max-tokens-cost-cap) accurately summarizes the Anthropic announcement. Verified by reading the source page.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -49,10 +49,14 @@ Most agent tooling tells you what happened after the run. AgentGuard stops the
 bad run while it is happening.
 
 AgentGuard is an **in-process agentic-loop guard**, not an LLM cost router. It
-runs inside the agent's process, sees the call graph, and raises exceptions
-that kill the run before the next bad call lands. Routers and gateways like
-Manifest or Vercel AI Gateway sit at the network layer and shape egress
-traffic. The layers are complementary — see the
+runs inside the agent's process, sees the call graph **across calls, retries,
+and providers**, and raises exceptions that kill the run before the next bad
+call lands. Single-call limits (Anthropic's per-tool `max_tokens`, OpenAI's
+`max_tokens`, model-side stop sequences) cap one response on one provider.
+AgentGuard caps the multi-call envelope the agent is running inside, no matter
+which provider answers the next call. Routers and gateways like Manifest or
+Vercel AI Gateway sit at the network layer and shape egress traffic. The
+layers are complementary -- see the
 [competitive notes](#runtime-control-vs-observability) for when each fits.
 
 | Problem | What AgentGuard does |
@@ -313,6 +317,44 @@ Competitive notes:
 - [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/competitive/vercel-ai-gateway.md)
 - [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](https://github.com/bmdhodl/agent47/blob/main/docs/competitive/agent-security-stack.md)
+
+## Anthropic per-tool `max_tokens` vs AgentGuard cross-call budget
+
+On 2026-06-02 Anthropic shipped a per-tool `max_tokens` parameter on the
+advisor tool. That is a useful single-call output cap. It is not a substitute
+for the multi-call, multi-provider budget envelope an agent loop actually
+spends inside of.
+
+| Concern | Anthropic per-tool `max_tokens` | AgentGuard `BudgetGuard` |
+|---|---|---|
+| Scope | one tool call, one response | the whole run: every call, every retry, every nested goal |
+| Providers | Anthropic API only | Anthropic, OpenAI, local LLMs, anything you call from Python |
+| Counts | output tokens on that response | calls + USD across the run (input + output + retries) |
+| Failure mode | response truncates at the cap | `BudgetExceeded` raised in-process; the run stops |
+| Retry storms | not handled (each retry caps independently) | `RetryGuard` and `LoopGuard` stop the storm before it accumulates |
+| Cross-provider migration | re-cap per provider | one ceiling, regardless of which provider the next call hits |
+
+```python
+from agentguard import BudgetGuard, LoopGuard, RetryGuard, Tracer
+
+# One ceiling for the whole run, regardless of provider or retry count.
+budget = BudgetGuard(max_cost_usd=2.00, max_calls=20)
+loop = LoopGuard(max_repeats=3)
+retry = RetryGuard(max_retries=3)
+tracer = Tracer(service="multi-provider-agent", guards=[loop, retry])
+
+with tracer.trace("agent.run"):
+    budget.consume(calls=1, cost_usd=0.02)   # anthropic call
+    budget.consume(calls=1, cost_usd=0.01)   # openai fallback
+    budget.consume(calls=1, cost_usd=0.00)   # local llama.cpp
+    # If the cumulative cost or call count crosses the ceiling,
+    # BudgetExceeded is raised here. The provider-side max_tokens
+    # of any single call would not have stopped this.
+```
+
+Use both. Set per-call output caps where the provider supports them. Wrap the
+agent loop in `BudgetGuard` for the run-level ceiling. The two layers protect
+different failure modes.
 
 ## Decision Traces
 


### PR DESCRIPTION
﻿## Summary

- Anthropic shipped per-tool `max_tokens` on the advisor tool on 2026-06-02. That caps one response on one provider.
- Reframe the README "Why AgentGuard" lead to make the cross-call / cross-provider envelope explicit, and add a comparison section that contrasts the single-call cap against `BudgetGuard` directly.
- Regenerate `sdk/PYPI_README.md` so the PyPI page stays in sync (enforced by `test_committed_pypi_readme_is_in_sync`).

The two layers are complementary, not substitutes. Make that explicit before readers conclude the runtime layer is now redundant.

## Test plan

- [x] `pytest sdk/tests/test_pypi_readme_sync.py` -> 5/5 pass
- [x] Full `pytest sdk/tests/` -> 1 pre-existing env-pollution failure (`test_init_default_local_sink`, caused by local `AGENTGUARD_API_KEY` env var, confirmed by re-running on stock main); all other 493 pass
- [x] Banned-word scan on README -> clean
- [x] No `.github/workflows/`, `.env*`, `security/`, or `sdk/` code touched

## Risk

Low. Documentation-only. The PyPI README sync test was the only hard gate; it passes. No SDK behavior change.

## Artifacts

- `WORK_PLAN.md` and `QA_REPORT.md` committed at repo root.

## Companion PR

Paired with bmdhodl/bmdpat#732 which adds the same comparison to the /tools/agentguard landing page.

Source signal: vault `Knowledge/sources/2026-06-03-anthropic-advisor-max-tokens-cost-cap.md`.

