### PR TITLE
docs(readme): name Uber $1,500/dev cap as enterprise pattern AgentGuard prevents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ gh skill install bmdhodl/agent47 agentguard
 Most agent tooling tells you what happened after the run. AgentGuard stops the
 bad run while it is happening.
 
+> The enterprise pattern AgentGuard prevents: surprise bills like Uber's
+> $1,500/developer Claude Code cap, but enforced at the call site where a
+> per-tool org policy cannot reach.
+
 AgentGuard is an **in-process agentic-loop guard**, not an LLM cost router. It
 runs inside the agent's process, sees the call graph, and raises exceptions
 that kill the run before the next bad call lands. Routers and gateways like

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -48,6 +48,10 @@ gh skill install bmdhodl/agent47 agentguard
 Most agent tooling tells you what happened after the run. AgentGuard stops the
 bad run while it is happening.
 
+> The enterprise pattern AgentGuard prevents: surprise bills like Uber's
+> $1,500/developer Claude Code cap, but enforced at the call site where a
+> per-tool org policy cannot reach.
+
 AgentGuard is an **in-process agentic-loop guard**, not an LLM cost router. It
 runs inside the agent's process, sees the call graph, and raises exceptions
 that kill the run before the next bad call lands. Routers and gateways like


### PR DESCRIPTION
## Summary
Adds a one-sentence positioning callout to the "Why AgentGuard" section of the README, naming Uber's $1,500/developer Claude Code cap as the concrete enterprise pattern AgentGuard prevents. Sharpens positioning toward in-process, call-site budget enforcement (vs a per-tool org policy that cannot reach the call site).

Source: Uber caps Claude Code usage at $1,500/dev (simonwillison.net, 2026-06-03).

## Changes
- README.md: +4 / -0 (one blockquote callout). No feature changes (AgentGuard is cannon-paused, positioning copy only).

## Test plan
- Docs-only change. No code paths touched.
- Verified: no banned voice words, no em dashes, single sentence, factually matches source ($1,500/developer Claude Code cap).

## Risk
Minimal. README-only, no dependencies, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)