### PR TITLE
docs: add competitor wedge map to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ envelope in-process and raises the exception that ends the run.
 | Wall-clock timeout | No | Yes |
 | In-process exception that ends the run | No | Yes |
 
+## How AgentGuard Differs (Wedge Map)
+
+AgentGuard's wedge is the **runtime envelope**: budget, token, rate, retry, and loop caps enforced at the call site while the agent is running.
+
+| Adjacent Tool | The Axis | AgentGuard's Runtime Wedge |
+|---|---|---|
+| **WorkOS Scoped Credentials** | **Identity vs. Execution** | WorkOS bounds what an agent is allowed to do (identity, scopes, audit). AgentGuard enforces what the agent is doing right now (budget, tokens, loops). They compose: WorkOS defines the envelope; AgentGuard enforces it at runtime. |
+| **Enterprise Budget Caps (e.g., Uber)** | **Policy vs. Call Site** | Org-wide caps prevent surprise bills (like Uber's $1,500 per developer Claude Code limit) but often rely on management memos or monthly billing alerts. AgentGuard brings that cap to the call site, stopping the runaway run in seconds instead of at the end of the month. |
+| **Vendor Per-Tool Caps** | **Single Call vs. Cross-Tool** | Anthropic's `max_tokens` on a tool call stops one oversized response. It does not stop a loop of 200 small calls, a retry storm, or a run that mixes providers. AgentGuard handles the budget envelope across every call, tool, and provider in the run. |
+
 Design constraints:
 
 - zero runtime dependencies

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -90,6 +90,16 @@ envelope in-process and raises the exception that ends the run.
 | Wall-clock timeout | No | Yes |
 | In-process exception that ends the run | No | Yes |
 
+## How AgentGuard Differs (Wedge Map)
+
+AgentGuard's wedge is the **runtime envelope**: budget, token, rate, retry, and loop caps enforced at the call site while the agent is running.
+
+| Adjacent Tool | The Axis | AgentGuard's Runtime Wedge |
+|---|---|---|
+| **WorkOS Scoped Credentials** | **Identity vs. Execution** | WorkOS bounds what an agent is allowed to do (identity, scopes, audit). AgentGuard enforces what the agent is doing right now (budget, tokens, loops). They compose: WorkOS defines the envelope; AgentGuard enforces it at runtime. |
+| **Enterprise Budget Caps (e.g., Uber)** | **Policy vs. Call Site** | Org-wide caps prevent surprise bills (like Uber's $1,500 per developer Claude Code limit) but often rely on management memos or monthly billing alerts. AgentGuard brings that cap to the call site, stopping the runaway run in seconds instead of at the end of the month. |
+| **Vendor Per-Tool Caps** | **Single Call vs. Cross-Tool** | Anthropic's `max_tokens` on a tool call stops one oversized response. It does not stop a loop of 200 small calls, a retry storm, or a run that mixes providers. AgentGuard handles the budget envelope across every call, tool, and provider in the run. |
+
 Design constraints:
 
 - zero runtime dependencies


### PR DESCRIPTION
## Summary
- Consolidates competitive positioning into a single 'How AgentGuard Differs (Wedge Map)' section.
- Covers WorkOS (identity vs runtime), Uber (org-wide call-site enforcement), and Anthropic (cross-tool budget envelope).
- Follows voice rules (no em dashes, no banned words).

## Test plan
- [x] Verified README rendering.
- [x] Verified voice rules compliance.

## Artifacts
- N/A

## Risk
Low. Documentation only.

## PR Consolidation
This PR consolidates the positioning work from #575, #567, #578, and #579. Those PRs should be closed in favor of this one. #574 remains held due to a false statistic in the mem0 card.
