### PR TITLE
docs: WorkOS scoped-credentials vs AgentGuard positioning wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,17 @@ on one provider. AgentGuard covers the whole run across every provider and
 every call. Use both: set the per-call cap at the provider, set the
 run-envelope cap in AgentGuard.
 
+Scoped agent identity is a different layer again. WorkOS shipped productized
+scoped agent credentials on 2026-06-04: per-agent identity, RBAC scopes, and an
+audit trail of what each agent did. That is identity-time control. It decides
+who the agent is and what it is allowed to touch before the run starts.
+AgentGuard is run-time control. It caps budget, tokens, and rate, and trips the
+kill-switch on what the agent is doing right now. The two compose: WorkOS bounds
+the envelope, AgentGuard enforces that envelope at execution. A scoped
+credential does not stop a loop, a retry storm, or a budget overrun once the run
+is live. See [where AgentGuard fits in the agent security
+stack](docs/competitive/agent-security-stack.md) for the full layer map.
+
 Competitive notes:
 
 - [AgentGuard vs Vercel AI Gateway](docs/competitive/vercel-ai-gateway.md)

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -350,6 +350,17 @@ on one provider. AgentGuard covers the whole run across every provider and
 every call. Use both: set the per-call cap at the provider, set the
 run-envelope cap in AgentGuard.
 
+Scoped agent identity is a different layer again. WorkOS shipped productized
+scoped agent credentials on 2026-06-04: per-agent identity, RBAC scopes, and an
+audit trail of what each agent did. That is identity-time control. It decides
+who the agent is and what it is allowed to touch before the run starts.
+AgentGuard is run-time control. It caps budget, tokens, and rate, and trips the
+kill-switch on what the agent is doing right now. The two compose: WorkOS bounds
+the envelope, AgentGuard enforces that envelope at execution. A scoped
+credential does not stop a loop, a retry storm, or a budget overrun once the run
+is live. See [where AgentGuard fits in the agent security
+stack](https://github.com/bmdhodl/agent47/blob/main/docs/competitive/agent-security-stack.md) for the full layer map.
+
 Competitive notes:
 
 - [AgentGuard vs Vercel AI Gateway](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/competitive/vercel-ai-gateway.md)

--- a/site/index.html
+++ b/site/index.html
@@ -980,6 +980,11 @@
               <div><p>AgentGuard47 focuses on runtime enforcement and incident control.</p></div>
               <div><p>It is not prompt management, eval orchestration, or a trace warehouse.</p></div>
             </div>
+            <div class="compare-row">
+              <div><strong>Pairs with scoped identity</strong><p>Composes</p></div>
+              <div><p>Scoped agent credentials (WorkOS-style) decide who the agent is and what it may touch.</p></div>
+              <div><p>AgentGuard47 caps budget, tokens, and rate on what the agent does once the run is live.</p></div>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

WorkOS shipped productized scoped agent credentials on 2026-06-04 (per-agent identity, RBAC scopes, audit trail). Anyone searching "control my AI agent" will hit that marketing first, so the AgentGuard README needs a one-paragraph wedge so the difference is obvious.

This PR draws the line without picking a fight:

- WorkOS scoped agent credentials = identity-time. Who the agent is, what scopes/RBAC it has, audit trail of what it did.
- AgentGuard = run-time. Budget cap, token cap, rate cap, kill-switch on what the agent is doing right now.
- They compose, not compete. WorkOS bounds the envelope, AgentGuard enforces it at execution.

Changes:

- README.md: wedge paragraph in the "Runtime Control vs Observability" section, with a See-also link to the agent-security-stack layer map.
- site/index.html: matching one-liner compare-row in the Positioning section.
- sdk/PYPI_README.md: regenerated from README to satisfy the readme-sync CI guard.

Doc-only, +27/-0 across 3 files. No new dependencies.

## Test plan

- `python scripts/generate_pypi_readme.py --check` passes (PYPI README in sync with README).
- No banned marketing words, no em dashes in the added copy.
- No denylist paths touched (docs and landing copy only).
- Links resolve: agent-security-stack.md exists in docs/competitive/.

## Risk

Low. Positioning/documentation copy only, no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
