### PR TITLE
ci: add automated Claude PR review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   claude-review:
+    # Forked PRs don't receive repo secrets, so the OAuth token would be empty.
+    # Only run for same-repo PRs (agent47 is public and takes external forks).
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,37 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. Focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+
+            Use `gh pr comment` for overall feedback and
+            mcp__github_inline_comment__create_inline_comment for specific
+            line-level comments. Be concise and only flag real issues.
+            The PR branch is already checked out in the working directory.
+          claude_args: |
+            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds automated PR code review via the official anthropics/claude-code-action (v1), authed with a Claude subscription OAuth token (secret CLAUDE_CODE_OAUTH_TOKEN) so there is no per-token API bill. Runs on every PR (opened + synchronize) and posts inline + summary comments. NOTE: the review job fails until the CLAUDE_CODE_OAUTH_TOKEN secret is set on this repo.