### PR TITLE
fix(mcp-server): resolve npm audit findings (fast-uri, hono)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary
- Updated \package-lock.json\ in \mcp-server\ to resolve fast-uri (high) and hono (moderate) vulnerabilities.
- Verified \
pm audit\ returns 0 vulnerabilities.

Fixes #596

## Test plan
- [x] \
pm audit\ in \mcp-server\ reports 0 vulnerabilities.

## Artifacts
- N/A

## Risk
Low. Bumped transitive dependency versions via npm audit fix.