### PR TITLE
docs: position AgentGuard against Mem0 cross-user memory contamination finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ enough to create surprise spend.
 
 > **⭐ Star this repo** if AgentGuard stops one runaway run for you. It is how other builders find it.
 
+## Why runtime control
+
+The Mem0 2026 agent memory survey found 57 to 71 percent cross-user memory
+contamination across eight major agent frameworks. The failure mode is
+consistent: keyword retrieval pulls memory written by one user into another
+user's context, with weak staleness handling and no user-scoped isolation. The
+memory layer does not enforce the boundary. AgentGuard is the runtime control
+layer that does, sitting inside the agent process and stopping the bad run
+while it happens.
+
 ## Install
 
 ### As a Python package

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -23,6 +23,16 @@ enough to create surprise spend.
 
 > **⭐ Star this repo** if AgentGuard stops one runaway run for you. It is how other builders find it.
 
+## Why runtime control
+
+The Mem0 2026 agent memory survey found 57 to 71 percent cross-user memory
+contamination across eight major agent frameworks. The failure mode is
+consistent: keyword retrieval pulls memory written by one user into another
+user's context, with weak staleness handling and no user-scoped isolation. The
+memory layer does not enforce the boundary. AgentGuard is the runtime control
+layer that does, sitting inside the agent process and stopping the bad run
+while it happens.
+
 ## Install
 
 ### As a Python package

--- a/site/index.html
+++ b/site/index.html
@@ -849,6 +849,11 @@
                 loops, retries, and timeouts while your agent is still running. No
                 account, API key, or dashboard required for the first proof.
               </p>
+              <p class="lead">
+                The Mem0 2026 agent memory survey found 57 to 71 percent cross-user
+                memory contamination across major agent frameworks. AgentGuard is the
+                runtime control layer that enforces what the memory layer does not.
+              </p>
               <div class="hero-actions">
                 <a class="btn btn-red" href="#local-proof">Run proof in 60 seconds</a>
                 <a class="btn btn-secondary" href="https://github.com/bmdhodl/agent47">Inspect GitHub</a>


### PR DESCRIPTION
## Summary
Positioning copy only. Adds a short paragraph to the README (above the install snippet) and a matching one-liner to the site landing page hero, citing the Mem0 2026 agent memory survey finding of 57 to 71 percent cross-user memory contamination across major agent frameworks. Names the failure mode (keyword retrieval pulling one user's memory into another user's context, weak staleness handling, no user-scoped isolation) and positions AgentGuard as the runtime control layer that enforces what the memory layer does not.

Landing page: a landing page exists in-repo at `site/index.html`, so the hero one-liner was added there. Not N/A.

Citation: the Mem0 survey source has no verified URL, so it is cited as "Mem0 2026 agent memory survey" with no link, per the citation rule. No blog link.

## Changes
- `README.md` - new "Why runtime control" paragraph above `## Install`.
- `site/index.html` - matching one-liner in the hero section.
- `sdk/PYPI_README.md` - regenerated via `scripts/generate_pypi_readme.py --write` to satisfy the pypi-readme-sync CI guard.

## Test plan
- `python scripts/generate_pypi_readme.py --check` exits 0 (PYPI README in sync).
- `python -m ruff check scripts/generate_pypi_readme.py` passes.
- Diff scanned for em-dashes and banned vocabulary: clean. Used "agent frameworks" instead of the banned word.
- 25 insertions across 3 files, no new dependencies, no code paths touched.

## Risk
Low. Documentation and static-site copy only. No code, no auth, no secrets, no denylist paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
