### PR TITLE
docs(readme): add adjacent-tools wedge map section (batched positioning)

### DIFF
--- a/QA_REPORT.md
+++ b/QA_REPORT.md
@@ -1,68 +1,26 @@
-# QA_REPORT — README containment scope positioning
+# QA_REPORT — competitor wedge map README batch (2026-06-12)
 
-**Verdict: PASS**
+**Verdict: WARN** (one unsupported fact claim in public README copy; everything else passes)
 
-## Checks
+## Checklist
 
-### Scope match with WORK_PLAN
-- [x] Added a "Scope" block after "Design constraints" list — matches plan.
-- [x] One block, 14 LOC added. Under the planned ~30 LOC ceiling.
-- [x] Sentence 1 names AgentGuard's scope (runtime budget/token/rate/retry/
-      loop/timeout caps, in-process).
-- [x] Sentence 2 names OS-level containment as out of scope and lists
-      Anthropic's four primitives (process sandboxes, VMs, filesystem
-      boundaries, egress controls).
-- [x] Anthropic URL present: https://www.anthropic.com/news/how-we-contain-claude
+| Check | Result |
+|---|---|
+| Single wedge-map section covering WorkOS / Uber / per-tool-token-cap axes | PASS — `## How AgentGuard Differs From Adjacent Tools` at README.md:379, one axis table + 4 compose bullets. Routers/gateways row is additive, consistent with WORK_PLAN. |
+| mem0 excluded (`grep -i mem0 README.md` empty) | PASS — 0 hits in README.md and sdk/PYPI_README.md. mem0 appears only in internal artifacts (RESEARCH.md/WORK_PLAN.md) documenting the exclusion. |
+| Thinking-tokens feature excluded | PASS — no code changes; no README claim of thinking-token accounting. RESEARCH.md "Decisions" deliberately omits even the prose mention (defensible: unshipped capability). |
+| Positioning copy only, no feature commits | PASS — diff is README.md, sdk/PYPI_README.md (regenerated), WORK_PLAN.md, RESEARCH.md. One commit, docs only. |
+| Voice: no em dashes in added lines | PASS for README/PYPI added lines. Three em dashes in added lines of internal artifacts only (WORK_PLAN.md:1, RESEARCH.md:1, RESEARCH.md:50 quoting repo CLAUDE.md). Not user-facing; noted, not blocking. |
+| Voice: banned words in added lines | PASS — only "hit" is WORK_PLAN.md:63 quoting the banned-word grep pattern itself. No banned words in README/PYPI copy. Tone is builder-first, short sentences. |
+| Uber fact check vs RESEARCH.md | PASS on the headline claim — README.md:400-402 says "$1,500 per month in token spend on each AI coding tool" (per employee, per tool), matching the source of record. Task card's imprecise "per developer Claude Code cap" was correctly NOT used. |
+| **Unsupported claim** | **WARN — README.md:406 "Fortune 50 finance team". Uber is not Fortune 50 (Fortune 500 rank ~#58-#74 in recent lists) and RESEARCH.md cites no rank. Suggest "Fortune 100" or "a $40B company".** |
+| sdk/PYPI_README.md regenerated | PASS — `python scripts/generate_pypi_readme.py --check` exit 0. |
+| Sync test | PASS — `python -m pytest sdk/tests/test_pypi_readme_sync.py -q` -> 5 passed. |
+| Secrets | None added. |
+| Denylist paths (.github/workflows/, .env*, supabase/migrations/, security/) | Untouched. |
+| Test coverage | No regression — no test files modified or removed. |
+| Scope vs WORK_PLAN | Matches — 4 files, 193 insertions / 87 deletions, well under 400 LOC cap. |
 
-### Done criteria from queue task frontmatter
-- [x] `verifier: "agent47 README updated with scope statement that cites
-      Anthropic's containment doc as the canonical map for the adjacent gap"`
-      — satisfied by the new Scope section.
-- [x] `done_artifact: "agent47 README.md PR with positioning paragraph"` —
-      this PR.
+## Required fix before merge
 
-### Voice / style
-- [x] No banned words (harness, leverage, streamline, delve, landscape,
-      cutting-edge, game-changer, revolutionary, seamless, robust, holistic,
-      synergy, ecosystem) in the new block. Grepped.
-- [x] No em-dashes added by this change. Pre-existing em-dashes in
-      unrelated section headings are untouched.
-- [x] Builder-to-builder tone matches surrounding text (compare to PocketOS
-      section: "does not replace least-privilege creds").
-
-### Integration with PR #568
-- [x] No duplication with the new cross-call envelope vs. `max_tokens`
-      comparison table (lines 76-85). The Scope block is a different
-      axis: in-process vs. OS-level. PR #568 contrasts AgentGuard with
-      Anthropic's single-call cap; this contrasts AgentGuard with
-      Anthropic's process-level containment.
-- [x] The "layers are complementary" framing echoes the existing
-      "complementary" framing in the "Why AgentGuard" section (line 54),
-      which is consistent house style.
-
-### Denylist + safety
-- [x] No files in `.github/workflows/`, `.env*`, `supabase/migrations/`,
-      `security/`, Stripe/Clerk config, or secrets touched.
-- [x] No new dependencies.
-- [x] No test coverage regression (docs-only change, no test files
-      touched).
-- [x] No secrets, credentials, or API keys added.
-
-### Coverage of the queue task requirement
-The queue task asks for:
-1. "one sentence naming AgentGuard's scope (runtime budget/token/rate caps)"
-   — covered in sentence 1.
-2. "one sentence noting that OS-level containment (process sandboxes, VMs,
-   filesystem boundaries, egress controls) is out of scope, with a link to
-   Anthropic's 'How we contain Claude' post"
-   — covered in sentence 2 + the markdown link.
-
-### Triple-check stranger-read
-Read the new block cold. First sentence names what AgentGuard does.
-Second names what it doesn't do and where to look for the adjacent layer.
-A closing sentence ties it back to the existing "complementary" framing so
-the section doesn't read as defensive disclaimer.
-
-## Issues found
-
-None blocking.
+1. README.md:406 (and the mirrored line in sdk/PYPI_README.md): replace "Fortune 50" with a supported framing, then regenerate the PyPI README.

--- a/README.md
+++ b/README.md
@@ -376,6 +376,45 @@ Competitive notes:
 - [AgentGuard vs Manifest (LLM router)](docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](docs/competitive/agent-security-stack.md)
 
+## How AgentGuard Differs From Adjacent Tools
+
+The wedge map. AgentGuard is the runtime envelope: budget, token, rate, and
+kill caps enforced in-process, at the call site, on what the agent is doing
+right now. Adjacent tools work on different axes. Most of them compose with
+AgentGuard instead of competing with it.
+
+| Adjacent tool | Its axis | AgentGuard's axis |
+|---|---|---|
+| Scoped agent credentials (WorkOS) | Identity-time: who the agent is, what scopes it holds, audit trail of what it did | Run-time: budget, token, rate, and kill enforcement on what it is doing right now |
+| Org-level per-tool spend caps (the Uber pattern) | Policy-time: a monthly dollar ceiling per employee per tool, enforced at the billing layer | Call-site: stops the single runaway run minutes in, not at month end |
+| Provider per-tool token caps (Anthropic per-tool `max_tokens`) | One call, one tool, one provider | Cross-call, cross-provider budget envelope for the whole run |
+| LLM routers and gateways (Manifest, Vercel AI Gateway) | Network layer: route and shape egress traffic | In-process: sees the call graph, raises the exception that ends the run |
+
+How they compose:
+
+- **Scoped credentials and AgentGuard stack.** WorkOS-style agent identity
+  gives each agent its own credential, scoped permissions, and an audit log.
+  That bounds what the agent may touch. AgentGuard enforces what it spends
+  while touching it. Identity-time and run-time are different layers of the
+  same control plane. Use both.
+- **Org caps need a call-site enforcer.** Uber now limits employees to $1,500
+  per month in token spend on each AI coding tool
+  ([Bloomberg via Simon Willison, June 2026](https://simonwillison.net/2026/Jun/3/uber-caps-usage/)).
+  That policy fires at the billing layer, after the spend, and a per-tool cap
+  cannot see one dev burning across three tools in the same week. A
+  `BudgetGuard` fires inside the process, on the run that is misbehaving,
+  before the bill exists. If a Fortune 50 finance team needs this primitive,
+  so does your two-person agent project.
+- **Per-call caps are table stakes.** Anthropic's per-tool `max_tokens` stops
+  one oversized response. It does not stop 200 small calls in a loop, a retry
+  storm, or a run that mixes providers. Set the per-call cap at the provider
+  and the run-envelope cap in AgentGuard.
+- **Gateways shape traffic, guards end runs.** Routers sit at the network
+  layer and never see the agent's call graph. AgentGuard runs inside the
+  process and raises `BudgetExceeded`, `LoopDetected`, or
+  `RetryLimitExceeded` where the loop lives. Details in the
+  [competitive notes](#runtime-control-vs-observability) above.
+
 ## Decision Traces
 
 Capture proposal, human edit, approval, override, and binding events through the

--- a/README.md
+++ b/README.md
@@ -403,8 +403,8 @@ How they compose:
   That policy fires at the billing layer, after the spend, and a per-tool cap
   cannot see one dev burning across three tools in the same week. A
   `BudgetGuard` fires inside the process, on the run that is misbehaving,
-  before the bill exists. If a Fortune 50 finance team needs this primitive,
-  so does your two-person agent project.
+  before the bill exists. If Uber's finance team needs this primitive, so
+  does your two-person agent project.
 - **Per-call caps are table stakes.** Anthropic's per-tool `max_tokens` stops
   one oversized response. It does not stop 200 small calls in a loop, a retry
   storm, or a run that mixes providers. Set the per-call cap at the provider

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,44 +1,64 @@
-# RESEARCH — Anthropic per-tool max_tokens positioning update
+# RESEARCH — competitor wedge map README batch (2026-06-12)
 
 ## Sources
 
-- Vault source card: `Knowledge/sources/2026-06-03-anthropic-advisor-max-tokens-cost-cap.md`
-  - Claim: "The advisor tool now supports a max_tokens parameter to cap the advisor model's output per call, reducing latency and output token cost for workloads that don't need full-length advisor responses. Set tools[].max_tokens on the advisor tool definition."
-  - Claim: "On the Claude API, you are no longer billed for a request when it returns stop_reason: 'refusal' without Claude having generated any output."
-- Anthropic release notes URL of record (in queue task frontmatter): https://platform.claude.com/docs/en/release-notes/overview#june-2-2026
-- Queue task: `Queue/agent47/anthropic-advisor-max-tokens-update-positioning.md`
+- Vault batch card: `Queue/agent47/competitor-wedge-map-readme-batch.md`
+  (supersedes workos-positioning-update, agentguard-uber-validation-readme,
+  thinking-tokens-breakdown-agentguard; holds mem0-contamination-positioning).
+- Batching rule: `Queue/agent47/_README.md` § Competitor-positioning batching
+  rule (2026-06-07), incl. fact-gating clause.
+- WorkOS: vault `Knowledge/sources/2026-06-04-workos-scoped-agent-credentials.md`.
+  Claim used: WorkOS productizes scoped agent credentials (agent-specific
+  identity, per-agent RBAC, audit logs). Identity-time vs run-time framing;
+  "different wedges, same buyer"; composable, not adversarial. Confidence
+  marked medium in the source (marketing-layer copy), so README copy describes
+  the category axis, not WorkOS internals.
+- Uber: vault `Knowledge/sources/2026-06-03-uber-caps-claude-code-1500.md`,
+  confidence high, verified 2026-06-04. URL of record:
+  https://simonwillison.net/2026/Jun/3/uber-caps-usage/ (Bloomberg report).
+  Exact claim: Uber limits all employees to $1,500/month in token spending on
+  EACH AI coding tool. Per-tool, per-employee. The task card's shorthand
+  "$1,500/developer Claude Code cap" is imprecise; README uses the accurate
+  per-employee-per-tool form. The per-tool blindspot (one dev across Claude
+  Code + Cursor + Copilot can spend 3x before policy fires) is itself the
+  wedge argument for a cross-tool runtime envelope.
+- Anthropic per-tool `max_tokens`: already cited in README.md:62-64 with the
+  2026-06-02 release-notes URL. Wedge map reuses the existing fact; adds no
+  new claim.
+- Routers/gateways: existing README.md:53-58 (Manifest, Vercel AI Gateway) and
+  docs/competitive/manifest.md, docs/competitive/vercel-ai-gateway.md. Reused.
 
 ## Verified current README state (before edit)
 
-`README.md:1-13` — Headline is "Stop runaway Python agents before they burn money." `AgentGuard47 is a zero-dependency runtime control SDK for Python agents.` Lead value prop is in-process safety, not specifically per-call vs cross-call distinction.
+- README.md:48-98 "Why AgentGuard": in-process vs router framing (Manifest,
+  Vercel AI Gateway), cross-call cross-provider envelope, per-tool
+  `max_tokens` comparison table. No WorkOS, no Uber, no unified wedge section.
+- README.md:351-377 "Runtime Control vs Observability": capability table +
+  competitive notes links. Insertion point: new section goes directly after
+  this one (before "Decision Traces", README.md:379).
+- `grep -i mem0 README.md` -> no match (must stay that way).
+- `grep -i "WorkOS|Uber|1,500" README.md` -> no match before edit.
 
-`README.md:44-72` — `## Why AgentGuard` section has the "Problem -> What AgentGuard does" table. Includes "Run spends too much | Raises BudgetExceeded". The framing does not contrast against provider-native caps.
+## Build/CI constraints verified
 
-`README.md:293-313` — `## Runtime Control vs Observability` table has 8 rows comparing AgentGuard to "generic tracing platforms." It does NOT yet have a row about provider-native per-call token caps.
+- `sdk/PYPI_README.md` is GENERATED from README.md by
+  `scripts/generate_pypi_readme.py` (README_PATH = Path("README.md"), line 11).
+  `sdk/tests/test_pypi_readme_sync.py::test_committed_pypi_readme_is_in_sync`
+  diffs the committed file against the generator output. Any README edit
+  requires `python scripts/generate_pypi_readme.py --write` + committing
+  sdk/PYPI_README.md.
+- Repo CLAUDE.md: "do not add one-off reports ... to the repo root" — WORK_PLAN,
+  RESEARCH, QA_REPORT already exist at root on main from prior worker runs;
+  this run refreshes them in place, adds no new root files.
+- Anchor-style internal links (`#runtime-control-vs-observability`) are already
+  used at README.md:58, so an anchor link in the new section is safe for the
+  PyPI link rewriter.
 
-`README.md:218-219` — Auto-patch section mentions Anthropic by name in passing ("If you already call OpenAI or Anthropic directly"). No discussion of per-tool max_tokens.
+## Decisions
 
-## Verified competitive notes in repo
-
-- `docs/competitive/vercel-ai-gateway.md` — referenced from README
-- `docs/competitive/manifest.md` — referenced from README
-- `docs/competitive/agent-security-stack.md` — referenced from README
-
-None of these cover per-tool / per-call provider caps. The new contrast belongs in the README itself (as a row + short paragraph), not as a fourth competitive-notes file, since the task is positioning-paragraph reframing.
-
-## What is in scope for this PR
-
-Per queue task and queue-worker invocation:
-
-- agent47 README positioning update (this PR).
-- NOT in scope: bmdpat landing-page edit, PYPI_README, ARCHITECTURE, AGENTS, docs/competitive/*. The bmdpat half is held for Patrick per the queue-sweep instructions.
-
-## Voice constraints from vault AGENTS.md
-
-Forbidden: harness, leverage, streamline, delve, landscape, cutting-edge, game-changer, revolutionary, seamless, robust, holistic, synergy, ecosystem, engagement, retainer, governance audit, book a call, schedule a call, discovery call, SOW, compliance package. No em dashes. Use periods, commas, parens.
-
-## Honest scope of Anthropic's change
-
-- Per-tool `max_tokens` is an **output-token cap per single tool call** on the advisor tool definition.
-- It does NOT cover: cross-tool budgets, cross-call accumulation, multi-provider abstraction (OpenAI + Anthropic in one app), retry storms, loop detection, in-process exception-based kill, rate limits per minute, time-window caps, or anything OpenAI-native.
-- These are exactly the layers AgentGuard already covers. The positioning update simply states this contrast plainly.
+- Thinking-token accounting NOT mentioned even in prose: the parsing of
+  `usage.output_tokens_details.thinking_tokens` is a deferred feature
+  (cannon-paused). A README differentiator claim for an unshipped capability
+  would be false. The card's "may mention" is permissive, not required.
+- mem0 excluded entirely per fact-gating (false 57-71% stat, open Request
+  2026-06-04-2330). No memory-layer bullet ships in this batch.

--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -1,66 +1,74 @@
-# WORK_PLAN — README containment scope positioning
+# WORK_PLAN — competitor wedge map README batch (2026-06-12)
 
-## Problem
+## Problem statement
 
-AgentGuard's README does not explicitly name what it is NOT: an OS-level
-containment layer. Anthropic published a canonical four-layer containment
-taxonomy on 2026-05-30 (process sandboxes, VMs, filesystem boundaries, egress
-controls). Without a clear scope statement that cites this reference,
-builders evaluating AgentGuard cannot tell where the SDK ends and where
-sibling containment primitives begin. PR #568 just added a cross-call
-envelope vs. per-tool `max_tokens` comparison; this change adds the adjacent
-gap statement.
+Competitor-positioning signals (WorkOS scoped agent credentials, Uber's per-tool
+spend caps, Anthropic per-tool `max_tokens`) currently spawn one paragraph + one
+PR each. Per the 2026-06-07 batching rule, they accumulate into ONE
+"wedge map" README section refreshed in batch. The README has scattered
+positioning (Manifest/gateway in "Why AgentGuard", a per-tool `max_tokens`
+table, "Runtime Control vs Observability") but no unified adjacent-tools wedge
+map, no WorkOS positioning, and no Uber cap reference.
 
 ## Approach
 
-Add a short "Scope" block after the existing "Design constraints" list,
-before the "Real Incidents AgentGuard Prevents" section. Two sentences:
+Add one new section, `## How AgentGuard Differs From Adjacent Tools`,
+immediately after "Runtime Control vs Observability" in README.md. One axis
+table (WorkOS, org per-tool spend caps / Uber pattern, provider per-call token
+caps, routers/gateways) plus four short compose bullets. Then regenerate
+`sdk/PYPI_README.md` (generated from README.md; CI test
+`test_committed_pypi_readme_is_in_sync` fails otherwise).
 
-1. Name AgentGuard's scope: runtime budget/token/rate caps inside the agent
-   process.
-2. Name what is out of scope (OS-level containment: process sandboxes, VMs,
-   filesystem boundaries, egress controls) and cite Anthropic's "How we
-   contain Claude" post as the canonical reference for that layer.
+Explicit exclusions per the task card and fact-gating rule:
+- NO mem0 / memory-layer contamination claim (57-71% stat disputed, held on
+  Requests/2026-06-04-2330-blocked-decision-mem0-blog-false-stat.md).
+- NO thinking-tokens parsing feature (cannon-paused). Also no prose claim of
+  thinking-token accounting: the card says "may mention", but the parsing
+  feature is unshipped, so claiming it in the README would be a false
+  capability claim. Omitted deliberately.
+- No feature commits. Copy only.
 
-This integrates with PR #568's positioning (in-process exception layer) by
-extending the same frame outward: in-process is one layer, OS-level
-containment is the adjacent one.
+Fact correction applied: the task card says "Uber's $1,500/developer Claude
+Code cap". The source of record (Bloomberg via Simon Willison, 2026-06-03)
+says $1,500/month per employee per AI coding tool. README copy uses the
+accurate form.
 
 ## Files likely to touch
 
-- `README.md` — one block insert (~6 lines) after the Design constraints
-  list.
+- README.md (new section, ~35 lines)
+- sdk/PYPI_README.md (regenerated)
+- WORK_PLAN.md / RESEARCH.md / QA_REPORT.md (existing root artifacts, refreshed)
 
 ## What "done" looks like
 
-- [ ] README has a "Scope" block naming AgentGuard's runtime budget/token/
-      rate scope.
-- [ ] The block states OS-level containment is out of scope and lists
-      Anthropic's four primitives.
-- [ ] A link to https://www.anthropic.com/news/how-we-contain-claude is
-      present.
-- [ ] No duplication with the existing "Design constraints", "Why
-      AgentGuard", or "Threat model: agent data exfiltration" sections.
-- [ ] No conflict with PR #568's cross-call envelope framing.
-- [ ] No banned voice words. No em dashes. Diff under ~30 LOC.
+- [ ] README has one "How AgentGuard Differs From Adjacent Tools" section
+      covering WorkOS (identity-time vs run-time), Uber org-cap pattern
+      (policy-time vs call-site), per-tool token caps (per-call vs run
+      envelope), routers/gateways (network vs in-process).
+- [ ] No mem0 mention anywhere in README.
+- [ ] sdk/PYPI_README.md regenerated and in sync.
+- [ ] Voice rules hold: no em dashes, no banned words.
+- [ ] Single PR, <= 400 LOC changed, no new deps, no denylist paths.
+
+## Verification commands
+
+Run from repo root. All of 1-3 FAILED (no match) before implementation
+(verified 2026-06-12).
+
+1. `grep -c "How AgentGuard Differs From Adjacent Tools" README.md` -> >= 1 after
+2. `grep -c "WorkOS" README.md` -> >= 1 after
+3. `grep -c "1,500" README.md` -> >= 1 after
+4. NEGATIVE: `grep -ci "mem0" README.md` -> 0 before AND after
+5. `python scripts/generate_pypi_readme.py --check` -> exit 0 after regen
+6. NEGATIVE (banned words): `grep -Ei "leverage|streamline|delve|cutting-edge|game-changer|revolutionary|seamless|robust|holistic|synergy|ecosystem" README.md` -> no new hits vs baseline
+7. `python -m pytest sdk/tests/test_pypi_readme_sync.py -q` -> pass
 
 ## Risks / assumptions
 
-- Risk: scope block reads as defensive rather than clarifying. Mitigation:
-  same tone as the existing PocketOS section ("does not replace
-  least-privilege creds").
-- Assumption: Anthropic's URL (`/news/how-we-contain-claude`) is stable. The
-  source card at
-  `Knowledge/sources/2026-05-30-anthropic-claude-containment-sandbox.md`
-  preserves the quotes if the URL moves.
-- Risk: voice rules. README uses straight prose, no em-dashes, no fluff
-  words. Verified during Triple-check.
-
-## Karpathy-guidelines pass
-
-- Surgical scope: one file, one insert.
-- Verifiable success: greppable strings ("process sandboxes", "filesystem
-  boundaries", "egress controls", "how-we-contain-claude").
-- Surface assumption: Anthropic's four primitives stay the canonical
-  taxonomy; if Anthropic publishes a revised taxonomy this paragraph
-  revisits.
+- Risk: duplication with existing "Why AgentGuard" Manifest/max_tokens copy.
+  Mitigation: wedge map is the consolidated cross-tool view; it states each
+  axis in one line and links the existing competitive notes. Kept short.
+- Assumption: WorkOS positioning is composable ("they stack"), per the
+  2026-06-04 source (identity-time vs run-time, same buyer, different wedge).
+- PR consolidation of #574/#575/#567/#578/#579 is flagged for Patrick in the
+  task card; this worker does not close or reference PR #574.

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -405,8 +405,8 @@ How they compose:
   That policy fires at the billing layer, after the spend, and a per-tool cap
   cannot see one dev burning across three tools in the same week. A
   `BudgetGuard` fires inside the process, on the run that is misbehaving,
-  before the bill exists. If a Fortune 50 finance team needs this primitive,
-  so does your two-person agent project.
+  before the bill exists. If Uber's finance team needs this primitive, so
+  does your two-person agent project.
 - **Per-call caps are table stakes.** Anthropic's per-tool `max_tokens` stops
   one oversized response. It does not stop 200 small calls in a loop, a retry
   storm, or a run that mixes providers. Set the per-call cap at the provider

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -378,6 +378,45 @@ Competitive notes:
 - [AgentGuard vs Manifest (LLM router)](https://github.com/bmdhodl/agent47/blob/v1.2.13/docs/competitive/manifest.md)
 - [Where AgentGuard fits in the agent security stack](https://github.com/bmdhodl/agent47/blob/main/docs/competitive/agent-security-stack.md)
 
+## How AgentGuard Differs From Adjacent Tools
+
+The wedge map. AgentGuard is the runtime envelope: budget, token, rate, and
+kill caps enforced in-process, at the call site, on what the agent is doing
+right now. Adjacent tools work on different axes. Most of them compose with
+AgentGuard instead of competing with it.
+
+| Adjacent tool | Its axis | AgentGuard's axis |
+|---|---|---|
+| Scoped agent credentials (WorkOS) | Identity-time: who the agent is, what scopes it holds, audit trail of what it did | Run-time: budget, token, rate, and kill enforcement on what it is doing right now |
+| Org-level per-tool spend caps (the Uber pattern) | Policy-time: a monthly dollar ceiling per employee per tool, enforced at the billing layer | Call-site: stops the single runaway run minutes in, not at month end |
+| Provider per-tool token caps (Anthropic per-tool `max_tokens`) | One call, one tool, one provider | Cross-call, cross-provider budget envelope for the whole run |
+| LLM routers and gateways (Manifest, Vercel AI Gateway) | Network layer: route and shape egress traffic | In-process: sees the call graph, raises the exception that ends the run |
+
+How they compose:
+
+- **Scoped credentials and AgentGuard stack.** WorkOS-style agent identity
+  gives each agent its own credential, scoped permissions, and an audit log.
+  That bounds what the agent may touch. AgentGuard enforces what it spends
+  while touching it. Identity-time and run-time are different layers of the
+  same control plane. Use both.
+- **Org caps need a call-site enforcer.** Uber now limits employees to $1,500
+  per month in token spend on each AI coding tool
+  ([Bloomberg via Simon Willison, June 2026](https://simonwillison.net/2026/Jun/3/uber-caps-usage/)).
+  That policy fires at the billing layer, after the spend, and a per-tool cap
+  cannot see one dev burning across three tools in the same week. A
+  `BudgetGuard` fires inside the process, on the run that is misbehaving,
+  before the bill exists. If a Fortune 50 finance team needs this primitive,
+  so does your two-person agent project.
+- **Per-call caps are table stakes.** Anthropic's per-tool `max_tokens` stops
+  one oversized response. It does not stop 200 small calls in a loop, a retry
+  storm, or a run that mixes providers. Set the per-call cap at the provider
+  and the run-envelope cap in AgentGuard.
+- **Gateways shape traffic, guards end runs.** Routers sit at the network
+  layer and never see the agent's call graph. AgentGuard runs inside the
+  process and raises `BudgetExceeded`, `LoopDetected`, or
+  `RetryLimitExceeded` where the loop lives. Details in the
+  [competitive notes](#runtime-control-vs-observability) above.
+
 ## Decision Traces
 
 Capture proposal, human edit, approval, override, and binding events through the


### PR DESCRIPTION
## Summary
- Adds one "How AgentGuard Differs From Adjacent Tools" wedge-map section to README.md per the 2026-06-07 batching rule: WorkOS scoped agent credentials (identity-time vs run-time), the Uber per-employee-per-tool spend-cap pattern (policy-time vs call-site), Anthropic per-tool max_tokens (per-call vs run envelope), routers/gateways (network vs in-process).
- mem0 memory-layer claim is HELD OUT pending fact correction (disputed 57-71% stat). Thinking-tokens parsing feature excluded (deferred); no capability claim made for it.
- sdk/PYPI_README.md regenerated. Positioning copy only, no feature changes.

## Test plan
- [x] python scripts/generate_pypi_readme.py --check (exit 0)
- [x] python -m pytest sdk/tests/test_pypi_readme_sync.py -q (5 passed)
- [x] grep -i mem0 README.md returns nothing
- [x] No new em dashes or banned vocabulary in added README lines
- [x] Uber claim matches source of record: $1,500/month per employee per AI coding tool (Bloomberg via Simon Willison, 2026-06-03)

## Artifacts
WORK_PLAN.md, RESEARCH.md, QA_REPORT.md refreshed at repo root (existing artifact convention). QA verdict: WARN resolved (Fortune 50 claim replaced with sourced Uber reference in 36b0554).

## Risk
Low. Docs-only diff (README + generated PYPI_README + root artifacts). No code paths, no deps, no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
