### PR TITLE
security: clear mcp-server npm audit high (hono) via overrides pin

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -41,6 +41,9 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.22.0"
   },
+  "overrides": {
+    "hono": "^4.12.25"
+  },
   "devDependencies": {
     "@types/node": "^25.2.2",
     "typescript": "^5.0.0"


### PR DESCRIPTION
Fixes #596

## What changed
Adds an `overrides` entry to `mcp-server/package.json` pinning `hono` to `^4.12.25`, plus the regenerated `package-lock.json`.

## Finding reality (vs the issue title)
The issue tracks "fast-uri (high), hono + qs (moderate)". Current state in `mcp-server/`:
- `fast-uri` is already at the patched `3.1.2` (via `ajv`) and is **no longer flagged**.
- The open **high** is `hono@4.12.18`, pulled transitively through `@modelcontextprotocol/sdk` -> `@hono/node-server`, with several advisories.
- `qs` is no longer a flagged path.

`npm audit fix` reported `fixAvailable: false` because npm will not bump hono through the SDK's pinned subtree on its own. An explicit `overrides` pin does it cleanly: the SDK's own range is `hono@^4.11.4`, so `4.12.25` is in range and **not a major bump**. Dependabot PR #570 (hono 4.12.23) addresses the same chain; this goes one patch further to the latest 4.12.x and clears every finding.

## Verification (in the sandbox clone)

Before:
```
3 vulnerabilities (2 moderate, 1 high)
```

After the override (`npm ci` from the updated lockfile):
```
found 0 vulnerabilities
```

`npm test` passes (tsc build + all 10 server tests).

## Scope
Security maintenance only. No new dependency (hono was already transitive), no source change. Override + lockfile only. Branch protection requires 1 human review, so this PR sits until reviewed.

## Test plan
- `cd mcp-server && npm ci && npm audit` -> 0 vulnerabilities
- `npm test` -> build + 10/10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>