### PR TITLE
feat(guards): persistent cross-process state for BudgetGuard

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -141,6 +141,30 @@ rate = RateLimitGuard(max_calls_per_minute=60)
 rate.check()
 ```
 
+## Persistent budgets (cross-process)
+
+By default a guard's counters live in memory and reset when the process exits. For
+agents that run as repeated short-lived invocations (cron jobs, serverless functions,
+CI steps, scheduled tasks), give `BudgetGuard` a `store` so the ceiling holds across
+separate processes. The store is atomic and cross-process locked, so concurrent
+invocations never lose an update.
+
+```python
+from agentguard import BudgetGuard, JsonFileStateStore
+
+# Enforce 400 calls/day across every separate subprocess invocation.
+guard = BudgetGuard(
+    max_calls=400,
+    store=JsonFileStateStore("agent-budget.json"),
+    key="fleet",
+    period="day",   # bucket resets at the UTC day boundary; omit for a lifetime total
+)
+guard.consume(calls=1)  # raises BudgetExceeded once the shared count passes 400
+```
+
+Without `store=`, behavior is unchanged (in-memory, zero-config). A corrupt store
+raises `StateStoreError` rather than silently resetting to zero.
+
 ## Goal-level metering
 
 Measuring cost per completed goal, not per call.

--- a/sdk/agentguard/__init__.py
+++ b/sdk/agentguard/__init__.py
@@ -57,6 +57,7 @@ from .schemas import (
 )
 from .setup import get_budget_guard, get_tracer, init, shutdown
 from .sinks import HttpSink
+from .state import JsonFileStateStore, StateStore, StateStoreError
 from .tracing import JsonlFileSink, StdoutSink, Tracer, TraceSink
 
 
@@ -96,6 +97,7 @@ __all__ = [
     "Goal",
     "HttpSink",
     "InitConfig",
+    "JsonFileStateStore",
     "JsonlFileSink",
     "LoopDetected",
     "LoopGuard",
@@ -104,6 +106,8 @@ __all__ = [
     "RepoConfig",
     "RetryGuard",
     "RetryLimitExceeded",
+    "StateStore",
+    "StateStoreError",
     "StdoutSink",
     "TimeoutExceeded",
     "TimeoutGuard",

--- a/sdk/agentguard/guards.py
+++ b/sdk/agentguard/guards.py
@@ -21,7 +21,10 @@ import threading
 import time
 from collections import Counter, deque
 from dataclasses import dataclass
-from typing import Any, Callable, Deque, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Optional, Tuple
+
+if TYPE_CHECKING:
+    from .state import StateStore
 
 
 class AgentGuardError(Exception):
@@ -214,9 +217,21 @@ class BudgetGuard(BaseGuard):
         max_cost_usd: Optional[float] = None,
         warn_at_pct: Optional[float] = None,
         on_warning: Optional[Callable[[str], None]] = None,
+        *,
+        store: Optional["StateStore"] = None,
+        key: Optional[str] = None,
+        period: Optional[str] = None,
+        now: Optional[Callable[[], float]] = None,
     ) -> None:
         if max_tokens is None and max_calls is None and max_cost_usd is None:
             raise ValueError("Provide max_tokens, max_calls, or max_cost_usd")
+        if store is not None and not key:
+            raise ValueError("key is required when store is set")
+        if period is not None:
+            if store is None:
+                raise ValueError("period requires a store")
+            if period != "day":
+                raise ValueError("period must be 'day' or None")
         self._max_tokens = max_tokens
         self._max_calls = max_calls
         self._max_cost_usd = max_cost_usd
@@ -225,6 +240,11 @@ class BudgetGuard(BaseGuard):
         self._warned = False
         self._lock = threading.Lock()
         self.state = BudgetState()
+        # Persistence (optional). store=None keeps the in-memory behavior unchanged.
+        self._store = store
+        self._key = key
+        self._period = period
+        self._now = now if now is not None else time.time
 
     @property
     def max_tokens(self) -> Optional[int]:
@@ -272,28 +292,84 @@ class BudgetGuard(BaseGuard):
         # that trips BudgetExceeded.
         from .goal import _record_consume
         _record_consume(tokens=tokens, calls=calls, cost_usd=cost_usd)
+        if self._store is None:
+            self._consume_in_memory(tokens, calls, cost_usd)
+        else:
+            self._consume_persistent(tokens, calls, cost_usd)
+
+    def _consume_in_memory(self, tokens: float, calls: float, cost_usd: float) -> None:
         with self._lock:
             self.state.tokens_used += tokens
             self.state.calls_used += calls
             self.state.cost_used += cost_usd
-            if self._max_tokens is not None and self.state.tokens_used > self._max_tokens:
-                raise BudgetExceeded(
-                    f"Token budget exceeded: {self.state.tokens_used} > {self._max_tokens} "
-                    f"(this call added {tokens} tokens)"
-                )
-            if self._max_calls is not None and self.state.calls_used > self._max_calls:
-                raise BudgetExceeded(
-                    f"Call budget exceeded: {self.state.calls_used} > {self._max_calls} "
-                    f"(this call added {calls} calls)"
-                )
-            if self._max_cost_usd is not None and self.state.cost_used > self._max_cost_usd:
-                raise BudgetExceeded(
-                    f"Cost budget exceeded: ${self.state.cost_used:.4f} > ${self._max_cost_usd:.4f} "
-                    f"(this call added ${cost_usd:.4f})"
-                )
-            # Check warning threshold
+            self._enforce_limits(
+                self.state.tokens_used, self.state.calls_used, self.state.cost_used,
+                tokens, calls, cost_usd,
+            )
             if self._warn_at_pct is not None and not self._warned:
                 self._check_warning()
+
+    def _consume_persistent(self, tokens: float, calls: float, cost_usd: float) -> None:
+        bucket = self._period_bucket()
+
+        def mutator(current: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+            st = dict(current) if current else {}
+            st["tokens_used"] = st.get("tokens_used", 0) + tokens
+            st["calls_used"] = st.get("calls_used", 0) + calls
+            st["cost_used"] = st.get("cost_used", 0.0) + cost_usd
+            return st
+
+        # The store's update() is atomic and cross-process locked, so the increment is
+        # durable even when this same call is the one that trips the limit. self._lock
+        # additionally serializes threads within this process.
+        with self._lock:
+            new = self._store.update(bucket, mutator)  # type: ignore[union-attr]
+            self.state = BudgetState(
+                tokens_used=int(new["tokens_used"]),
+                calls_used=int(new["calls_used"]),
+                cost_used=float(new["cost_used"]),
+            )
+            self._enforce_limits(
+                new["tokens_used"], new["calls_used"], new["cost_used"],
+                tokens, calls, cost_usd,
+            )
+            if self._warn_at_pct is not None and not self._warned:
+                self._check_warning()
+
+    def _period_bucket(self) -> str:
+        """Storage key for the current period. With period='day' the key rolls over at
+        the UTC day boundary, giving a deterministic per-day reset."""
+        if self._period is None:
+            return self._key  # type: ignore[return-value]
+        day = time.strftime("%Y-%m-%d", time.gmtime(self._now()))
+        return f"{self._key}:{day}"
+
+    def _enforce_limits(
+        self,
+        tokens_used: float,
+        calls_used: float,
+        cost_used: float,
+        added_tokens: float,
+        added_calls: float,
+        added_cost: float,
+    ) -> None:
+        """Raise BudgetExceeded if any configured limit is exceeded. Shared by the
+        in-memory and persistent paths so both produce identical messages."""
+        if self._max_tokens is not None and tokens_used > self._max_tokens:
+            raise BudgetExceeded(
+                f"Token budget exceeded: {tokens_used} > {self._max_tokens} "
+                f"(this call added {added_tokens} tokens)"
+            )
+        if self._max_calls is not None and calls_used > self._max_calls:
+            raise BudgetExceeded(
+                f"Call budget exceeded: {calls_used} > {self._max_calls} "
+                f"(this call added {added_calls} calls)"
+            )
+        if self._max_cost_usd is not None and cost_used > self._max_cost_usd:
+            raise BudgetExceeded(
+                f"Cost budget exceeded: ${cost_used:.4f} > ${self._max_cost_usd:.4f} "
+                f"(this call added ${added_cost:.4f})"
+            )
 
     def _check_warning(self) -> None:
         """Emit a warning if usage crosses the warn_at_pct threshold.
@@ -327,10 +403,16 @@ class BudgetGuard(BaseGuard):
                 self._on_warning(msg)
 
     def reset(self) -> None:
-        """Reset all usage counters to zero."""
+        """Reset all usage counters to zero.
+
+        With a persistent store, this also clears the current period's stored state so
+        the ceiling restarts for every process sharing the store.
+        """
         with self._lock:
             self.state = BudgetState()
             self._warned = False
+            if self._store is not None:
+                self._store.clear(self._period_bucket())
 
     def __repr__(self) -> str:
         parts = []

--- a/sdk/agentguard/state.py
+++ b/sdk/agentguard/state.py
@@ -1,0 +1,215 @@
+"""Persistent, cross-process state backends for AgentGuard guards.
+
+In-memory guards lose their counters when the process exits. Agents that run as
+repeated short-lived invocations (cron jobs, serverless functions, CI steps, Windows
+scheduled tasks) cannot enforce a ceiling that way: every new process starts at zero.
+
+A :class:`StateStore` lets a guard persist its accumulator so the ceiling holds across
+separate processes. The default :class:`JsonFileStateStore` writes one JSON file,
+guarded by a cross-process lock so concurrent processes do not lose updates.
+
+Usage::
+
+    from agentguard import BudgetGuard, JsonFileStateStore
+
+    # Enforce 400 calls/day across many separate scheduled subprocess invocations:
+    guard = BudgetGuard(
+        max_calls=400,
+        store=JsonFileStateStore("agent-budget.json"),
+        key="fleet",
+        period="day",
+    )
+    guard.consume(calls=1)
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
+
+from .guards import AgentGuardError
+
+
+class StateStoreError(AgentGuardError):
+    """Raised when a StateStore cannot read or persist state.
+
+    A corrupt or unreadable store raises this rather than silently resetting to zero -
+    a guard that quietly forgets its budget is worse than no guard.
+    """
+
+
+@runtime_checkable
+class StateStore(Protocol):
+    """Pluggable persistent state backend for guards.
+
+    Implementations must make :meth:`update` an atomic read-modify-write so two
+    processes sharing the same store and key never lose an increment.
+    """
+
+    def read(self, key: str) -> Optional[Dict[str, Any]]:
+        """Return the state dict stored at ``key``, or None if absent."""
+        ...
+
+    def update(
+        self, key: str, mutator: Callable[[Optional[Dict[str, Any]]], Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Atomically load ``key``, apply ``mutator``, persist, and return the new state."""
+        ...
+
+    def clear(self, key: str) -> None:
+        """Remove the state stored at ``key``."""
+        ...
+
+
+class _CrossProcessLock:
+    """Portable advisory lock using an exclusive lock file.
+
+    Acquired by creating a lock file with ``O_CREAT | O_EXCL``. A stale lock left by a
+    crashed holder (older than ``stale_after`` seconds) is broken so the system cannot
+    deadlock forever. Works on both POSIX and Windows.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        timeout: float = 10.0,
+        poll: float = 0.01,
+        stale_after: float = 60.0,
+    ) -> None:
+        self._path = Path(path)
+        self._timeout = timeout
+        self._poll = poll
+        self._stale_after = stale_after
+        self._fd: Optional[int] = None
+
+    def acquire(self) -> None:
+        deadline = time.monotonic() + self._timeout
+        while True:
+            try:
+                self._fd = os.open(str(self._path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.write(self._fd, str(os.getpid()).encode("ascii"))
+                return
+            except FileExistsError:
+                # Break a stale lock whose holder likely died. On Windows the held lock
+                # file is open and unlink raises, so a live holder keeps the lock.
+                try:
+                    age = time.time() - self._path.stat().st_mtime
+                    if age > self._stale_after:
+                        os.unlink(self._path)
+                        continue
+                except OSError:
+                    pass
+                if time.monotonic() >= deadline:
+                    raise StateStoreError(
+                        f"timed out acquiring lock {self._path} after {self._timeout}s"
+                    ) from None
+                time.sleep(self._poll)
+
+    def release(self) -> None:
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            finally:
+                self._fd = None
+        try:
+            os.unlink(self._path)
+        except OSError:
+            pass
+
+    def __enter__(self) -> "_CrossProcessLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        self.release()
+        return False
+
+
+class JsonFileStateStore:
+    """File-backed :class:`StateStore`.
+
+    One JSON file holds a mapping of ``key -> state dict``. Writes are atomic (temp file
+    + ``os.replace``) and serialized by a cross-process lock so concurrent processes do
+    not lose updates. A corrupt store raises :class:`StateStoreError`.
+
+    Args:
+        path: Path to the JSON state file. Parent directories are created.
+        lock_timeout: Seconds to wait for the cross-process lock before raising.
+    """
+
+    def __init__(self, path: Any, *, lock_timeout: float = 10.0) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self._path.with_name(self._path.name + ".lock")
+        self._lock = _CrossProcessLock(lock_path, timeout=lock_timeout)
+
+    def _read_all(self) -> Dict[str, Any]:
+        if not self._path.exists():
+            return {}
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise StateStoreError(f"cannot read state file {self._path}: {exc}") from exc
+        if not raw.strip():
+            return {}
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise StateStoreError(
+                f"state file {self._path} is corrupt: {exc}. Refusing to silently reset "
+                f"to zero; fix or delete the file."
+            ) from exc
+        if not isinstance(data, dict):
+            raise StateStoreError(
+                f"state file {self._path} has unexpected shape: {type(data).__name__}"
+            )
+        return data
+
+    def _write_all(self, data: Dict[str, Any]) -> None:
+        fd, tmp = tempfile.mkstemp(
+            dir=str(self._path.parent), prefix=self._path.name + ".", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, self._path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def read(self, key: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._read_all().get(key)
+
+    def update(
+        self, key: str, mutator: Callable[[Optional[Dict[str, Any]]], Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        with self._lock:
+            data = self._read_all()
+            new_value = mutator(data.get(key))
+            if not isinstance(new_value, dict):
+                raise StateStoreError(
+                    f"mutator must return a dict, got {type(new_value).__name__}"
+                )
+            data[key] = new_value
+            self._write_all(data)
+            return new_value
+
+    def clear(self, key: str) -> None:
+        with self._lock:
+            data = self._read_all()
+            if key in data:
+                del data[key]
+                self._write_all(data)
+
+    def __repr__(self) -> str:
+        return f"JsonFileStateStore({self._path!r})"

--- a/sdk/tests/test_exports.py
+++ b/sdk/tests/test_exports.py
@@ -140,6 +140,7 @@ class TestTopLevelExports(unittest.TestCase):
             "unpatch_openai_async", "unpatch_anthropic_async",
             "InitConfig", "RepoConfig", "ProfileDefaults", "SUPPORTED_PROFILES",
             "Goal", "Call",
+            "StateStore", "StateStoreError", "JsonFileStateStore",
         }
         self.assertEqual(set(agentguard.__all__), expected)
 

--- a/sdk/tests/test_guard_persistence.py
+++ b/sdk/tests/test_guard_persistence.py
@@ -1,0 +1,163 @@
+"""Tests for persistent, cross-process guard state (BudgetGuard store=).
+
+The headline test is two real OS processes sharing one store file: if the cross-process
+lock is wrong, increments are lost and the combined count overshoots the ceiling. The
+suite also proves state survives process death, that a corrupt store raises instead of
+silently resetting, that period='day' resets deterministically via an injected clock,
+and that the in-memory default is unchanged.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from agentguard import (
+    AgentGuardError,
+    BudgetExceeded,
+    BudgetGuard,
+    JsonFileStateStore,
+    StateStoreError,
+)
+
+_SDK_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_in_memory_default_unchanged_without_store():
+    # Backward compatibility: no store -> exact original behavior.
+    guard = BudgetGuard(max_calls=2)
+    guard.consume(calls=1)
+    guard.consume(calls=1)
+    with pytest.raises(BudgetExceeded):
+        guard.consume(calls=1)
+
+
+def test_store_requires_key(tmp_path):
+    with pytest.raises(ValueError, match="key is required"):
+        BudgetGuard(max_calls=5, store=JsonFileStateStore(tmp_path / "s.json"))
+
+
+def test_period_requires_store():
+    with pytest.raises(ValueError, match="period requires a store"):
+        BudgetGuard(max_calls=5, period="day")
+
+
+def test_persists_across_instances(tmp_path):
+    path = tmp_path / "budget.json"
+    g1 = BudgetGuard(max_calls=3, store=JsonFileStateStore(path), key="fleet")
+    g1.consume(calls=1)
+    g1.consume(calls=1)
+    del g1  # the process/object goes away
+
+    # A brand new guard from the same store + key sees the prior usage.
+    g2 = BudgetGuard(max_calls=3, store=JsonFileStateStore(path), key="fleet")
+    g2.consume(calls=1)  # 3rd call total - at the limit, still ok
+    with pytest.raises(BudgetExceeded):
+        g2.consume(calls=1)  # 4th call total - over the ceiling
+
+
+def test_overflow_is_durable(tmp_path):
+    # The increment that trips the limit must still be persisted.
+    path = tmp_path / "budget.json"
+    g = BudgetGuard(max_calls=1, store=JsonFileStateStore(path), key="k")
+    g.consume(calls=1)
+    with pytest.raises(BudgetExceeded):
+        g.consume(calls=1)
+    stored = JsonFileStateStore(path).read("k")
+    assert stored["calls_used"] == 2  # the overflow call was recorded
+
+
+def test_corrupt_store_raises_not_silent_reset(tmp_path):
+    path = tmp_path / "budget.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    guard = BudgetGuard(max_calls=5, store=JsonFileStateStore(path), key="k")
+    with pytest.raises(StateStoreError):
+        guard.consume(calls=1)
+    # StateStoreError is an AgentGuardError, so callers catching the base type see it.
+    assert issubclass(StateStoreError, AgentGuardError)
+
+
+def test_period_day_resets_on_rollover(tmp_path):
+    path = tmp_path / "budget.json"
+    clock = {"t": 0.0}  # 1970-01-01 UTC
+
+    def now():
+        return clock["t"]
+
+    guard = BudgetGuard(
+        max_calls=2, store=JsonFileStateStore(path), key="fleet", period="day", now=now
+    )
+    guard.consume(calls=1)
+    guard.consume(calls=1)
+    with pytest.raises(BudgetExceeded):
+        guard.consume(calls=1)  # day 1 ceiling hit
+
+    clock["t"] = 86_400.0  # advance to the next UTC day
+    guard.consume(calls=1)  # fresh bucket -> allowed again
+    guard.consume(calls=1)
+    with pytest.raises(BudgetExceeded):
+        guard.consume(calls=1)
+
+
+def test_reset_clears_persisted_state(tmp_path):
+    path = tmp_path / "budget.json"
+    store = JsonFileStateStore(path)
+    guard = BudgetGuard(max_calls=2, store=store, key="k")
+    guard.consume(calls=1)
+    guard.consume(calls=1)
+    guard.reset()
+    guard.consume(calls=1)  # ceiling restarted
+    assert store.read("k")["calls_used"] == 1
+
+
+_WORKER = textwrap.dedent(
+    """
+    import sys
+    from agentguard import BudgetGuard, JsonFileStateStore, BudgetExceeded
+    path, ceiling, attempts = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+    guard = BudgetGuard(max_calls=ceiling, store=JsonFileStateStore(path), key="fleet")
+    ok = 0
+    for _ in range(attempts):
+        try:
+            guard.consume(calls=1)
+            ok += 1
+        except BudgetExceeded:
+            break
+    print(ok)
+    """
+)
+
+
+def test_two_processes_share_one_ceiling_no_lost_updates(tmp_path):
+    # Two real OS processes hammer the same store. With a correct cross-process lock the
+    # combined number of successful consumes equals the ceiling exactly. A broken lock
+    # loses updates and lets MORE than `ceiling` calls succeed.
+    path = tmp_path / "budget.json"
+    ceiling = 20
+    attempts = 15  # 2 * 15 = 30 attempts against a ceiling of 20
+
+    env = {"PYTHONPATH": str(_SDK_DIR)}
+    import os
+
+    env = {**os.environ, **env}
+
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", _WORKER, str(path), str(ceiling), str(attempts)],
+            stdout=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        for _ in range(2)
+    ]
+    outs = [p.communicate(timeout=60)[0] for p in procs]
+    assert all(p.returncode == 0 for p in procs), outs
+
+    successes = sum(int(o.strip().splitlines()[-1]) for o in outs)
+    assert successes == ceiling, f"expected exactly {ceiling} successful consumes, got {successes}"
+
+    final = JsonFileStateStore(path).read("fleet")
+    assert final["calls_used"] >= ceiling


### PR DESCRIPTION
## What
Adds an optional persistent state backend so a `BudgetGuard` ceiling holds across **separate process invocations**, not just within one process.

## Why
Guards held counters in memory only. An agent that runs as repeated short-lived invocations (cron, serverless, CI, scheduled tasks) could not enforce a ceiling - every new process started at zero. This is the gap blocking AgentGuard from guarding scheduled-fleet workloads.

## API (backward compatible)
```python
from agentguard import BudgetGuard, JsonFileStateStore
guard = BudgetGuard(max_calls=400, store=JsonFileStateStore("agent-budget.json"), key="fleet", period="day")
guard.consume(calls=1)
```
`store=None` keeps in-memory behavior byte-for-byte. New params are keyword-only.

## Design
- `StateStore` protocol + `JsonFileStateStore`: atomic writes (temp + os.replace), portable cross-process lock, corrupt store raises `StateStoreError` (no silent reset to zero).
- `period='day'` resets at the UTC day boundary via an injectable clock.
- Shared `_enforce_limits` keeps in-memory and persistent error messages identical.

## Tests (all green; 784 total, 9 new)
- persistence across instances + durable overflow
- corrupt-store-raises
- day rollover via injected clock
- reset clears persisted state
- **two real OS processes sharing one ceiling — proves no lost updates under the lock**

ruff clean. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)