### PR TITLE
docs(positioning): make reader-facing surface fully model-agnostic (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Public Docs
+- Made the reader-facing surface fully model-agnostic to match the
+  already-vendor-neutral code path: the README/PyPI "As a skill" heading now
+  leads with Codex alongside Claude Code, and the budget-aware escalation
+  example notes the escalate target can be any provider's model, not just
+  Claude.
+
 ### Onboarding
 - Bare `agentguard` now prints a friendly first-run welcome with the 60-second
   local path and the star call to action instead of an argparse help dump.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ agentguard
 The bare `agentguard` command prints a 60-second local tour. If the script is
 not on PATH, use `python -m agentguard` instead. Both run the same CLI.
 
-### As a skill (Claude Code, Cursor, Cline, and more)
+### As a skill (Codex, Claude Code, Cursor, Cline, and more)
 
 ```bash
 npx skills add bmdhodl/agent47

--- a/examples/budget_aware_escalation.py
+++ b/examples/budget_aware_escalation.py
@@ -37,6 +37,9 @@ def _simulated_model_call(model: str, prompt: str) -> dict:
 
 def main() -> int:
     guard = BudgetAwareEscalation(
+        # primary_model / escalate_model are plain strings - any provider works.
+        # This example escalates a cheap local model to a stronger one; the
+        # escalate target could just as easily be an OpenAI or other-provider model.
         primary_model="ollama/llama3.1:8b",
         escalate_model="claude-opus-4-6",
         escalate_on=(

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -35,7 +35,7 @@ agentguard
 The bare `agentguard` command prints a 60-second local tour. If the script is
 not on PATH, use `python -m agentguard` instead. Both run the same CLI.
 
-### As a skill (Claude Code, Cursor, Cline, and more)
+### As a skill (Codex, Claude Code, Cursor, Cline, and more)
 
 ```bash
 npx skills add bmdhodl/agent47


### PR DESCRIPTION
Resolves #511.

## Context
#511 audited where AgentGuard's reader-first surface (README, PyPI page, docs, examples) leans on Claude as the default voice, even though the code path is already model-agnostic. Owner decision on lead voice: **fully model-agnostic**.

## What changed
- **README + generated PYPI_README**: the `As a skill (…)` heading now leads with Codex alongside Claude Code (`Codex, Claude Code, Cursor, Cline, and more`).
- **examples/budget_aware_escalation.py**: a comment notes `escalate_model` is a plain string and can target any provider, not just Claude.
- **CHANGELOG**: Public Docs note.

## Already addressed before this PR (verified)
Most of the #511 inventory had drifted to already-fixed:
- README already shows **both** `--framework openai` and `--framework anthropic`.
- `docs/guides/coding-agent-safety-pack.md` already has parallel sections for Codex/AGENTS.md, Claude Code, Copilot, Cursor, and MCP.
- `docs/guides/coding-agents.md` already leads the skillpack example with `--target codex`.
- `agentguard quickstart --framework openai` already emits `gpt-4o-mini` (not a Claude model); anthropic emits Claude. No code bug.

## Deliberately unchanged (per #511 'What we are NOT changing')
- `CLAUDE.md` (Claude Code reads it), the `cost.py` pricing table (must be vendor-specific), the patcher modules, and frozen `proof/` artifacts.

## Proof
- `generate_pypi_readme.py --check` ✅ (PYPI_README regenerated, in sync)
- `sdk_release_guard.py` ✅
- ruff ✅ · full test suite **807 passed** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)