### PR TITLE
fix(ci): Claude PR review via CLI (dodge OAuth header bug)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,34 +7,47 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 jobs:
   claude-review:
-    # Forked PRs don't receive repo secrets, so the OAuth token would be empty.
-    # Only run for same-repo PRs (agent47 is public and takes external forks).
+    # Forked PRs don't receive repo secrets; skip them.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - name: Claude Code Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            Review this pull request. Focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
 
-            Use `gh pr comment` for overall feedback and
-            mcp__github_inline_comment__create_inline_comment for specific
-            line-level comments. Be concise and only flag real issues.
-            The PR branch is already checked out in the working directory.
-          claude_args: |
-            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+      - name: Review PR
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Pull the diff (cap size so we never blow the context window).
+          gh pr diff "$PR" --repo "$REPO" | head -c 200000 > /tmp/pr.diff
+          if [ ! -s /tmp/pr.diff ]; then
+            echo "Empty diff, nothing to review."
+            exit 0
+          fi
+
+          PROMPT='You are a senior code reviewer. Review the following pull request diff. Flag only real issues: bugs, security problems, and quality concerns. Be concise and specific, cite file/line where you can. If nothing is wrong, reply exactly "LGTM - no blocking issues." Output GitHub-flavored markdown. The diff follows:'
+
+          # claude -p with no prompt arg reads the whole prompt from stdin.
+          { printf '%s\n\n' "$PROMPT"; cat /tmp/pr.diff; } \
+            | claude -p --output-format text > /tmp/review.md
+
+          if [ ! -s /tmp/review.md ]; then
+            echo "Empty review output, skipping comment."
+            exit 0
+          fi
+
+          { echo "## ðŸ¤– Claude review"; echo; cat /tmp/review.md; } \
+            | gh pr comment "$PR" --repo "$REPO" --body-file -


### PR DESCRIPTION
Replaces the broken anthropics/claude-code-action (OAuth header bug, issue #1316) with a direct claude -p CLI call. Same free OAuth billing. Verified working on bmdpat#767.