### PR TITLE
feat(usage): break out Anthropic thinking tokens in usage accounting

### DIFF
--- a/sdk/agentguard/usage.py
+++ b/sdk/agentguard/usage.py
@@ -36,6 +36,9 @@ def normalize_usage(usage: Any, provider: Optional[str] = None) -> Optional[Dict
     )
     cache_read_input_tokens = _as_int(_nested_get(usage, "cache_read_input_tokens"))
     cache_creation_input_tokens = _as_int(_nested_get(usage, "cache_creation_input_tokens"))
+    thinking_tokens = _as_int(
+        _nested_get(usage, "output_tokens_details", "thinking_tokens")
+    )
 
     looks_openai = bool(
         prompt_tokens
@@ -72,6 +75,7 @@ def normalize_usage(usage: Any, provider: Optional[str] = None) -> Optional[Dict
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
+            thinking_tokens=thinking_tokens,
         )
 
     if looks_openai:
@@ -89,6 +93,7 @@ def normalize_usage(usage: Any, provider: Optional[str] = None) -> Optional[Dict
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
+            thinking_tokens=thinking_tokens,
         )
 
     if isinstance(usage, dict):
@@ -162,6 +167,7 @@ def _normalize_anthropic_usage(
     output_tokens: int,
     cache_read_input_tokens: int,
     cache_creation_input_tokens: int,
+    thinking_tokens: int = 0,
 ) -> Dict[str, int]:
     normalized = {
         "input_tokens": input_tokens,
@@ -176,4 +182,13 @@ def _normalize_anthropic_usage(
     if cache_creation_input_tokens:
         normalized["cache_write_input_tokens"] = cache_creation_input_tokens
         normalized["cache_creation_input_tokens"] = cache_creation_input_tokens
+    if thinking_tokens:
+        # Anthropic now breaks out billed extended-thinking tokens via
+        # usage.output_tokens_details.thinking_tokens. Surface thinking spend
+        # separately from the answer tokens so callers can attribute cost.
+        # Older responses omit the field; we add these keys only when present,
+        # keeping the normalized shape backward-compatible.
+        normalized["reasoning_tokens"] = thinking_tokens
+        normalized["thinking_tokens"] = thinking_tokens
+        normalized["answer_tokens"] = max(output_tokens - thinking_tokens, 0)
     return normalized

--- a/sdk/tests/test_savings.py
+++ b/sdk/tests/test_savings.py
@@ -67,6 +67,53 @@ class TestNormalizeUsage(unittest.TestCase):
             },
         )
 
+    def test_normalizes_anthropic_thinking_tokens_when_present(self):
+        # Messages API now reports usage.output_tokens_details.thinking_tokens,
+        # breaking out billed extended-thinking tokens. The final streaming
+        # message_delta carries the same shape.
+        normalized = normalize_usage(
+            {
+                "input_tokens": 300,
+                "output_tokens": 120,
+                "output_tokens_details": {"thinking_tokens": 80},
+            },
+            provider="anthropic",
+        )
+
+        self.assertEqual(
+            normalized,
+            {
+                "input_tokens": 300,
+                "output_tokens": 120,
+                "total_tokens": 420,
+                "reasoning_tokens": 80,
+                "thinking_tokens": 80,
+                "answer_tokens": 40,
+            },
+        )
+
+    def test_anthropic_thinking_tokens_absent_does_not_break_parsing(self):
+        # Older responses omit output_tokens_details entirely. Parsing must
+        # succeed and must not invent thinking/answer keys.
+        normalized = normalize_usage(
+            {
+                "input_tokens": 300,
+                "output_tokens": 120,
+            },
+            provider="anthropic",
+        )
+
+        self.assertEqual(
+            normalized,
+            {
+                "input_tokens": 300,
+                "output_tokens": 120,
+                "total_tokens": 420,
+            },
+        )
+        self.assertNotIn("thinking_tokens", normalized)
+        self.assertNotIn("answer_tokens", normalized)
+
     def test_returns_none_for_missing_usage_shape(self):
         self.assertIsNone(normalize_usage({"foo": "bar"}))
 


### PR DESCRIPTION
﻿## What

The Anthropic Messages API now returns `usage.output_tokens_details.thinking_tokens`, reporting how many of the billed output tokens were extended thinking (per the May 27, 2026 release notes; when streaming, the breakdown appears on the final `message_delta` event). AgentGuard's Anthropic usage normalizer previously lumped all output tokens into one bucket.

This adds backward-compatible parsing of `thinking_tokens` and exposes thinking-vs-answer spend separately in the normalized usage shape.

## Changes (`sdk/agentguard/usage.py`)

- Parse `usage.output_tokens_details.thinking_tokens` via the existing `_nested_get` helper (same pattern as the OpenAI `completion_tokens_details.reasoning_tokens` parse already in the file).
- In `_normalize_anthropic_usage`, when thinking tokens are present, add three keys:
  - `thinking_tokens` — billed extended-thinking tokens
  - `answer_tokens` — `output_tokens - thinking_tokens` (floored at 0)
  - `reasoning_tokens` — alias mirroring the OpenAI normalizer, so existing reasoning-aware consumers pick up the value for free
- **Backward-compatible:** older responses omit the field; parsing is unchanged and none of the new keys are added when absent.

## Field verification

Confirmed the exact field path `usage.output_tokens_details.thinking_tokens` against the linked source card (`Knowledge/sources/2026-06-05-anthropic-thinking-tokens-api.md`, a primary vendor source, conf: high) and the `claude-api` skill. Both agree on path and on the streaming `message_delta` location. No discrepancy.

## Tests (`sdk/tests/test_savings.py`)

Extended `TestNormalizeUsage` with two cases:
- `test_normalizes_anthropic_thinking_tokens_when_present` — asserts the breakdown is parsed and `answer_tokens` is computed.
- `test_anthropic_thinking_tokens_absent_does_not_break_parsing` — asserts older-shape responses parse cleanly and add no thinking/answer keys.

## Test plan

- `pytest sdk/tests/test_savings.py sdk/tests/test_cost.py` → 37 passed (incl. 2 new).
- Full `pytest sdk/tests` → 777 passed. (9 failures in `test_init.py` are pre-existing on a clean baseline — caused by a local `agentguard.toml` in the sandbox env that `init` auto-discovers — and are unrelated to this change. Verified by stashing this diff and re-running.)
- No new dependencies. Diff: +62 LOC across 2 files. No denylist paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
