### PR TITLE
fix(mcp-server): remediate npm audit fast-uri high (#596)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -44,5 +44,8 @@
   "devDependencies": {
     "@types/node": "^25.2.2",
     "typescript": "^5.0.0"
+  },
+  "overrides": {
+    "hono": "^4.12.23"
   }
 }


### PR DESCRIPTION
Fixes #596

## Summary
Resolves the security finding in `mcp-server/` tracked by #596. Result: `npm audit` now reports **0 vulnerabilities** (0 high, 0 moderate).

## What the audit actually showed
On current `main`, the **fast-uri HIGH is already cleared** — the lockfile resolves `fast-uri` to `3.1.2`, which is past the advisory range, so it is no longer flagged. The only remaining findings were **3 moderate** hono advisories reached transitively through `@modelcontextprotocol/sdk` → `@hono/node-server` → `hono` (resolved 4.12.18). npm reported these as "No fix available" because it will not auto-bump a transitively-pinned dependency.

## Fix
Added an `overrides` entry pinning `hono` to `^4.12.23` (resolves to `4.12.25`). All four hono GHSAs (GHSA-xrhx-7g5j-rcj5, GHSA-3hrh-pfw6-9m5x, GHSA-f577-qrjj-4474, GHSA-2gcr-mfcq-wcc3) have a vulnerable range of `<4.12.21`, so this clears every one. This matches the target of dependabot #570 (hono 4.12.23) but goes through an override since the SDK is the pinning parent — the bump-alone in #570 would not flow through to the SDK's transitive hono. **This supersedes dependabot #570.**

## Before
```
3 moderate severity vulnerabilities
(hono x4 advisories via @modelcontextprotocol/sdk; fast-uri NOT flagged — already 3.1.2)
```

## After
```
found 0 vulnerabilities
```

## Files changed
- `mcp-server/package.json` (added `overrides`)
- `mcp-server/package-lock.json` (hono 4.12.18 → 4.12.25)

`npm run build` (tsc) passes. No source changes.

> CI is billing-dark org-wide (Request 2026-06-14-2205); checks will not run until Actions billing is restored. Needs 1 human review to merge.