### PR TITLE
docs: refresh ops/03 roadmap, anchor on human-signal distribution baseline

### DIFF
--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,9 +3,18 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
-**Last reviewed:** 2026-06-06
+**Last reviewed:** 2026-06-16
 
 ## Current Focus Notes
+
+- Read adoption from human signal, not raw volume. PyPI published-package
+  downloads are real signal: CI installs the SDK from the local checkout, not
+  from the published `agentguard47` wheel, so CI runs do not register as
+  published-package downloads. GitHub clone counts are discounted: several
+  scheduled checkout workflows inflate them, so the high clones-per-unique
+  ratio is substantially our own CI. Anchor NOW/NEXT/LATER on published-package
+  downloads plus human GitHub signals (stars, referrers), per the `sdk_pulse.py`
+  human-signal-vs-machine-volume split (2026-06-05).
 
 - Current SDK release candidate is `v1.2.13` from `main`; public PyPI latest
   remains `v1.2.10` until the next tag publish succeeds. The stale `v1.2.11`


### PR DESCRIPTION
## What changed
Refreshes `ops/03-ROADMAP_NOW_NEXT_LATER.md`:
- Bumps **Last reviewed** to 2026-06-16 (the doc was past the 5-day freshness threshold).
- Adds a Current Focus Note that anchors NOW/NEXT/LATER on **human signal, not raw volume**.

## Why
Per the 2026-06-05 self-inflicted-CI audit: PyPI published-package downloads are real signal (CI installs the SDK from the local checkout, not the published `agentguard47` wheel), while GitHub clone counts are partly self-inflicted by scheduled checkout workflows and should be discounted. The roadmap should read adoption from published-package downloads plus human GitHub signals (stars, referrers), per the `sdk_pulse.py` human-signal-vs-machine-volume split.

## Test plan
Docs-only change. No code, no deps. `git diff` is a single-file, 11 LOC edit to `ops/03-ROADMAP_NOW_NEXT_LATER.md`. No banned vocabulary, no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>