### PR TITLE
docs: refresh roadmap and focus notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ envelope in-process and raises the exception that ends the run.
 | Wall-clock timeout | No | Yes |
 | In-process exception that ends the run | No | Yes |
 
+## How AgentGuard Differs (Wedge Map)
+
+AgentGuard's wedge is the **runtime envelope**: budget, token, rate, retry, and loop caps enforced at the call site while the agent is running.
+
+| Adjacent Tool | The Axis | AgentGuard's Runtime Wedge |
+|---|---|---|
+| **WorkOS Scoped Credentials** | **Identity vs. Execution** | WorkOS bounds what an agent is allowed to do (identity, scopes, audit). AgentGuard enforces what the agent is doing right now (budget, tokens, loops). They compose: WorkOS defines the envelope; AgentGuard enforces it at runtime. |
+| **Enterprise Budget Caps (e.g., Uber)** | **Policy vs. Call Site** | Org-wide caps prevent surprise bills (like Uber's $1,500 per developer Claude Code limit) but often rely on management memos or monthly billing alerts. AgentGuard brings that cap to the call site, stopping the runaway run in seconds instead of at the end of the month. |
+| **Vendor Per-Tool Caps** | **Single Call vs. Cross-Tool** | Anthropic's `max_tokens` on a tool call stops one oversized response. It does not stop a loop of 200 small calls, a retry storm, or a run that mixes providers. AgentGuard handles the budget envelope across every call, tool, and provider in the run. |
+
 Design constraints:
 
 - zero runtime dependencies

--- a/ops/03-ROADMAP_NOW_NEXT_LATER.md
+++ b/ops/03-ROADMAP_NOW_NEXT_LATER.md
@@ -3,10 +3,11 @@
 SDK repo work only. Distribution-facing docs and package metadata count when
 they directly strengthen coding-agent adoption.
 
-**Last reviewed:** 2026-06-06
+**Last reviewed:** 2026-06-17
 
 ## Current Focus Notes
 
+- **Human-signal baseline for distribution metrics.** As of 2026-06-05, the distribution baseline (shipped in `sdk_pulse.py`) distinguishes human activation (PyPI package downloads) from machine volume (scheduled checkout clones). Clone counts are discounted as partly self-inflicted by internal CI workflows; human-likely download counts are the primary signal for coding-agent adoption.
 - Current SDK release candidate is `v1.2.13` from `main`; public PyPI latest
   remains `v1.2.10` until the next tag publish succeeds. The stale `v1.2.11`
   tag failed before PyPI publish, and the stale `v1.2.12` tag points at a
@@ -29,6 +30,7 @@ they directly strengthen coding-agent adoption.
 
 | Item | Status |
 |------|--------|
+| Competitor Wedge Map consolidation | Done - README wedge map (WorkOS, Uber, Anthropic) refreshed on 2026-06-17 |
 | Eval assertion expansion | Done - `EvalSuite` now has >=12 built-in assertions |
 | `estimate_cost` pricing refresh | Done - Anthropic and Google pricing refreshed on 2026-03-26; OpenAI entries retained pending direct re-verification from this environment |
 | `RetryGuard` - cap retry attempts per tool | Done - configurable per-tool retry ceilings now raise `RetryLimitExceeded` |

--- a/sdk/PYPI_README.md
+++ b/sdk/PYPI_README.md
@@ -90,6 +90,16 @@ envelope in-process and raises the exception that ends the run.
 | Wall-clock timeout | No | Yes |
 | In-process exception that ends the run | No | Yes |
 
+## How AgentGuard Differs (Wedge Map)
+
+AgentGuard's wedge is the **runtime envelope**: budget, token, rate, retry, and loop caps enforced at the call site while the agent is running.
+
+| Adjacent Tool | The Axis | AgentGuard's Runtime Wedge |
+|---|---|---|
+| **WorkOS Scoped Credentials** | **Identity vs. Execution** | WorkOS bounds what an agent is allowed to do (identity, scopes, audit). AgentGuard enforces what the agent is doing right now (budget, tokens, loops). They compose: WorkOS defines the envelope; AgentGuard enforces it at runtime. |
+| **Enterprise Budget Caps (e.g., Uber)** | **Policy vs. Call Site** | Org-wide caps prevent surprise bills (like Uber's $1,500 per developer Claude Code limit) but often rely on management memos or monthly billing alerts. AgentGuard brings that cap to the call site, stopping the runaway run in seconds instead of at the end of the month. |
+| **Vendor Per-Tool Caps** | **Single Call vs. Cross-Tool** | Anthropic's `max_tokens` on a tool call stops one oversized response. It does not stop a loop of 200 small calls, a retry storm, or a run that mixes providers. AgentGuard handles the budget envelope across every call, tool, and provider in the run. |
+
 Design constraints:
 
 - zero runtime dependencies


### PR DESCRIPTION
## Summary
- Refreshes ops/03-ROADMAP_NOW_NEXT_LATER.md with current date.
- Adds focus note on human-signal baseline for distribution metrics.
- Moves Competitor Wedge Map consolidation to recently completed.
- Follows voice rules.

## Test plan
- Documentation only.

## Risk
None.
