### PR TITLE
ci: reduce Actions spend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,36 @@ name: CI
 
 on:
   push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "inbox/**"
+      - "memory/**"
+      - "ops/**"
+      - "proof/**"
   pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "inbox/**"
+      - "memory/**"
+      - "ops/**"
+      - "proof/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       PYTHONPATH: sdk
     strategy:
@@ -36,9 +58,11 @@ jobs:
         with:
           name: coverage-report
           path: coverage.xml
+          retention-days: 7
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       PYTHONPATH: sdk
     steps:
@@ -62,6 +86,7 @@ jobs:
 
   mcp:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -76,6 +101,7 @@ jobs:
 
   mcp-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6


### PR DESCRIPTION
## Summary
- restrict CI pushes to main instead of every feature branch
- skip docs/proof/memory/ops-only changes
- add PR concurrency cancellation and job timeouts
- reduce coverage artifact retention

## Verification
- YAML parsed successfully in clean worktree
- agent47 local review fixes validated separately: CLI import ok, productivity tests pass, CI guardrail test passes