### PR TITLE
docs(readme): name Uber's $1,500/dev cap as the enterprise budget pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ gh skill install bmdhodl/agent47 agentguard
 Most agent tooling tells you what happened after the run. AgentGuard stops the
 bad run while it is happening.
 
+Used to prevent surprise bills like Uber's $1,500/developer Claude Code cap,
+but enforced at the call site, where a per-tool org policy can't reach.
+
 AgentGuard is an **in-process agentic-loop guard**, not an LLM cost router. It
 runs inside the agent's process, sees the call graph, and raises exceptions
 that kill the run before the next bad call lands. Routers and gateways like
@@ -169,6 +172,20 @@ BudgetGuard(max_cost_usd=5.00, max_calls=50, warn_at_pct=0.8)
 
 The guard raises `BudgetExceeded` before the run blows the cap. Same
 conversation, one config line instead of a memo.
+
+### Uber — $1,500/developer cap on Claude Code (June 2026)
+
+Uber set a $1,500 per-developer monthly cap on Claude Code after its AI
+budget ran hot. That cap is a per-tool org policy: it bounds spend per seat,
+per tool, from the outside. It cannot see a single run that loops, retries
+across providers, or chains 200 small calls inside one agent process.
+
+Source: [Simon Willison](https://simonwillison.net/2026/Jun/3/uber-caps-usage/)
+
+This is the enterprise pattern AgentGuard targets: the same dollar ceiling,
+enforced at the call site with `BudgetGuard`, where the run actually spends
+the money. Org caps and in-process caps are complementary: keep the seat
+budget, add the run-level stop.
 
 ## Local Proof in 60 Seconds
 

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -48,6 +48,9 @@ gh skill install bmdhodl/agent47 agentguard
 Most agent tooling tells you what happened after the run. AgentGuard stops the
 bad run while it is happening.
 
+Used to prevent surprise bills like Uber's $1,500/developer Claude Code cap,
+but enforced at the call site, where a per-tool org policy can't reach.
+
 AgentGuard is an **in-process agentic-loop guard**, not an LLM cost router. It
 runs inside the agent's process, sees the call graph, and raises exceptions
 that kill the run before the next bad call lands. Routers and gateways like
@@ -171,6 +174,20 @@ BudgetGuard(max_cost_usd=5.00, max_calls=50, warn_at_pct=0.8)
 
 The guard raises `BudgetExceeded` before the run blows the cap. Same
 conversation, one config line instead of a memo.
+
+### Uber — $1,500/developer cap on Claude Code (June 2026)
+
+Uber set a $1,500 per-developer monthly cap on Claude Code after its AI
+budget ran hot. That cap is a per-tool org policy: it bounds spend per seat,
+per tool, from the outside. It cannot see a single run that loops, retries
+across providers, or chains 200 small calls inside one agent process.
+
+Source: [Simon Willison](https://simonwillison.net/2026/Jun/3/uber-caps-usage/)
+
+This is the enterprise pattern AgentGuard targets: the same dollar ceiling,
+enforced at the call site with `BudgetGuard`, where the run actually spends
+the money. Org caps and in-process caps are complementary: keep the seat
+budget, add the run-level stop.
 
 ## Local Proof in 60 Seconds
 


### PR DESCRIPTION
## Summary

Positioning-only README sharpen (AgentGuard is cannon-paused — copy only, no feature changes):

- Adds one sentence under **Why AgentGuard** naming Uber's $1,500/developer Claude Code cap as the surprise-bill pattern AgentGuard prevents, framed as call-site enforcement a per-tool org policy can't reach.
- Adds a concrete **Uber** enterprise example under **Real Incidents AgentGuard Prevents** (alongside the existing PocketOS / Microsoft entries), making the in-process-cap-vs-org-policy wedge explicit.
- Regenerates `sdk/PYPI_README.md` (auto-generated from `README.md` via `scripts/generate_pypi_readme.py`; `test_committed_pypi_readme_is_in_sync` enforces parity, so the mirror must move with the source).

## Test plan

- [x] `python scripts/generate_pypi_readme.py --check` — generated PyPI README in sync
- [x] `python -m pytest sdk/tests/test_pypi_readme_sync.py -q` — 5 passed
- [x] `python scripts/sdk_preflight.py` — pypi-readme sync + test gates pass
- [x] `python scripts/sdk_release_guard.py` — release guard passed
- [x] `python -m ruff check sdk/agentguard/` — all checks passed
- [x] `git diff --check` — clean (CRLF normalization warnings only)

## Artifacts

- Diff: 2 files, +34 lines, additions only (`README.md` + generated `sdk/PYPI_README.md`).
- Source datapoint: https://simonwillison.net/2026/Jun/3/uber-caps-usage/
- Queue task: `Queue/agent47/agentguard-uber-validation-readme.md`

## Risk

Low. Docs/positioning copy only. No code paths, no public API, no new dependencies, no denylist paths touched. The only non-obvious bit is the required `sdk/PYPI_README.md` regeneration, which is verified green by the sync test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
