### PR TITLE
docs(readme): position AgentGuard vs cross-user memory contamination

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ enough to create surprise spend.
 
 ## Why runtime control, not just memory
 
-The Mem0 2026 agent memory survey found a 57-71% cross-user contamination rate across eight major agent runtimes. The root cause is keyword retrieval with weak staleness handling: memory written by one user gets recalled into another user's context, which leaks PII and bleeds decisions across sessions. The memory layer is where state goes wrong, but the runtime is where you can still stop it. AgentGuard sits at the call site and enforces hard budget, loop, retry, and timeout limits in-process, so a contaminated recall cannot turn into a runaway loop or a sustained spend incident before the run ends.
+The 2026 paper [No Attacker Needed: Unintentional Cross-User Contamination in Shared-State LLM Agents](https://arxiv.org/abs/2604.01350) measured a 57-71% contamination rate under raw shared state, with no attacker involved. Scope-bound artifacts from one user persist in shared memory and get misapplied to another user's context, which can leak data and bleed decisions across sessions. The memory layer is where state goes wrong, but the runtime is where you can still stop it. AgentGuard sits at the call site and enforces hard budget, loop, retry, and timeout limits in-process, so a contaminated recall cannot turn into a runaway loop or a sustained spend incident before the run ends.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ enough to create surprise spend.
 
 > **⭐ Star this repo** if AgentGuard stops one runaway run for you. It is how other builders find it.
 
+## Why runtime control, not just memory
+
+The Mem0 2026 agent memory survey found a 57-71% cross-user contamination rate across eight major agent runtimes. The root cause is keyword retrieval with weak staleness handling: memory written by one user gets recalled into another user's context, which leaks PII and bleeds decisions across sessions. The memory layer is where state goes wrong, but the runtime is where you can still stop it. AgentGuard sits at the call site and enforces hard budget, loop, retry, and timeout limits in-process, so a contaminated recall cannot turn into a runaway loop or a sustained spend incident before the run ends.
+
 ## Install
 
 ### As a Python package

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -23,6 +23,10 @@ enough to create surprise spend.
 
 > **⭐ Star this repo** if AgentGuard stops one runaway run for you. It is how other builders find it.
 
+## Why runtime control, not just memory
+
+The Mem0 2026 agent memory survey found a 57-71% cross-user contamination rate across eight major agent runtimes. The root cause is keyword retrieval with weak staleness handling: memory written by one user gets recalled into another user's context, which leaks PII and bleeds decisions across sessions. The memory layer is where state goes wrong, but the runtime is where you can still stop it. AgentGuard sits at the call site and enforces hard budget, loop, retry, and timeout limits in-process, so a contaminated recall cannot turn into a runaway loop or a sustained spend incident before the run ends.
+
 ## Install
 
 ### As a Python package

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -25,7 +25,7 @@ enough to create surprise spend.
 
 ## Why runtime control, not just memory
 
-The Mem0 2026 agent memory survey found a 57-71% cross-user contamination rate across eight major agent runtimes. The root cause is keyword retrieval with weak staleness handling: memory written by one user gets recalled into another user's context, which leaks PII and bleeds decisions across sessions. The memory layer is where state goes wrong, but the runtime is where you can still stop it. AgentGuard sits at the call site and enforces hard budget, loop, retry, and timeout limits in-process, so a contaminated recall cannot turn into a runaway loop or a sustained spend incident before the run ends.
+The 2026 paper [No Attacker Needed: Unintentional Cross-User Contamination in Shared-State LLM Agents](https://arxiv.org/abs/2604.01350) measured a 57-71% contamination rate under raw shared state, with no attacker involved. Scope-bound artifacts from one user persist in shared memory and get misapplied to another user's context, which can leak data and bleed decisions across sessions. The memory layer is where state goes wrong, but the runtime is where you can still stop it. AgentGuard sits at the call site and enforces hard budget, loop, retry, and timeout limits in-process, so a contaminated recall cannot turn into a runaway loop or a sustained spend incident before the run ends.
 
 ## Install
 

--- a/site/index.html
+++ b/site/index.html
@@ -956,6 +956,10 @@
               <h3>Timeout drift</h3>
               <p>Make long-running agent work fail clearly instead of hanging until the operator notices.</p>
             </div>
+            <div class="card guard">
+              <h3>Contaminated memory recall</h3>
+              <p>The Mem0 2026 agent memory survey found 57-71% cross-user contamination. When a bad recall fires, hard runtime limits stop it from becoming a runaway loop or spend incident.</p>
+            </div>
           </div>
         </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -958,7 +958,7 @@
             </div>
             <div class="card guard">
               <h3>Contaminated memory recall</h3>
-              <p>The Mem0 2026 agent memory survey found 57-71% cross-user contamination. When a bad recall fires, hard runtime limits stop it from becoming a runaway loop or spend incident.</p>
+              <p>Shared-state agents show a 57-71% cross-user contamination rate with no attacker involved (arXiv 2604.01350). When a bad recall fires, hard runtime limits stop it from becoming a runaway loop or spend incident.</p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

Adds a short positioning section to the README (above the install snippet) framing AgentGuard as the in-process runtime control layer for the memory-contamination failure mode. Cites the Mem0 2026 agent memory survey: a 57-71% cross-user contamination rate driven by keyword retrieval with weak staleness handling. Mirrors a matching guard card in the site landing features section, and regenerates `sdk/PYPI_README.md` from the source via `scripts/generate_pypi_readme.py`.

The survey URL was unverified in the source signal (single TLDR bullet, no direct paper link), so the citation reads "Mem0 2026 agent memory survey" with no link, per the no-unverified-link rule.

## Test plan

- `python scripts/generate_pypi_readme.py --check` passes (PYPI_README in sync)
- `python scripts/sdk_release_guard.py` passes
- Docs-only diff: 12 insertions across README.md, sdk/PYPI_README.md (generated), site/index.html
- No banned marketing words, no em dashes, no closed-repo references

## Risk

Low. Docs-only. No code, tests, workflows, or dependencies touched.
