### PR TITLE
feat(cli): frictionless first-run welcome, `python -m agentguard`, and a README badge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ AgentGuard is the public SDK wedge in the BMD PAT LLC portfolio: a zero-dependen
   - `guards.py`: the guard family and their exceptions.
   - `setup.py`: `init()` / `get_tracer()` / `get_budget_guard()` / `shutdown()` convenience entrypoints.
   - `instrument.py`, `decision.py`, `evaluation.py`, `cost.py`, `usage.py`, `savings.py`, `escalation.py`, `schemas.py`, `profiles.py`, `repo_config.py`, `reporting.py`, `export.py`: instrumentation, decision tracing, eval, cost/usage accounting, and report surfaces.
-  - `cli.py`, `doctor.py`, `demo.py`, `quickstart.py`, `skillpack.py`: the CLI and local proof surfaces.
+  - `cli.py`, `__main__.py`, `doctor.py`, `demo.py`, `quickstart.py`, `skillpack.py`, `first_run.py`: the CLI and local proof surfaces. `__main__.py` makes `python -m agentguard` mirror the console script; `first_run.py` holds the bare-command welcome and the paste-able "Guarded by AgentGuard" badge used by `agentguard welcome` / `agentguard badge`.
   - [`sdk/agentguard/integrations/`](sdk/agentguard/integrations/): optional, guarded-import framework adapters (`crewai.py`, `langchain.py`, `langgraph.py`).
   - [`sdk/agentguard/sinks/`](sdk/agentguard/sinks/): non-core sinks (`http.py` -> `HttpSink`, `otel.py` -> `OtelTraceSink`).
 - [`sdk/tests/`](sdk/tests/): behavioral, structural, hardening, DX, and integration-style tests for the SDK.
@@ -117,3 +117,4 @@ the last raw git tag, because a tag can exist for a failed package publish.
 
 - 2026-04-09: Created root `ARCHITECTURE.md` as the repo-level architecture law for future nightshift and PR work.
 - 2026-05-17: Refreshed directory map, data flow, and abstractions to match the repo as of 2026-05-17 — added the Python `agentguard-mcp/` local-budget server and `skills/`; documented the two distinct MCP surfaces and the current `sdk/agentguard/` module layout.
+- 2026-06-06: Documented the install-activation surfaces — `__main__.py` (`python -m agentguard`), the bare-command welcome, and the `agentguard badge` network-effect surface in `first_run.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Onboarding
+- Bare `agentguard` now prints a friendly first-run welcome with the 60-second
+  local path and the star call to action instead of an argparse help dump.
+- Added `python -m agentguard` as an entry point so the CLI works even when the
+  `agentguard` script is not on PATH.
+- Added `agentguard welcome` and `agentguard badge`. `badge` prints a
+  paste-able "Guarded by AgentGuard" README badge (markdown, rST, or HTML) so
+  adopters can advertise the SDK and drive new installs.
+
 ## 1.2.13
 
 ### Release Operations

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ enough to create surprise spend.
 
 ```bash
 pip install agentguard47
+agentguard
 ```
+
+The bare `agentguard` command prints a 60-second local tour. If the script is
+not on PATH, use `python -m agentguard` instead. Both run the same CLI.
 
 ### As a skill (Claude Code, Cursor, Cline, and more)
 
@@ -195,6 +199,24 @@ What you should see:
 
 Notebook version:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/main/examples/quickstart.ipynb)
+
+## Show Your Repo Is Guarded
+
+Once AgentGuard stops a runaway run for you, add the badge to your README so
+other builders find it:
+
+```bash
+agentguard badge
+```
+
+```markdown
+[![Guarded by AgentGuard](https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)](https://github.com/bmdhodl/agent47)
+```
+
+[![Guarded by AgentGuard](https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)](https://github.com/bmdhodl/agent47)
+
+`agentguard badge --format rst` and `--format html` print the same badge for
+other doc formats.
 
 ## Copy-Paste Repo Setup
 
@@ -465,7 +487,7 @@ assert result.passed
 - License: MIT
 - Core runtime dependencies: zero
 - Trace format: JSONL
-- Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
+- Local commands: `welcome`, `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`, `badge`
 - MCP package: [`@agentguard47/mcp-server`](mcp-server/)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 

--- a/memory/distribution.md
+++ b/memory/distribution.md
@@ -1,6 +1,6 @@
 # SDK Distribution
 
-**Last Updated:** 2026-05-29
+**Last Updated:** 2026-06-06
 
 ## Core Message
 AgentGuard stops coding agents from looping, retrying forever, and burning
@@ -31,6 +31,13 @@ budget.
   listing now passes checks, so merge is the upstream maintainers' call
 - Show HN
 - LangChain / GitHub community posts
+
+## Network-Effect Surfaces
+- "Guarded by AgentGuard" README badge via `agentguard badge` (markdown/rst/
+  html). Every adopting repo becomes a backlink + social proof. This is the
+  direct lever on the stars-vs-downloads gap; promote it wherever a user has
+  just seen a guard fire (demo close, report, README).
+- Star CTA stays in `doctor`, `demo`, and the bare-command welcome.
 
 ## Keep Repeating
 - zero dependency

--- a/memory/state.md
+++ b/memory/state.md
@@ -1,6 +1,6 @@
 # SDK State
 
-**Last Updated:** 2026-05-30
+**Last Updated:** 2026-06-06
 
 ## Product
 - AgentGuard = zero-dependency Python SDK for runtime guardrails.
@@ -31,3 +31,14 @@
   (GitHub stars sit at 3 against thousands of PyPI downloads)
 - distribution before new features
 - coding-agent onboarding and proof
+
+## Install / Activation Surface (unreleased, on `main`)
+- Bare `agentguard` prints a guided first-run welcome (60-second local path +
+  star CTA), not an argparse help dump. Logic in `first_run.render_welcome`.
+- `python -m agentguard` now works (`sdk/agentguard/__main__.py`) so the CLI
+  runs without the console script on PATH. The older `python -m agentguard.cli`
+  fallback still works and stays in doctor/demo/quickstart hints.
+- `agentguard badge` prints a paste-able "Guarded by AgentGuard" README badge
+  (markdown/rst/html) — the cheapest install→backlink network-effect surface,
+  aimed directly at the stars-vs-downloads gap. Surfaced in the welcome, the
+  demo close, and the README.

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,7 +3,7 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
-**Last reviewed:** 2026-05-29
+**Last reviewed:** 2026-06-06
 
 ## Current Focus Notes
 
@@ -50,6 +50,7 @@ they directly strengthen coding-agent adoption.
 | Coding-agent review-loop proof | Done - `examples/coding_agent_review_loop.py` demonstrates local budget and retry stops for review/refinement loops without API keys or network calls |
 | Follow-up handoff | Done - `ops/FOLLOWUP.md` records next hygiene and activation-metrics work without burying it in PR notes |
 | Opt-in activation metrics design | Done - `docs/guides/activation-metrics-design.md` defines allowed questions, consent boundaries, forbidden fields, and local-first non-goals without adding telemetry |
+| Frictionless first-run + badge network effect | Done - bare `agentguard` prints a guided welcome instead of argparse help, `python -m agentguard` works without PATH setup, and `agentguard badge` prints a paste-able "Guarded by AgentGuard" README badge (the lowest-friction install→backlink surface) |
 
 ## Now (next 2 weeks)
 

--- a/proof/frictionless-install-2026-06-06/VALIDATION.md
+++ b/proof/frictionless-install-2026-06-06/VALIDATION.md
@@ -48,4 +48,13 @@ against thousands of PyPI downloads.
 - release-guard: passed
 - full suite: 794 passed, total coverage 92.5% (>= 80 gate)
 - `first_run.py` coverage: 100%
+- `__main__.py` coverage: 100% (import-level test + end-to-end subprocess test)
 - `python -m agentguard` end-to-end subprocess test: passing
+
+## Automated review follow-ups (PR #584, claude-review: no blocking issues)
+
+Applied the three minor nits the automated review raised:
+- Closed the `__main__.py` import-coverage gap with a wiring test (now 100%).
+- Refreshed the stale `test_first_run.py` module docstring.
+- Strengthened the badge assertions to match the full linked-image markdown
+  (`[![Guarded by AgentGuard](`) instead of an incidental substring.

--- a/proof/frictionless-install-2026-06-06/VALIDATION.md
+++ b/proof/frictionless-install-2026-06-06/VALIDATION.md
@@ -46,14 +46,15 @@ against thousands of PyPI downloads.
 - bandit: clean (exit 0)
 - structural (test_architecture.py): 9 passed
 - release-guard: passed
-- full suite: 795 passed, total coverage ~92.5% (>= 80 gate)
+- full suite: 807 passed, total coverage ~92.6% (>= 80 gate)
 - `first_run.py` coverage: 100%
 - `__main__.py` coverage: 100% (import-level wiring test + end-to-end subprocess test)
+- `cli.py` coverage: 99% (`main()` is now measured, not pragma-excluded; the one
+  remaining miss is a pre-existing early `return` in `_decisions`, unrelated)
 - `python -m agentguard` end-to-end subprocess test: passing
 
-Note: `checks.txt` was regenerated after the review-fix commit (8baa888). The
-first capture predated the fix and showed `__main__.py` at 0% / 794 passed; the
-current `checks.txt` is the source of truth and shows 100% / 795 passed.
+Note: `checks.txt` is the source of truth and is regenerated after every fix
+commit. Earlier captures that predated a fix have been superseded.
 
 ## Automated review follow-ups (PR #584, claude-review: no blocking issues)
 
@@ -64,5 +65,12 @@ Applied the three minor nits the first review raised:
   (`[![Guarded by AgentGuard](`) instead of an incidental substring.
 
 Second review raised one item — the proof artifacts contradicted each other
-because `checks.txt` predated the fix. Resolved by regenerating `checks.txt`
-above; it now shows `__main__.py` at 100% and 795 passing, matching this file.
+because `checks.txt` predated the fix. Resolved by regenerating `checks.txt`,
+which now matches this file.
+
+Third review raised two real items, both applied:
+- Removed `# pragma: no cover` from `cli.main()` and added `TestCliRouting`, a
+  parametrized test that pins every dispatch branch (bare + 11 subcommands) so
+  routing regressions are caught. `cli.py` main() is now measured (99% overall).
+- Cleaned `BADGE_RST`'s redundant `f`-prefixes on placeholder-free lines.
+- Confirmed `Optional` is already imported in `cli.py` (no change needed).

--- a/proof/frictionless-install-2026-06-06/VALIDATION.md
+++ b/proof/frictionless-install-2026-06-06/VALIDATION.md
@@ -74,3 +74,9 @@ Third review raised two real items, both applied:
   routing regressions are caught. `cli.py` main() is now measured (99% overall).
 - Cleaned `BADGE_RST`'s redundant `f`-prefixes on placeholder-free lines.
 - Confirmed `Optional` is already imported in `cli.py` (no change needed).
+
+Fourth review: "LGTM - no blocking issues." Two minor polish items applied:
+- Tightened the `python -m agentguard` subprocess test timeout from 60s to 15s
+  (catches real hangs fast; still leaves margin for cold interpreter start).
+- Regenerated `cli-behavior.txt` to capture all badge formats, including the
+  previously missing `--format rst`.

--- a/proof/frictionless-install-2026-06-06/VALIDATION.md
+++ b/proof/frictionless-install-2026-06-06/VALIDATION.md
@@ -46,15 +46,23 @@ against thousands of PyPI downloads.
 - bandit: clean (exit 0)
 - structural (test_architecture.py): 9 passed
 - release-guard: passed
-- full suite: 794 passed, total coverage 92.5% (>= 80 gate)
+- full suite: 795 passed, total coverage ~92.5% (>= 80 gate)
 - `first_run.py` coverage: 100%
-- `__main__.py` coverage: 100% (import-level test + end-to-end subprocess test)
+- `__main__.py` coverage: 100% (import-level wiring test + end-to-end subprocess test)
 - `python -m agentguard` end-to-end subprocess test: passing
+
+Note: `checks.txt` was regenerated after the review-fix commit (8baa888). The
+first capture predated the fix and showed `__main__.py` at 0% / 794 passed; the
+current `checks.txt` is the source of truth and shows 100% / 795 passed.
 
 ## Automated review follow-ups (PR #584, claude-review: no blocking issues)
 
-Applied the three minor nits the automated review raised:
+Applied the three minor nits the first review raised:
 - Closed the `__main__.py` import-coverage gap with a wiring test (now 100%).
 - Refreshed the stale `test_first_run.py` module docstring.
 - Strengthened the badge assertions to match the full linked-image markdown
   (`[![Guarded by AgentGuard](`) instead of an incidental substring.
+
+Second review raised one item — the proof artifacts contradicted each other
+because `checks.txt` predated the fix. Resolved by regenerating `checks.txt`
+above; it now shows `__main__.py` at 100% and 795 passing, matching this file.

--- a/proof/frictionless-install-2026-06-06/VALIDATION.md
+++ b/proof/frictionless-install-2026-06-06/VALIDATION.md
@@ -1,0 +1,51 @@
+# Frictionless install + badge network effect — proof
+
+**Date:** 2026-06-06
+
+## Goal
+
+Make SDK installation as frictionless as possible (already zero-dependency) and
+add a low-friction network-effect loop that converts installs into visible
+proof / new installs. Directly targets the documented gap: 3 GitHub stars
+against thousands of PyPI downloads.
+
+## What changed (SDK only, zero new dependencies)
+
+1. **Bare `agentguard` now welcomes instead of dumping argparse help.**
+   `cli.main()` routes the no-args path to `first_run.render_welcome`, which
+   shows the 60-second local path (`doctor` -> `demo` -> `quickstart`) and the
+   star CTA. The most-typed first command after `pip install` now guides the
+   user to a win.
+
+2. **`python -m agentguard` works.** Added `sdk/agentguard/__main__.py` mirroring
+   the console script, so the CLI runs without the `agentguard` script on PATH.
+   The older `python -m agentguard.cli` fallback still works and stays in the
+   doctor/demo/quickstart hints.
+
+3. **`agentguard badge` network-effect surface.** Prints a paste-able
+   "Guarded by AgentGuard" README badge (markdown / rst / html). Every adopting
+   repo becomes a backlink and social proof. Surfaced in the welcome, the demo
+   close ("Show your repo is guarded"), and a dedicated README section.
+
+4. **`agentguard welcome` subcommand** for re-showing the tour on demand.
+
+## Files
+
+- `sdk/agentguard/__main__.py` (new)
+- `sdk/agentguard/first_run.py` (welcome + badge renderers)
+- `sdk/agentguard/cli.py` (welcome/badge subcommands + bare-command routing)
+- `sdk/agentguard/demo.py` (badge nudge at the success moment)
+- `sdk/tests/test_first_run.py` (welcome, badge, CLI dispatch, end-to-end
+  `python -m agentguard` subprocess test)
+- README.md / CHANGELOG.md / sdk/PYPI_README.md (regenerated)
+- ARCHITECTURE.md, ops/03-ROADMAP, memory/state.md, memory/distribution.md
+
+## Verification (see checks.txt and cli-behavior.txt)
+
+- ruff: All checks passed
+- bandit: clean (exit 0)
+- structural (test_architecture.py): 9 passed
+- release-guard: passed
+- full suite: 794 passed, total coverage 92.5% (>= 80 gate)
+- `first_run.py` coverage: 100%
+- `python -m agentguard` end-to-end subprocess test: passing

--- a/proof/frictionless-install-2026-06-06/checks.txt
+++ b/proof/frictionless-install-2026-06-06/checks.txt
@@ -1,3 +1,4 @@
+# Regenerated 2026-06-06T08:25:34Z after review-fix commit (8baa888). Supersedes the pre-fix capture.
 === ruff ===
 All checks passed!
 === bandit (security) ===
@@ -12,16 +13,16 @@ collected 9 items
 
 sdk\tests\test_architecture.py .........                                 [100%]
 
-============================== 9 passed in 0.20s ==============================
+============================== 9 passed in 0.55s ==============================
 === release-guard ===
 Release guard passed.
-=== full suite + coverage ===
+=== full suite + coverage (--cov=agentguard) ===
 ============================= test session starts =============================
 platform win32 -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
 rootdir: K:\agent47\.claude\worktrees\upbeat-thompson-79aa7b\sdk
 configfile: pyproject.toml
 plugins: anyio-4.9.0, langsmith-0.3.45, cov-7.1.0
-collected 794 items
+collected 795 items
 
 sdk\tests\test_architecture.py .........                                 [  1%]
 sdk\tests\test_async_patches.py ..........                               [  2%]
@@ -45,12 +46,12 @@ sdk\tests\test_evaluation.py ............................                [ 36%]
 sdk\tests\test_example_starters.py .........                             [ 37%]
 sdk\tests\test_export.py ...........                                     [ 38%]
 sdk\tests\test_exports.py ...............                                [ 40%]
-sdk\tests\test_first_run.py ............                                 [ 42%]
+sdk\tests\test_first_run.py .............                                [ 42%]
 sdk\tests\test_goal.py ........                                          [ 43%]
 sdk\tests\test_guard_persistence.py .........                            [ 44%]
 sdk\tests\test_guards.py ............................................... [ 50%]
 ..........................................                               [ 55%]
-sdk\tests\test_hardening.py ...........................................  [ 60%]
+sdk\tests\test_hardening.py ...........................................  [ 61%]
 sdk\tests\test_hosted_ingest_contract.py ....                            [ 61%]
 sdk\tests\test_http_sink.py .......................                      [ 64%]
 sdk\tests\test_init.py ...............................................   [ 70%]
@@ -81,43 +82,43 @@ sdk\tests\test_v1_coverage.py .............                              [100%]
 =============================== tests coverage ================================
 _______________ coverage: platform win32, python 3.13.2-final-0 _______________
 
-Name                                       Stmts   Miss  Cover
---------------------------------------------------------------
+Name                                       Stmts   Miss  Cover   Missing
+------------------------------------------------------------------------
 sdk\agentguard\__init__.py                    22      0   100%
-sdk\agentguard\__main__.py                     1      1     0%
+sdk\agentguard\__main__.py                     1      0   100%
 sdk\agentguard\_trace_naming.py               16      0   100%
 sdk\agentguard\atracing.py                    72      0   100%
-sdk\agentguard\cli.py                        129      1    99%
-sdk\agentguard\cost.py                        51      1    98%
-sdk\agentguard\decision.py                   214     30    86%
-sdk\agentguard\demo.py                        98      2    98%
-sdk\agentguard\doctor.py                     138     11    92%
-sdk\agentguard\escalation.py                 225     23    90%
+sdk\agentguard\cli.py                        129      1    99%   167
+sdk\agentguard\cost.py                        51      1    98%   109
+sdk\agentguard\decision.py                   214     30    86%   91, 97, 100-101, 110, 112, 116-117, 125, 149, 156-161, 167, 169, 181, 184, 203, 205, 209, 234, 540-542, 549, 551, 773, 780
+sdk\agentguard\demo.py                        98      2    98%   46, 180
+sdk\agentguard\doctor.py                     138     11    92%   57, 121, 159, 223-230, 234
+sdk\agentguard\escalation.py                 225     23    90%   51, 57, 69, 81, 94, 105, 152, 154, 161-164, 166, 168, 181, 186, 244, 307, 362, 390-392, 398, 411, 414
 sdk\agentguard\evaluation.py                 264      0   100%
 sdk\agentguard\export.py                      31      0   100%
 sdk\agentguard\first_run.py                   48      0   100%
-sdk\agentguard\goal.py                        79      1    99%
-sdk\agentguard\guards.py                     327      5    98%
-sdk\agentguard\instrument.py                 280     40    86%
+sdk\agentguard\goal.py                        79      1    99%   111
+sdk\agentguard\guards.py                     327      5    98%   167, 234, 252, 257, 337
+sdk\agentguard\instrument.py                 280     40    86%   62, 185-186, 205-219, 226, 229, 256-257, 271-272, 276, 297, 342-349, 366, 420, 453-454, 479, 482, 514-515, 519, 540
 sdk\agentguard\integrations\__init__.py        4      0   100%
 sdk\agentguard\integrations\crewai.py         79      0   100%
-sdk\agentguard\integrations\langchain.py     226     58    74%
+sdk\agentguard\integrations\langchain.py     226     59    74%   16-18, 80, 91-95, 110-111, 150-161, 173-177, 191, 208-219, 223-224, 239-240, 249-253, 281-285, 306, 313-318, 325-329, 342-343, 360-361
 sdk\agentguard\integrations\langgraph.py      43      0   100%
 sdk\agentguard\profiles.py                    15      0   100%
-sdk\agentguard\quickstart.py                 169      5    97%
-sdk\agentguard\repo_config.py                 80      8    90%
-sdk\agentguard\reporting.py                  129      7    95%
-sdk\agentguard\savings.py                    138      7    95%
-sdk\agentguard\schemas.py                     96     11    89%
-sdk\agentguard\setup.py                      101      4    96%
+sdk\agentguard\quickstart.py                 169      5    97%   50-52, 70, 214
+sdk\agentguard\repo_config.py                 80      8    90%   18, 31, 38-39, 56, 71, 82, 88
+sdk\agentguard\reporting.py                  129      7    95%   21, 46, 131, 253-258
+sdk\agentguard\savings.py                    138      7    95%   29, 91, 136, 152, 156, 170, 178
+sdk\agentguard\schemas.py                     96     11    89%   75, 78, 102, 109, 194-200
+sdk\agentguard\setup.py                      101      4    96%   255-256, 265-266
 sdk\agentguard\sinks\__init__.py               3      0   100%
-sdk\agentguard\sinks\http.py                 175     12    93%
-sdk\agentguard\sinks\otel.py                  98      8    92%
-sdk\agentguard\skillpack.py                  127      4    97%
-sdk\agentguard\state.py                      110     25    77%
-sdk\agentguard\tracing.py                    228     12    95%
-sdk\agentguard\usage.py                       91     17    81%
---------------------------------------------------------------
+sdk\agentguard\sinks\http.py                 175     12    93%   146-147, 344-350, 357-368
+sdk\agentguard\sinks\otel.py                  98      8    92%   38-39, 64, 152-153, 179, 198-199
+sdk\agentguard\skillpack.py                  127      4    97%   63-65, 82
+sdk\agentguard\state.py                      110     25    77%   96-110, 120-121, 155-156, 158, 167, 182-187, 200, 215
+sdk\agentguard\tracing.py                    228     12    95%   104, 142, 164-170, 237-238, 264, 271
+sdk\agentguard\usage.py                       91     17    81%   15, 17, 19, 58, 78, 87, 99-113
+------------------------------------------------------------------------
 TOTAL                                       3907    293    93%
 Required test coverage of 80% reached. Total coverage: 92.50%
-============================ 794 passed in 19.79s =============================
+============================ 795 passed in 24.29s =============================

--- a/proof/frictionless-install-2026-06-06/checks.txt
+++ b/proof/frictionless-install-2026-06-06/checks.txt
@@ -1,0 +1,123 @@
+=== ruff ===
+All checks passed!
+=== bandit (security) ===
+bandit exit: 0
+=== structural ===
+============================= test session starts =============================
+platform win32 -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
+rootdir: K:\agent47\.claude\worktrees\upbeat-thompson-79aa7b\sdk
+configfile: pyproject.toml
+plugins: anyio-4.9.0, langsmith-0.3.45, cov-7.1.0
+collected 9 items
+
+sdk\tests\test_architecture.py .........                                 [100%]
+
+============================== 9 passed in 0.20s ==============================
+=== release-guard ===
+Release guard passed.
+=== full suite + coverage ===
+============================= test session starts =============================
+platform win32 -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
+rootdir: K:\agent47\.claude\worktrees\upbeat-thompson-79aa7b\sdk
+configfile: pyproject.toml
+plugins: anyio-4.9.0, langsmith-0.3.45, cov-7.1.0
+collected 794 items
+
+sdk\tests\test_architecture.py .........                                 [  1%]
+sdk\tests\test_async_patches.py ..........                               [  2%]
+sdk\tests\test_atracing.py ........................                      [  5%]
+sdk\tests\test_ci_guardrails.py ...                                      [  5%]
+sdk\tests\test_ci_tools_requirements_guard.py ......                     [  6%]
+sdk\tests\test_cli_report.py .........                                   [  7%]
+sdk\tests\test_concurrency.py ........                                   [  8%]
+sdk\tests\test_cost.py .......................                           [ 11%]
+sdk\tests\test_cost_guardrail.py ...................................     [ 15%]
+sdk\tests\test_coverage_gaps.py ........................................ [ 21%]
+......                                                                   [ 21%]
+sdk\tests\test_crewai_integration.py ..........                          [ 23%]
+sdk\tests\test_dashboard_handoff_docs.py ..                              [ 23%]
+sdk\tests\test_decision_trace.py .............                           [ 24%]
+sdk\tests\test_demo.py ...                                               [ 25%]
+sdk\tests\test_doctor.py ..........                                      [ 26%]
+sdk\tests\test_dx.py .............................................       [ 32%]
+sdk\tests\test_e2e_pipeline.py ....                                      [ 32%]
+sdk\tests\test_evaluation.py ............................                [ 36%]
+sdk\tests\test_example_starters.py .........                             [ 37%]
+sdk\tests\test_export.py ...........                                     [ 38%]
+sdk\tests\test_exports.py ...............                                [ 40%]
+sdk\tests\test_first_run.py ............                                 [ 42%]
+sdk\tests\test_goal.py ........                                          [ 43%]
+sdk\tests\test_guard_persistence.py .........                            [ 44%]
+sdk\tests\test_guards.py ............................................... [ 50%]
+..........................................                               [ 55%]
+sdk\tests\test_hardening.py ...........................................  [ 60%]
+sdk\tests\test_hosted_ingest_contract.py ....                            [ 61%]
+sdk\tests\test_http_sink.py .......................                      [ 64%]
+sdk\tests\test_init.py ...............................................   [ 70%]
+sdk\tests\test_instrument.py ...........                                 [ 71%]
+sdk\tests\test_instrument_patch.py ..........                            [ 72%]
+sdk\tests\test_integration_cost_guardrail.py .                           [ 73%]
+sdk\tests\test_integration_dashboard_script.py ...........               [ 74%]
+sdk\tests\test_langchain_integration.py ..................               [ 76%]
+sdk\tests\test_langgraph_integration.py ............                     [ 78%]
+sdk\tests\test_mcp_registry_metadata.py .....                            [ 78%]
+sdk\tests\test_otel_sink.py ...........                                  [ 80%]
+sdk\tests\test_production.py ................                            [ 82%]
+sdk\tests\test_pypi_readme_sync.py .....                                 [ 82%]
+sdk\tests\test_quickstart.py ..............                              [ 84%]
+sdk\tests\test_release_discussion_category.py .....                      [ 85%]
+sdk\tests\test_repo_config.py ............                               [ 86%]
+sdk\tests\test_reporting.py ........                                     [ 87%]
+sdk\tests\test_savings.py ............                                   [ 89%]
+sdk\tests\test_schemas.py ........................                       [ 92%]
+sdk\tests\test_sdk_preflight.py .........                                [ 93%]
+sdk\tests\test_sdk_release_guard.py ............                         [ 94%]
+sdk\tests\test_skillpack.py ..........                                   [ 96%]
+sdk\tests\test_smoke.py .                                                [ 96%]
+sdk\tests\test_sticky_agent_proof.py ..                                  [ 96%]
+sdk\tests\test_tracing.py ..............                                 [ 98%]
+sdk\tests\test_v1_coverage.py .............                              [100%]
+
+=============================== tests coverage ================================
+_______________ coverage: platform win32, python 3.13.2-final-0 _______________
+
+Name                                       Stmts   Miss  Cover
+--------------------------------------------------------------
+sdk\agentguard\__init__.py                    22      0   100%
+sdk\agentguard\__main__.py                     1      1     0%
+sdk\agentguard\_trace_naming.py               16      0   100%
+sdk\agentguard\atracing.py                    72      0   100%
+sdk\agentguard\cli.py                        129      1    99%
+sdk\agentguard\cost.py                        51      1    98%
+sdk\agentguard\decision.py                   214     30    86%
+sdk\agentguard\demo.py                        98      2    98%
+sdk\agentguard\doctor.py                     138     11    92%
+sdk\agentguard\escalation.py                 225     23    90%
+sdk\agentguard\evaluation.py                 264      0   100%
+sdk\agentguard\export.py                      31      0   100%
+sdk\agentguard\first_run.py                   48      0   100%
+sdk\agentguard\goal.py                        79      1    99%
+sdk\agentguard\guards.py                     327      5    98%
+sdk\agentguard\instrument.py                 280     40    86%
+sdk\agentguard\integrations\__init__.py        4      0   100%
+sdk\agentguard\integrations\crewai.py         79      0   100%
+sdk\agentguard\integrations\langchain.py     226     58    74%
+sdk\agentguard\integrations\langgraph.py      43      0   100%
+sdk\agentguard\profiles.py                    15      0   100%
+sdk\agentguard\quickstart.py                 169      5    97%
+sdk\agentguard\repo_config.py                 80      8    90%
+sdk\agentguard\reporting.py                  129      7    95%
+sdk\agentguard\savings.py                    138      7    95%
+sdk\agentguard\schemas.py                     96     11    89%
+sdk\agentguard\setup.py                      101      4    96%
+sdk\agentguard\sinks\__init__.py               3      0   100%
+sdk\agentguard\sinks\http.py                 175     12    93%
+sdk\agentguard\sinks\otel.py                  98      8    92%
+sdk\agentguard\skillpack.py                  127      4    97%
+sdk\agentguard\state.py                      110     25    77%
+sdk\agentguard\tracing.py                    228     12    95%
+sdk\agentguard\usage.py                       91     17    81%
+--------------------------------------------------------------
+TOTAL                                       3907    293    93%
+Required test coverage of 80% reached. Total coverage: 92.50%
+============================ 794 passed in 19.79s =============================

--- a/proof/frictionless-install-2026-06-06/checks.txt
+++ b/proof/frictionless-install-2026-06-06/checks.txt
@@ -1,5 +1,5 @@
-# Regenerated 2026-06-06T08:25:34Z after review-fix commit (8baa888). Supersedes the pre-fix capture.
-=== ruff ===
+# Regenerated after review-fix commits (pragma removal + routing tests + BADGE_RST cleanup). Source of truth.
+=== ruff (gated paths: sdk/agentguard + scripts) ===
 All checks passed!
 === bandit (security) ===
 bandit exit: 0
@@ -13,7 +13,7 @@ collected 9 items
 
 sdk\tests\test_architecture.py .........                                 [100%]
 
-============================== 9 passed in 0.55s ==============================
+============================== 9 passed in 0.18s ==============================
 === release-guard ===
 Release guard passed.
 === full suite + coverage (--cov=agentguard) ===
@@ -22,7 +22,7 @@ platform win32 -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
 rootdir: K:\agent47\.claude\worktrees\upbeat-thompson-79aa7b\sdk
 configfile: pyproject.toml
 plugins: anyio-4.9.0, langsmith-0.3.45, cov-7.1.0
-collected 795 items
+collected 807 items
 
 sdk\tests\test_architecture.py .........                                 [  1%]
 sdk\tests\test_async_patches.py ..........                               [  2%]
@@ -33,38 +33,38 @@ sdk\tests\test_cli_report.py .........                                   [  7%]
 sdk\tests\test_concurrency.py ........                                   [  8%]
 sdk\tests\test_cost.py .......................                           [ 11%]
 sdk\tests\test_cost_guardrail.py ...................................     [ 15%]
-sdk\tests\test_coverage_gaps.py ........................................ [ 21%]
+sdk\tests\test_coverage_gaps.py ........................................ [ 20%]
 ......                                                                   [ 21%]
-sdk\tests\test_crewai_integration.py ..........                          [ 23%]
-sdk\tests\test_dashboard_handoff_docs.py ..                              [ 23%]
+sdk\tests\test_crewai_integration.py ..........                          [ 22%]
+sdk\tests\test_dashboard_handoff_docs.py ..                              [ 22%]
 sdk\tests\test_decision_trace.py .............                           [ 24%]
-sdk\tests\test_demo.py ...                                               [ 25%]
+sdk\tests\test_demo.py ...                                               [ 24%]
 sdk\tests\test_doctor.py ..........                                      [ 26%]
-sdk\tests\test_dx.py .............................................       [ 32%]
+sdk\tests\test_dx.py .............................................       [ 31%]
 sdk\tests\test_e2e_pipeline.py ....                                      [ 32%]
-sdk\tests\test_evaluation.py ............................                [ 36%]
-sdk\tests\test_example_starters.py .........                             [ 37%]
+sdk\tests\test_evaluation.py ............................                [ 35%]
+sdk\tests\test_example_starters.py .........                             [ 36%]
 sdk\tests\test_export.py ...........                                     [ 38%]
 sdk\tests\test_exports.py ...............                                [ 40%]
-sdk\tests\test_first_run.py .............                                [ 42%]
-sdk\tests\test_goal.py ........                                          [ 43%]
-sdk\tests\test_guard_persistence.py .........                            [ 44%]
-sdk\tests\test_guards.py ............................................... [ 50%]
-..........................................                               [ 55%]
+sdk\tests\test_first_run.py .........................                    [ 43%]
+sdk\tests\test_goal.py ........                                          [ 44%]
+sdk\tests\test_guard_persistence.py .........                            [ 45%]
+sdk\tests\test_guards.py ............................................... [ 51%]
+..........................................                               [ 56%]
 sdk\tests\test_hardening.py ...........................................  [ 61%]
-sdk\tests\test_hosted_ingest_contract.py ....                            [ 61%]
+sdk\tests\test_hosted_ingest_contract.py ....                            [ 62%]
 sdk\tests\test_http_sink.py .......................                      [ 64%]
 sdk\tests\test_init.py ...............................................   [ 70%]
-sdk\tests\test_instrument.py ...........                                 [ 71%]
-sdk\tests\test_instrument_patch.py ..........                            [ 72%]
+sdk\tests\test_instrument.py ...........                                 [ 72%]
+sdk\tests\test_instrument_patch.py ..........                            [ 73%]
 sdk\tests\test_integration_cost_guardrail.py .                           [ 73%]
 sdk\tests\test_integration_dashboard_script.py ...........               [ 74%]
-sdk\tests\test_langchain_integration.py ..................               [ 76%]
+sdk\tests\test_langchain_integration.py ..................               [ 77%]
 sdk\tests\test_langgraph_integration.py ............                     [ 78%]
-sdk\tests\test_mcp_registry_metadata.py .....                            [ 78%]
+sdk\tests\test_mcp_registry_metadata.py .....                            [ 79%]
 sdk\tests\test_otel_sink.py ...........                                  [ 80%]
 sdk\tests\test_production.py ................                            [ 82%]
-sdk\tests\test_pypi_readme_sync.py .....                                 [ 82%]
+sdk\tests\test_pypi_readme_sync.py .....                                 [ 83%]
 sdk\tests\test_quickstart.py ..............                              [ 84%]
 sdk\tests\test_release_discussion_category.py .....                      [ 85%]
 sdk\tests\test_repo_config.py ............                               [ 86%]
@@ -72,7 +72,7 @@ sdk\tests\test_reporting.py ........                                     [ 87%]
 sdk\tests\test_savings.py ............                                   [ 89%]
 sdk\tests\test_schemas.py ........................                       [ 92%]
 sdk\tests\test_sdk_preflight.py .........                                [ 93%]
-sdk\tests\test_sdk_release_guard.py ............                         [ 94%]
+sdk\tests\test_sdk_release_guard.py ............                         [ 95%]
 sdk\tests\test_skillpack.py ..........                                   [ 96%]
 sdk\tests\test_smoke.py .                                                [ 96%]
 sdk\tests\test_sticky_agent_proof.py ..                                  [ 96%]
@@ -88,7 +88,7 @@ sdk\agentguard\__init__.py                    22      0   100%
 sdk\agentguard\__main__.py                     1      0   100%
 sdk\agentguard\_trace_naming.py               16      0   100%
 sdk\agentguard\atracing.py                    72      0   100%
-sdk\agentguard\cli.py                        129      1    99%   167
+sdk\agentguard\cli.py                        199      1    99%   167
 sdk\agentguard\cost.py                        51      1    98%   109
 sdk\agentguard\decision.py                   214     30    86%   91, 97, 100-101, 110, 112, 116-117, 125, 149, 156-161, 167, 169, 181, 184, 203, 205, 209, 234, 540-542, 549, 551, 773, 780
 sdk\agentguard\demo.py                        98      2    98%   46, 180
@@ -119,6 +119,6 @@ sdk\agentguard\state.py                      110     25    77%   96-110, 120-121
 sdk\agentguard\tracing.py                    228     12    95%   104, 142, 164-170, 237-238, 264, 271
 sdk\agentguard\usage.py                       91     17    81%   15, 17, 19, 58, 78, 87, 99-113
 ------------------------------------------------------------------------
-TOTAL                                       3907    293    93%
-Required test coverage of 80% reached. Total coverage: 92.50%
-============================ 795 passed in 24.29s =============================
+TOTAL                                       3977    293    93%
+Required test coverage of 80% reached. Total coverage: 92.63%
+============================ 807 passed in 17.27s =============================

--- a/proof/frictionless-install-2026-06-06/cli-behavior.txt
+++ b/proof/frictionless-install-2026-06-06/cli-behavior.txt
@@ -16,10 +16,20 @@ If 'agentguard' is not on PATH, prefix any command with 'python -m agentguard'.
 
 If AgentGuard saved you a runaway run, star it so others find it: https://github.com/bmdhodl/agent47
 
-### agentguard badge ###
+### agentguard badge (markdown, default) ###
 Guarded by AgentGuard badge:
 
 [![Guarded by AgentGuard](https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)](https://github.com/bmdhodl/agent47)
+
+Renders a blue badge that links back to https://github.com/bmdhodl/agent47
+Add it to your README so other builders find AgentGuard.
+
+### agentguard badge --format rst ###
+Guarded by AgentGuard badge:
+
+.. image:: https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6
+   :target: https://github.com/bmdhodl/agent47
+   :alt: Guarded by AgentGuard
 
 Renders a blue badge that links back to https://github.com/bmdhodl/agent47
 Add it to your README so other builders find AgentGuard.

--- a/proof/frictionless-install-2026-06-06/cli-behavior.txt
+++ b/proof/frictionless-install-2026-06-06/cli-behavior.txt
@@ -1,0 +1,33 @@
+### python -m agentguard (bare welcome) ###
+AgentGuard
+Stop agents from looping, retrying forever, and burning budget.
+Zero dependencies. Local-first. No API key needed.
+
+Try it in 60 seconds (all local, no network):
+  agentguard doctor      verify the install and write a local trace
+  agentguard demo        watch budget, loop, and retry guards stop a run
+  agentguard quickstart --framework raw --write   drop a starter into your repo
+
+More:
+  agentguard --help      list every command
+  agentguard badge       copy a README badge for your repo
+
+If 'agentguard' is not on PATH, prefix any command with 'python -m agentguard'.
+
+If AgentGuard saved you a runaway run, star it so others find it: https://github.com/bmdhodl/agent47
+
+### agentguard badge ###
+Guarded by AgentGuard badge:
+
+[![Guarded by AgentGuard](https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)](https://github.com/bmdhodl/agent47)
+
+Renders a blue badge that links back to https://github.com/bmdhodl/agent47
+Add it to your README so other builders find AgentGuard.
+
+### agentguard badge --format html ###
+Guarded by AgentGuard badge:
+
+<a href="https://github.com/bmdhodl/agent47"><img src="https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6" alt="Guarded by AgentGuard"></a>
+
+Renders a blue badge that links back to https://github.com/bmdhodl/agent47
+Add it to your README so other builders find AgentGuard.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -29,7 +29,11 @@ enough to create surprise spend.
 
 ```bash
 pip install agentguard47
+agentguard
 ```
+
+The bare `agentguard` command prints a 60-second local tour. If the script is
+not on PATH, use `python -m agentguard` instead. Both run the same CLI.
 
 ### As a skill (Claude Code, Cursor, Cline, and more)
 
@@ -197,6 +201,24 @@ What you should see:
 
 Notebook version:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bmdhodl/agent47/blob/v1.2.13/examples/quickstart.ipynb)
+
+## Show Your Repo Is Guarded
+
+Once AgentGuard stops a runaway run for you, add the badge to your README so
+other builders find it:
+
+```bash
+agentguard badge
+```
+
+```markdown
+[![Guarded by AgentGuard](https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)](https://github.com/bmdhodl/agent47)
+```
+
+[![Guarded by AgentGuard](https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)](https://github.com/bmdhodl/agent47)
+
+`agentguard badge --format rst` and `--format html` print the same badge for
+other doc formats.
 
 ## Copy-Paste Repo Setup
 
@@ -467,7 +489,7 @@ assert result.passed
 - License: MIT
 - Core runtime dependencies: zero
 - Trace format: JSONL
-- Local commands: `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`
+- Local commands: `welcome`, `doctor`, `demo`, `quickstart`, `report`, `incident`, `eval`, `badge`
 - MCP package: [`@agentguard47/mcp-server`](https://github.com/bmdhodl/agent47/tree/v1.2.13/mcp-server)
 - Glama listing: [`AgentGuard47`](https://glama.ai/mcp/servers/bmdhodl/agent47)
 

--- a/sdk/agentguard/__main__.py
+++ b/sdk/agentguard/__main__.py
@@ -1,0 +1,10 @@
+"""Run the AgentGuard CLI with ``python -m agentguard``.
+
+This mirrors the ``agentguard`` console script so the tool works even when the
+script is not on PATH, without forcing users to remember ``-m agentguard.cli``.
+"""
+
+from agentguard.cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdk/agentguard/cli.py
+++ b/sdk/agentguard/cli.py
@@ -9,10 +9,28 @@ from agentguard.decision import extract_decision_events
 from agentguard.demo import run_offline_demo
 from agentguard.doctor import run_doctor
 from agentguard.evaluation import _extract_cost, _load_events
+from agentguard.first_run import render_badge, render_welcome
 from agentguard.quickstart import FRAMEWORK_CHOICES, run_quickstart
 from agentguard.reporting import render_incident_report
 from agentguard.savings import summarize_savings
 from agentguard.skillpack import TARGET_CHOICES, run_skillpack
+
+
+def _package_version() -> Optional[str]:
+    try:
+        from importlib.metadata import version
+
+        return version("agentguard47")
+    except Exception:
+        return None
+
+
+def _welcome() -> None:
+    render_welcome(version=_package_version())
+
+
+def _badge(fmt: str = "markdown") -> None:
+    render_badge(fmt=fmt)
 
 
 def _summarize(path: str) -> None:
@@ -246,6 +264,16 @@ def main() -> None:  # pragma: no cover
     parser = argparse.ArgumentParser(prog="agentguard")
     sub = parser.add_subparsers(dest="cmd")
 
+    sub.add_parser("welcome", help="Show the first-run welcome and 60-second local path")
+
+    badge = sub.add_parser("badge", help="Print a paste-able 'Guarded by AgentGuard' README badge")
+    badge.add_argument(
+        "--format",
+        choices=["markdown", "rst", "html"],
+        default="markdown",
+        help="Badge snippet format. Defaults to markdown.",
+    )
+
     summarize = sub.add_parser("summarize", help="Summarize a JSONL trace file")
     summarize.add_argument("path")
 
@@ -396,7 +424,11 @@ def main() -> None:  # pragma: no cover
     )
 
     args = parser.parse_args()
-    if args.cmd == "summarize":
+    if args.cmd == "welcome":
+        _welcome()
+    elif args.cmd == "badge":
+        _badge(fmt=args.format)
+    elif args.cmd == "summarize":
         _summarize(args.path)
     elif args.cmd == "report":
         _report(args.path, as_json=args.json_output)
@@ -439,7 +471,7 @@ def main() -> None:  # pragma: no cover
             force=args.force,
         )
     else:
-        parser.print_help()
+        _welcome()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/sdk/agentguard/cli.py
+++ b/sdk/agentguard/cli.py
@@ -260,7 +260,7 @@ def _eval(path: str, ci: bool = False) -> None:
         raise SystemExit(1)
 
 
-def main() -> None:  # pragma: no cover
+def main() -> None:
     parser = argparse.ArgumentParser(prog="agentguard")
     sub = parser.add_subparsers(dest="cmd")
 

--- a/sdk/agentguard/demo.py
+++ b/sdk/agentguard/demo.py
@@ -83,6 +83,7 @@ def run_offline_demo(
     _render_module_fallback(fallback_commands, out)
     _print(out, "SDK gives you local enforcement. The dashboard adds alerts, retained history, and remote controls.")
     _print(out, "")
+    _print(out, "Show your repo is guarded (and help others find it): agentguard badge")
     _print(out, STAR_CALL_TO_ACTION)
     return 0
 

--- a/sdk/agentguard/first_run.py
+++ b/sdk/agentguard/first_run.py
@@ -20,9 +20,9 @@ BADGE_MARKDOWN = (
     f"({GITHUB_REPO_URL})"
 )
 BADGE_RST = (
-    f".. image:: https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6\n"
+    ".. image:: https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6\n"
     f"   :target: {GITHUB_REPO_URL}\n"
-    f"   :alt: Guarded by AgentGuard"
+    "   :alt: Guarded by AgentGuard"
 )
 BADGE_HTML = (
     f'<a href="{GITHUB_REPO_URL}">'

--- a/sdk/agentguard/first_run.py
+++ b/sdk/agentguard/first_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List
+import sys
+from typing import List, Optional, TextIO
 
 LOCAL_TRACE_FILE = ".agentguard/traces.jsonl"
 RAW_QUICKSTART_FILE = "agentguard_raw_quickstart.py"
@@ -9,6 +10,24 @@ RAW_QUICKSTART_COMMAND = "agentguard quickstart --framework raw --write"
 GITHUB_REPO_URL = "https://github.com/bmdhodl/agent47"
 STAR_CALL_TO_ACTION = (
     f"If AgentGuard saved you a runaway run, star it so others find it: {GITHUB_REPO_URL}"
+)
+
+# Paste-able proof badge. Every repo that adds it is a backlink and social proof,
+# which is the cheapest network-effect surface the SDK has.
+BADGE_MARKDOWN = (
+    "[![Guarded by AgentGuard]"
+    "(https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6)]"
+    f"({GITHUB_REPO_URL})"
+)
+BADGE_RST = (
+    f".. image:: https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6\n"
+    f"   :target: {GITHUB_REPO_URL}\n"
+    f"   :alt: Guarded by AgentGuard"
+)
+BADGE_HTML = (
+    f'<a href="{GITHUB_REPO_URL}">'
+    '<img src="https://img.shields.io/badge/guarded%20by-AgentGuard-3b82f6" '
+    'alt="Guarded by AgentGuard"></a>'
 )
 
 
@@ -22,3 +41,58 @@ def local_proof_commands(*, include_demo: bool = False) -> List[str]:
     if include_demo:
         return ["agentguard demo", *commands]
     return commands
+
+
+def render_welcome(stream: Optional[TextIO] = None, *, version: Optional[str] = None) -> None:
+    """Print the friendly first-run welcome shown for a bare ``agentguard`` call.
+
+    This is the most-typed command right after ``pip install`` and the first
+    impression of the tool. Keep it short, local-first, and guide the user to a
+    win in under a minute instead of dumping argparse help.
+    """
+    out = stream or sys.stdout
+    header = "AgentGuard"
+    if version:
+        header = f"AgentGuard {version}"
+
+    _print(out, header)
+    _print(out, "Stop agents from looping, retrying forever, and burning budget.")
+    _print(out, "Zero dependencies. Local-first. No API key needed.")
+    _print(out, "")
+    _print(out, "Try it in 60 seconds (all local, no network):")
+    _print(out, "  agentguard doctor      verify the install and write a local trace")
+    _print(out, "  agentguard demo        watch budget, loop, and retry guards stop a run")
+    _print(out, f"  {RAW_QUICKSTART_COMMAND}   drop a starter into your repo")
+    _print(out, "")
+    _print(out, "More:")
+    _print(out, "  agentguard --help      list every command")
+    _print(out, "  agentguard badge       copy a README badge for your repo")
+    _print(out, "")
+    _print(out, "If 'agentguard' is not on PATH, prefix any command with 'python -m agentguard'.")
+    _print(out, "")
+    _print(out, STAR_CALL_TO_ACTION)
+
+
+def render_badge(stream: Optional[TextIO] = None, *, fmt: str = "markdown") -> None:
+    """Print a paste-able "Guarded by AgentGuard" badge for a repo README.
+
+    The badge is the SDK's lowest-friction network-effect surface: a user who
+    already trusts AgentGuard advertises it to every visitor of their repo.
+    """
+    out = stream or sys.stdout
+    snippet = {
+        "markdown": BADGE_MARKDOWN,
+        "rst": BADGE_RST,
+        "html": BADGE_HTML,
+    }.get(fmt, BADGE_MARKDOWN)
+
+    _print(out, "Guarded by AgentGuard badge:")
+    _print(out, "")
+    _print(out, snippet)
+    _print(out, "")
+    _print(out, f"Renders a blue badge that links back to {GITHUB_REPO_URL}")
+    _print(out, "Add it to your README so other builders find AgentGuard.")
+
+
+def _print(stream: TextIO, line: str) -> None:
+    stream.write(line + "\n")

--- a/sdk/tests/test_first_run.py
+++ b/sdk/tests/test_first_run.py
@@ -1,11 +1,18 @@
 """Tests that importing agentguard has no user-visible side effects."""
 
 import importlib
+import io
 import os
+import subprocess
 import sys
+from contextlib import redirect_stdout
 from unittest import mock
 
 import pytest
+
+import agentguard
+from agentguard import cli
+from agentguard.first_run import GITHUB_REPO_URL, render_badge, render_welcome
 
 
 @pytest.fixture(autouse=True)
@@ -45,3 +52,99 @@ class TestImportSideEffects:
             _reimport_agentguard()
 
         assert list(fake_home.iterdir()) == []
+
+
+class TestWelcome:
+    def test_render_welcome_guides_to_local_path(self):
+        buf = io.StringIO()
+        render_welcome(stream=buf)
+        out = buf.getvalue()
+
+        assert "AgentGuard" in out
+        assert "Zero dependencies" in out
+        assert "agentguard doctor" in out
+        assert "agentguard demo" in out
+        assert "agentguard quickstart --framework raw --write" in out
+        assert "agentguard --help" in out
+        assert "agentguard badge" in out
+        assert "python -m agentguard" in out
+        assert GITHUB_REPO_URL in out
+
+    def test_render_welcome_includes_version_when_provided(self):
+        buf = io.StringIO()
+        render_welcome(stream=buf, version="9.9.9")
+        assert "AgentGuard 9.9.9" in buf.getvalue()
+
+
+class TestBadge:
+    def test_render_badge_markdown_links_back_to_repo(self):
+        buf = io.StringIO()
+        render_badge(stream=buf)
+        out = buf.getvalue()
+
+        assert "Guarded by AgentGuard" in out
+        assert "img.shields.io/badge/guarded%20by-AgentGuard" in out
+        assert GITHUB_REPO_URL in out
+
+    def test_render_badge_rst_and_html_formats(self):
+        rst = io.StringIO()
+        render_badge(stream=rst, fmt="rst")
+        assert ".. image::" in rst.getvalue()
+        assert GITHUB_REPO_URL in rst.getvalue()
+
+        html = io.StringIO()
+        render_badge(stream=html, fmt="html")
+        assert "<img" in html.getvalue()
+        assert GITHUB_REPO_URL in html.getvalue()
+
+    def test_render_badge_unknown_format_falls_back_to_markdown(self):
+        buf = io.StringIO()
+        render_badge(stream=buf, fmt="bogus")
+        assert "![Guarded by AgentGuard]" in buf.getvalue()
+
+
+class TestCliDispatch:
+    def _run_cli(self, argv):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), redirect_stdout(buf):
+            cli.main()
+        return buf.getvalue()
+
+    def test_bare_command_shows_welcome_not_argparse_help(self):
+        out = self._run_cli(["agentguard"])
+        assert "Zero dependencies" in out
+        assert "agentguard doctor" in out
+        assert GITHUB_REPO_URL in out
+
+    def test_welcome_subcommand(self):
+        out = self._run_cli(["agentguard", "welcome"])
+        assert "agentguard demo" in out
+
+    def test_badge_subcommand_defaults_to_markdown(self):
+        out = self._run_cli(["agentguard", "badge"])
+        assert "![Guarded by AgentGuard]" in out
+
+    def test_badge_subcommand_html_format(self):
+        out = self._run_cli(["agentguard", "badge", "--format", "html"])
+        assert "<img" in out
+
+
+class TestModuleEntryPoint:
+    def test_python_dash_m_agentguard_runs_cli(self):
+        """`python -m agentguard` must work end-to-end (no PATH dependency)."""
+        sdk_root = os.path.dirname(os.path.dirname(os.path.abspath(agentguard.__file__)))
+        env = dict(os.environ)
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = sdk_root + (os.pathsep + existing if existing else "")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "agentguard"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "AgentGuard" in result.stdout
+        assert GITHUB_REPO_URL in result.stdout

--- a/sdk/tests/test_first_run.py
+++ b/sdk/tests/test_first_run.py
@@ -132,6 +132,37 @@ class TestCliDispatch:
         assert "<img" in out
 
 
+_CLI_ROUTES = [
+    (["agentguard"], "_welcome"),  # bare command -> welcome
+    (["agentguard", "welcome"], "_welcome"),
+    (["agentguard", "badge"], "_badge"),
+    (["agentguard", "summarize", "t.jsonl"], "_summarize"),
+    (["agentguard", "report", "t.jsonl"], "_report"),
+    (["agentguard", "eval", "t.jsonl"], "_eval"),
+    (["agentguard", "incident", "t.jsonl"], "_incident"),
+    (["agentguard", "decisions", "t.jsonl"], "_decisions"),
+    (["agentguard", "demo"], "_demo"),
+    (["agentguard", "doctor"], "_doctor"),
+    (["agentguard", "quickstart"], "_quickstart"),
+    (["agentguard", "skillpack"], "_skillpack"),
+]
+
+
+class TestCliRouting:
+    """Pin every dispatch branch in cli.main() so routing regressions are caught.
+
+    main() no longer carries `# pragma: no cover`, so each subcommand must be
+    exercised. Handlers are patched to keep the test fast and side-effect-free
+    (several real handlers raise SystemExit and write files).
+    """
+
+    @pytest.mark.parametrize("argv,handler", _CLI_ROUTES)
+    def test_main_routes_to_handler(self, argv, handler):
+        with mock.patch.object(cli, handler) as patched, mock.patch.object(sys, "argv", argv):
+            cli.main()
+        assert patched.called, f"{argv} should route to cli.{handler}"
+
+
 class TestModuleEntryPoint:
     def test_main_module_imports_cli_main(self):
         """Cover the module-level import in __main__.py and pin the wiring.

--- a/sdk/tests/test_first_run.py
+++ b/sdk/tests/test_first_run.py
@@ -1,4 +1,5 @@
-"""Tests that importing agentguard has no user-visible side effects."""
+"""First-run surface tests: import side effects, the welcome, the badge, CLI
+dispatch for the bare command, and the ``python -m agentguard`` entry point."""
 
 import importlib
 import io
@@ -100,7 +101,9 @@ class TestBadge:
     def test_render_badge_unknown_format_falls_back_to_markdown(self):
         buf = io.StringIO()
         render_badge(stream=buf, fmt="bogus")
-        assert "![Guarded by AgentGuard]" in buf.getvalue()
+        # Assert the full markdown structure (linked image), not an incidental
+        # substring that would also match a badge missing its outer link wrapper.
+        assert "[![Guarded by AgentGuard](" in buf.getvalue()
 
 
 class TestCliDispatch:
@@ -122,7 +125,7 @@ class TestCliDispatch:
 
     def test_badge_subcommand_defaults_to_markdown(self):
         out = self._run_cli(["agentguard", "badge"])
-        assert "![Guarded by AgentGuard]" in out
+        assert "[![Guarded by AgentGuard](" in out
 
     def test_badge_subcommand_html_format(self):
         out = self._run_cli(["agentguard", "badge", "--format", "html"])
@@ -130,6 +133,18 @@ class TestCliDispatch:
 
 
 class TestModuleEntryPoint:
+    def test_main_module_imports_cli_main(self):
+        """Cover the module-level import in __main__.py and pin the wiring.
+
+        Identity (``is``) is avoided because the autouse module-reload fixture
+        gives the freshly imported entry point a distinct function object.
+        """
+        import agentguard.__main__ as entry
+
+        assert callable(entry.main)
+        assert entry.main.__module__ == "agentguard.cli"
+        assert entry.main.__name__ == "main"
+
     def test_python_dash_m_agentguard_runs_cli(self):
         """`python -m agentguard` must work end-to-end (no PATH dependency)."""
         sdk_root = os.path.dirname(os.path.dirname(os.path.abspath(agentguard.__file__)))

--- a/sdk/tests/test_first_run.py
+++ b/sdk/tests/test_first_run.py
@@ -188,7 +188,9 @@ class TestModuleEntryPoint:
             capture_output=True,
             text=True,
             env=env,
-            timeout=60,
+            # Printing a welcome string is near-instant; a tight timeout still
+            # leaves margin for cold interpreter start but catches real hangs fast.
+            timeout=15,
         )
 
         assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Goal

Make SDK installation as frictionless as possible (already zero-dependency) and add a low-friction network-effect loop that converts installs into visible proof. Targets the documented gap: **3 GitHub stars vs thousands of PyPI downloads**.

## What changed (SDK only, zero new dependencies)

1. **Bare `agentguard` welcomes instead of dumping argparse help.** The most-typed first command after `pip install` now shows the 60-second local path (`doctor` → `demo` → `quickstart`) and the star CTA, via `first_run.render_welcome`.
2. **`python -m agentguard` works** (new `__main__.py`) — the CLI runs without the console script on PATH. The `python -m agentguard.cli` fallback still works and stays in existing hints.
3. **`agentguard badge`** prints a paste-able "Guarded by AgentGuard" README badge (markdown/rst/html). Every adopting repo becomes a backlink + social proof — the cheapest install→install loop. Surfaced in the welcome, the demo success moment, and a README section.
4. **`agentguard welcome`** subcommand to re-show the tour.

## Scope / non-goals

In-scope per `CLAUDE.md`: onboarding, activation, distribution-supporting assets tied to the real SDK. No new deps, no dashboard features, no guard changes. The heavily-tested `python -m agentguard.cli` fallback is left untouched.

## Proof (`proof/frictionless-install-2026-06-06/`)

- 794 tests pass, total coverage **92.5%** (≥80 gate); `first_run.py` at 100%
- ruff clean, bandit clean, structural pass, release-guard pass
- End-to-end `python -m agentguard` subprocess test included
- `cli-behavior.txt` captures the live welcome + badge output

Docs/memory refreshed: README, CHANGELOG (Unreleased), regenerated `sdk/PYPI_README.md`, `ARCHITECTURE.md`, `ops/03-ROADMAP`, `memory/state.md`, `memory/distribution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)