### PR TITLE
docs(readme): position AgentGuard runtime envelope vs WorkOS scoped agent credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ as the canonical reference. The layers are complementary: containment
 bounds what the process can touch; AgentGuard bounds what the agent loop
 inside that process can spend.
 
+## Identity vs Runtime: AgentGuard and scoped agent credentials
+
+Scoped agent credential products, such as the per-agent identity, RBAC, and
+audit logs that WorkOS productized in mid-2026, answer an identity-time
+question: who is this agent, what scopes does it hold, and what did it touch.
+AgentGuard answers a run-time question: what is the agent doing right now, and
+should this run be stopped before it spends more. One sets the envelope. The
+other enforces the envelope at execution with a budget cap, token cap, rate
+cap, and an in-process kill-switch. They compose rather than compete. Issue a
+scoped credential per agent for identity and audit, then wrap that agent's loop
+with AgentGuard so a runaway run cannot burn the budget the credential allows.
+
 ## Real Incidents AgentGuard Prevents
 
 ### PocketOS — agent deleted prod DB and backups in 9 seconds (May 2026)

--- a/proof/workos-positioning-2026-06-04/QA_REPORT.md
+++ b/proof/workos-positioning-2026-06-04/QA_REPORT.md
@@ -1,0 +1,29 @@
+# QA Report: WorkOS positioning update
+
+Date: 2026-06-04
+Branch: feat/workos-positioning-update
+Task: Queue/agent47/workos-positioning-update.md
+
+## Result: PASS
+
+## Checklist
+- [x] Docs/markup only (README.md, sdk/PYPI_README.md, site/index.html). No code, tests, workflows, env, or secrets touched.
+- [x] No denylist paths (.github/, .env*, supabase/migrations/, security/, secrets, auth config).
+- [x] Diff small: 29 insertions, 0 deletions, 3 files (well under 400 LOC).
+- [x] No banned words (harness, leverage, streamline, delve, landscape, cutting-edge, game-changer, revolutionary, seamless, robust, holistic, synergy, ecosystem) in added lines.
+- [x] No em dashes (U+2014) in added lines.
+- [x] No closed-repo mentions (consulting, client work, dashboard internals) introduced. The wedge paragraph is strictly identity-time vs run-time.
+- [x] Idempotency: no pre-existing WorkOS mention anywhere in repo before this change.
+- [x] sdk/PYPI_README.md regenerated via scripts/generate_pypi_readme.py --write; --check returns exit 0 (in sync).
+- [x] PYPI_README is generated, not hand-edited.
+
+## Source verification
+Source card: Knowledge/sources/2026-06-04-workos-scoped-agent-credentials.md
+- The card is explicit: derived from "TLDR AI Signals" sponsor/marketing copy, confidence = medium, "reading marketing-layer copy, not the SDK or docs."
+- No verifiable canonical announcement URL is present in the card.
+- Decision: described the capability (per-agent identity, RBAC, audit logs productized by WorkOS in mid-2026) WITHOUT asserting an unverifiable hard link or a precise date. Conservative framing per task instructions.
+
+## Content
+The wedge: scoped agent credentials = identity-time (who the agent is, scopes, audit).
+AgentGuard = run-time (budget/token/rate cap + in-process kill-switch). They compose,
+they do not compete. WorkOS bounds the envelope; AgentGuard enforces it at execution.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -109,6 +109,18 @@ as the canonical reference. The layers are complementary: containment
 bounds what the process can touch; AgentGuard bounds what the agent loop
 inside that process can spend.
 
+## Identity vs Runtime: AgentGuard and scoped agent credentials
+
+Scoped agent credential products, such as the per-agent identity, RBAC, and
+audit logs that WorkOS productized in mid-2026, answer an identity-time
+question: who is this agent, what scopes does it hold, and what did it touch.
+AgentGuard answers a run-time question: what is the agent doing right now, and
+should this run be stopped before it spends more. One sets the envelope. The
+other enforces the envelope at execution with a budget cap, token cap, rate
+cap, and an in-process kill-switch. They compose rather than compete. Issue a
+scoped credential per agent for identity and audit, then wrap that agent's loop
+with AgentGuard so a runaway run cannot burn the budget the credential allows.
+
 ## Real Incidents AgentGuard Prevents
 
 ### PocketOS — agent deleted prod DB and backups in 9 seconds (May 2026)

--- a/site/index.html
+++ b/site/index.html
@@ -980,6 +980,11 @@
               <div><p>AgentGuard47 focuses on runtime enforcement and incident control.</p></div>
               <div><p>It is not prompt management, eval orchestration, or a trace warehouse.</p></div>
             </div>
+            <div class="compare-row">
+              <div><strong>Identity vs runtime</strong><p>Composes</p></div>
+              <div><p>Scoped agent credentials answer who the agent is and what scopes it holds.</p></div>
+              <div><p>AgentGuard caps what the agent is doing right now and stops the run in-process. Use both.</p></div>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

WorkOS productized scoped agent credentials (per-agent identity, RBAC, audit logs) in mid-2026. Anyone searching "control my AI agent" hits that marketing first. This adds a one-paragraph wedge so visitors immediately see the difference and that the two layers compose:

- **Scoped agent credentials = identity-time** (who the agent is, what scopes it holds, audit trail).
- **AgentGuard = run-time** (budget cap, token cap, rate cap, in-process kill-switch on what the agent is doing right now).

They do not compete. One sets the envelope; the other enforces it at execution. Issue a scoped credential per agent for identity and audit, then wrap that agent's loop with AgentGuard so a runaway run cannot burn the budget the credential allows.

Changes:
- `README.md`: new "Identity vs Runtime" section placed right after "Scope".
- `site/index.html`: matching one-liner row in the Positioning compare table.
- `sdk/PYPI_README.md`: regenerated from README via `scripts/generate_pypi_readme.py --write` (generated file, not hand-edited).

## Test plan

- `python scripts/generate_pypi_readme.py --check` returns exit 0 (PYPI_README in sync with README).
- Diff is docs/markup only: 3 source files, 29 insertions, 0 deletions. No code, tests, workflows, env, or secrets touched.
- Verified no banned marketing words and no em dashes in the added copy.
- Source confidence is medium (vendor marketing-layer signal, no canonical SDK/docs URL available), so the capability is described without asserting an unverifiable hard link or precise date.

## Risk

Low. Documentation and static landing copy only. No behavior change, no dependency change.
