### PR TITLE
docs: AgentGuard "wedge map" — how it differs from adjacent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,33 @@ Competitive notes:
 - [AgentGuard vs Manifest (LLM router)](docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](docs/competitive/agent-security-stack.md)
 
+## How AgentGuard Differs From Adjacent Tools
+
+Other tools touch the same problem from a different layer. AgentGuard's wedge
+is the runtime envelope: budget, token, rate, and kill caps on what the agent
+is doing right now, at the call site. Here is where each adjacent tool stops
+and AgentGuard starts.
+
+- **Identity-time vs run-time.** Scoped agent credentials (for example WorkOS)
+  answer who the agent is, what scopes it holds, and what it did, with an audit
+  trail. That is identity-time. AgentGuard answers what the agent is spending
+  right now and stops it mid-run. That is run-time. They compose: scoped
+  credentials bound the envelope, AgentGuard enforces it at execution.
+- **Enterprise budget caps that reach the call site.** Used to prevent surprise
+  bills like Uber's $1,500/developer Claude Code cap, but enforced at the call
+  site, where a per-tool org policy can't reach. A seat or org policy caps the
+  bill after the fact. AgentGuard raises the exception that ends the run before
+  the spend lands.
+- **Per-tool token caps are not an org budget.** A single per-tool `max_tokens`
+  setting in one vendor's API caps one call's output on one provider. It does
+  not give you an org-wide runtime budget across every tool and every agent.
+  AgentGuard holds one ceiling across the whole run, including thinking-token
+  accounting, every retry, and every provider.
+
+**Who needs this:** teams running coding agents at scale (Uber, Microsoft),
+solo founders watching a retry storm eat a month of budget, anyone whose agent
+mixes providers in one run.
+
 ## Decision Traces
 
 Capture proposal, human edit, approval, override, and binding events through the


### PR DESCRIPTION
## What

Adds one README section, **"How AgentGuard Differs From Adjacent Tools"**, placed right after *Runtime Control vs Observability* so all comparison content lives together. README copy only, +27 lines, no code.

It consolidates competitor positioning into a single wedge map along three axes:

1. **Identity-time vs run-time.** Scoped agent credentials (e.g. WorkOS) = who the agent is, its scopes, audit trail. AgentGuard = budget/token/rate/kill enforcement on what it is doing right now. They compose: credentials bound the envelope, AgentGuard enforces it at execution.
2. **Enterprise budget caps that reach the call site.** Names the Uber $1,500/developer Claude Code cap pattern, but enforced at the call site where a per-tool org policy can't reach. Adds a "Who needs this" example list (Uber, Microsoft, solo founders).
3. **Per-tool token caps are not an org budget.** A single per-tool `max_tokens` in one vendor's API caps one call on one provider; it is not an org-wide runtime budget across every tool/agent. Mentions thinking-token accounting as a differentiator in prose only.

## Consolidation note

This consolidates the positioning that was spread across **#575 / #567 / #578 / #579** into one refreshable wedge-map section. Those PRs can be closed in favor of this one. **#574 (mem0 cross-user contamination) stays held** — it rests on a 57–71% stat that is still unverified, so no memory-layer bullet was added here. PR closing/consolidation is left to Patrick (a git + review action).

## Excluded by design

- No mem0 / memory-layer bullet (held on the false stat).
- No thinking-tokens feature/parsing code — AgentGuard is cannon-paused for features; only a one-clause prose mention.

## QA

- `git diff --stat` = README.md only (+27).
- 0 em dashes, 0 banned words in the added section (verified by grep).
- ~190 words, three axes, builder voice.